### PR TITLE
feat(web): add efficacy/safety comparison table + April 2026 data ing…

### DIFF
--- a/melanoma/scripts/upload_to_supabase.py
+++ b/melanoma/scripts/upload_to_supabase.py
@@ -301,6 +301,7 @@ ATTRIBUTE_MAPPING = {
     "MEDIAN_FOLLOWUP_PFS": "pfs_followup_months",
     "P_VALUE_PFS": "p_value_pfs",
     "HR_PFS": "hr_pfs",
+    "CI_HR_PFS": "ci_hr_pfs",
     "PFS_RATE_6M": "pfs_rate_6m",
     "PFS_RATE_9M": "pfs_rate_9m",
     "PFS_RATE_12M": "pfs_rate_12m",
@@ -314,6 +315,7 @@ ATTRIBUTE_MAPPING = {
     "MEDIAN_FOLLOWUP_OS": "os_followup_months",
     "P_VALUE_OS": "p_value_os",
     "HR_OS": "hr_os",
+    "CI_HR_OS": "ci_hr_os",
     "OS_RATE_6M": "os_rate_6m",
     "OS_RATE_9M": "os_rate_9m",
     "OS_RATE_12M": "os_rate_12m",
@@ -326,13 +328,16 @@ ATTRIBUTE_MAPPING = {
     "EFS": "efs",
     "P_VALUE_EFS": "p_value_efs",
     "HR_EFS": "hr_efs",
+    "CI_HR_EFS": "ci_hr_efs",
     "RFS": "rfs",
     "P_VALUE_RFS": "p_value_rfs",
     "LENGTH_RFS": "rfs_followup_months",
     "HR_RFS": "hr_rfs",
+    "CI_HR_RFS": "ci_hr_rfs",
     "MFS": "mfs",
     "LENGTH_MFS": "mfs_followup_months",
     "HR_MFS": "hr_mfs",
+    "CI_HR_MFS": "ci_hr_mfs",
 
     # Efficacy: Response
     "OBJECTIVE_RESPONSE_RATE": "orr",
@@ -345,6 +350,8 @@ ATTRIBUTE_MAPPING = {
     "DOR_RATE": "dor_rate",
     "TTR": "ttr",
     "TTP": "ttp",
+    "HR_TTP": "hr_ttp",
+    "CI_HR_TTP": "ci_hr_ttp",
     "TTNT": "ttnt",
     "TTF": "ttf",
 
@@ -355,7 +362,11 @@ ATTRIBUTE_MAPPING = {
     "SERIOUS_AE": "serious_ae_pct",
     "IMMUNE_RELATED_AE": "immune_related_ae_pct",
     "SERIOUS_IMMUNE_RELATED_AE": "serious_ir_ae_pct",
-    "AE_LED_TO_DEATH": "ae_death_pct",
+    "AE_LEADING_TO_DEATH": "ae_death_pct",
+    "AE_LEADING_TO_DOSE_INTERRUPTION": "ae_dose_interruption_pct",
+    "AE_LEADING_TO_DOSE_REDUCTION": "ae_dose_reduction_pct",
+    "AE_REQUIRING_HOSPITALIZATION": "ae_hospitalization_pct",
+    "IRR": "irr_pct",
 
     # Safety: TRAE
     "TRAE": "trae_pct",
@@ -365,6 +376,9 @@ ATTRIBUTE_MAPPING = {
     "GRADE_5_TRAE": "grade_5_trae_pct",
     "TRAE_LEADING_TO_DISCONTINUATION": "trae_discontinuation_pct",
     "TRAE_LEADING_TO_DEATH": "trae_death_pct",
+    "TRAE_LEADING_TO_DOSE_INTERRUPTION": "trae_dose_interruption_pct",
+    "TRAE_LEADING_TO_DOSE_REDUCTION": "trae_dose_reduction_pct",
+    "TRAE_REQUIRING_HOSPITALIZATION": "trae_hospitalization_pct",
     "TRAE_IMMUNE_RELATED": "trae_ir_ae_pct",
     "SERIOUS_TRAE": "serious_trae_pct",
 
@@ -376,6 +390,9 @@ ATTRIBUTE_MAPPING = {
     "GRADE_5_TEAE": "grade_5_teae_pct",
     "TEAE_LEADING_TO_DISCONTINUATION": "teae_discontinuation_pct",
     "TEAE_LEADING_TO_DEATH": "teae_death_pct",
+    "TEAE_LEADING_TO_DOSE_INTERRUPTION": "teae_dose_interruption_pct",
+    "TEAE_LEADING_TO_DOSE_REDUCTION": "teae_dose_reduction_pct",
+    "TEAE_REQUIRING_HOSPITALIZATION": "teae_hospitalization_pct",
     "TEAE_IMMUNE_RELATED": "teae_ir_ae_pct",
     "SERIOUS_TEAE": "serious_teae_pct",
 
@@ -407,6 +424,12 @@ ATTRIBUTE_MAPPING = {
     "GRADE_3_PLUS_AE_PNEUMONITIS": "grade_3_plus_ae_pneumonitis",
     "GRADE_3_PLUS_AE_ALANINE_AMINOTRANSFERASE": "grade_3_plus_ae_alt_increased",
     "GRADE_3_PLUS_AE_WBC_DECREASED": "grade_3_plus_ae_wbc_decreased",
+    "GRADE_3_PLUS_AE_AST_INCREASED": "grade_3_plus_ae_ast_increased",
+    "GRADE_3_PLUS_AE_FATIGUE": "grade_3_plus_ae_fatigue",
+    "GRADE_3_PLUS_AE_HYPERTHYROIDISM": "grade_3_plus_ae_hyperthyroidism",
+    "GRADE_3_PLUS_AE_HYPOTHYROIDISM": "grade_3_plus_ae_hypothyroidism",
+    "GRADE_3_PLUS_AE_IRR": "grade_3_plus_ae_irr",
+    "GRADE_3_PLUS_AE_VOMITING": "grade_3_plus_ae_vomiting",
 
     # Safety: Specific Grade 3+ TRAEs
     "GRADE_3_PLUS_TRAE_IMMUNE_RELATED": "grade_3_plus_trae_ir_ae",
@@ -432,6 +455,12 @@ ATTRIBUTE_MAPPING = {
     "GRADE_3_PLUS_TRAE_PNEUMONITIS": "grade_3_plus_trae_pneumonitis",
     "GRADE_3_PLUS_TRAE_ALANINE_AMINOTRANSFERASE": "grade_3_plus_trae_alt_increased",
     "GRADE_3_PLUS_TRAE_WBC_DECREASED": "grade_3_plus_trae_wbc_decreased",
+    "GRADE_3_PLUS_TRAE_AST_INCREASED": "grade_3_plus_trae_ast_increased",
+    "GRADE_3_PLUS_TRAE_FATIGUE": "grade_3_plus_trae_fatigue",
+    "GRADE_3_PLUS_TRAE_HYPERTHYROIDISM": "grade_3_plus_trae_hyperthyroidism",
+    "GRADE_3_PLUS_TRAE_HYPOTHYROIDISM": "grade_3_plus_trae_hypothyroidism",
+    "GRADE_3_PLUS_TRAE_IRR": "grade_3_plus_trae_irr",
+    "GRADE_3_PLUS_TRAE_VOMITING": "grade_3_plus_trae_vomiting",
 
     # Safety: Specific Grade 3+ TEAEs
     "GRADE_3_PLUS_TEAE_IMMUNE_RELATED": "grade_3_plus_teae_ir_ae",
@@ -457,6 +486,12 @@ ATTRIBUTE_MAPPING = {
     "GRADE_3_PLUS_TEAE_PNEUMONITIS": "grade_3_plus_teae_pneumonitis",
     "GRADE_3_PLUS_TEAE_ALANINE_AMINOTRANSFERASE": "grade_3_plus_teae_alt_increased",
     "GRADE_3_PLUS_TEAE_WBC_DECREASED": "grade_3_plus_teae_wbc_decreased",
+    "GRADE_3_PLUS_TEAE_AST_INCREASED": "grade_3_plus_teae_ast_increased",
+    "GRADE_3_PLUS_TEAE_FATIGUE": "grade_3_plus_teae_fatigue",
+    "GRADE_3_PLUS_TEAE_HYPERTHYROIDISM": "grade_3_plus_teae_hyperthyroidism",
+    "GRADE_3_PLUS_TEAE_HYPOTHYROIDISM": "grade_3_plus_teae_hypothyroidism",
+    "GRADE_3_PLUS_TEAE_IRR": "grade_3_plus_teae_irr",
+    "GRADE_3_PLUS_TEAE_VOMITING": "grade_3_plus_teae_vomiting",
 }
 
 def get_attr_value(attrs, key, default=None, is_numeric=False):
@@ -511,7 +546,7 @@ def upload_trial_outcomes():
                 mapped_arms = []
                 for trial in trials_list:
                     # Logic for trial IDs
-                    raw_id = trial.get("trial_id") or trial.get("abstract_id") or trial.get("publication_id") or trial.get("id", "unknown")
+                    raw_id = trial.get("trial_id") or trial.get("abstract_id") or trial.get("pub_id") or trial.get("publication_id") or trial.get("id", "unknown")
                     nct_id = trial.get("nct_id") or (raw_id if str(raw_id).startswith("NCT") else None)
                     
                     # Publication & Arm specific Logic
@@ -531,8 +566,13 @@ def upload_trial_outcomes():
                     
                     if source_type == 'publication':
                         actual_source_name = raw_id # Publication ID (Batch ID)
-                        # Specific logic for publication_id column matching user request
-                        pub_id_value = first_arm_attrs.get("AttributeType.PUBLICATION_NAME", {}).get("value") or first_arm_attrs.get("PUBLICATION_NAME", {}).get("value")
+                        pub_id_value = None
+                        for k, v in first_arm_attrs.items():
+                            if k.lower().replace("attributetype.", "") == "publication_name":
+                                candidate = v.get("value")
+                                if candidate not in (None, "", "Not found", "N/A", "Not available"):
+                                    pub_id_value = candidate
+                                break
                     else:
                         actual_source_name = source_name
                         pub_id_value = None
@@ -570,11 +610,12 @@ def upload_trial_outcomes():
                         # Fill in the flattened columns
                         is_nr_list = []
                         known_strings = [
-                            'id', 'source_type', 'source_name', 'abstract_id', 'publication_id', 
-                            'source_url', 'nct_id', 'arm_id', 'arm_name', 'cancer_type', 'sponsors', 
-                            'line_of_treatment', 'generic_name', 'brand_name', 'dosage', 
-                            'type_of_dosing', 'mechanism_of_action', 'target_protein', 
-                            'type_of_therapy', 'sub_therapy', 'is_nr', 'all_attributes', 'created_at'
+                            'id', 'source_type', 'source_name', 'abstract_id', 'publication_id',
+                            'source_url', 'nct_id', 'arm_id', 'arm_name', 'cancer_type', 'sponsors',
+                            'line_of_treatment', 'generic_name', 'brand_name', 'dosage',
+                            'type_of_dosing', 'mechanism_of_action', 'target_protein',
+                            'type_of_therapy', 'sub_therapy', 'is_nr', 'all_attributes', 'created_at',
+                            'ci_hr_pfs', 'ci_hr_os', 'ci_hr_efs', 'ci_hr_rfs', 'ci_hr_mfs', 'ci_hr_ttp',
                         ]
                         
                         for attr_key, col_name in ATTRIBUTE_MAPPING.items():

--- a/web/src/app/dashboard/[category]/analytics/page.tsx
+++ b/web/src/app/dashboard/[category]/analytics/page.tsx
@@ -33,7 +33,10 @@ import BubbleChart from '@/components/charts/BubbleChart';
 import DumbbellChart, { DumbbellDataPoint } from '@/components/charts/DumbbellChart';
 import { transformHeadToHeadData, transformEfficacySafetyData, transformBubbleChartData } from '@/lib/chart-transformers';
 import { analyticsApi } from '@/lib/api';
-import { HeadToHeadDataPoint, ChartMetric, TrialDataFile, EfficacySafetyDataPoint, BubbleChartDataPoint } from '@/types/analytics';
+import { HeadToHeadDataPoint, ChartMetric, TrialDataFile, EfficacySafetyDataPoint, BubbleChartDataPoint, EFFICACY_METRICS, SAFETY_METRICS } from '@/types/analytics';
+import { CompareTable } from '@/components/compare/CompareTable';
+import { buildCompareTable } from '@/lib/compare-transformers';
+import { CompareSelection, CompareSortMode, MAX_COMPARE_TREATMENTS } from '@/types/compare';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -41,6 +44,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { DashboardGlobalHeader } from '@/components/dashboard/DashboardGlobalHeader';
+import { cn } from '@/lib/utils';
 
 // ============================================================================
 // Category Mapping
@@ -88,15 +92,6 @@ function slugToCategory(slug: string): string {
 // Filter Options
 // ============================================================================
 
-const COMPANY_OPTIONS = [
-  { value: 'all', label: 'All' },
-  { value: 'bms', label: 'Bristol-Myers Squibb' },
-  { value: 'merck', label: 'Merck' },
-  { value: 'novartis', label: 'Novartis' },
-  { value: 'roche', label: 'Roche' },
-  { value: 'pfizer', label: 'Pfizer' },
-];
-
 // Note: Funding type filtering is now handled by the backend API
 
 const THERAPY_TYPE_OPTIONS = [
@@ -112,18 +107,13 @@ const RESOURCE_TYPE_OPTIONS = [
   { value: 'all', label: 'All' },
   { value: 'conference', label: 'Conference' },
   { value: 'publication', label: 'Publications' },
+  { value: 'live_feed_upcoming', label: 'Live Feed Upcoming', italic: true },
 ];
 
 const FUNDING_TYPE_OPTIONS = [
   { value: 'all', label: 'All' },
   { value: 'industry', label: 'Industry' },
   { value: 'non-industry', label: 'Non-Industry' },
-];
-
-const BIOMARKER_OPTIONS = [
-  { value: 'all', label: 'All' },
-  { value: 'yes', label: 'Yes' },
-  { value: 'no', label: 'No' },
 ];
 
 const EFFICACY_OPTIONS = [
@@ -385,13 +375,6 @@ const ADVANCED_LINE_OF_THERAPY_OPTIONS = [
   { value: 'Adjuvant', label: 'Adjuvant' },
   { value: 'Neoadjuvant', label: 'Neoadjuvant' },
 ];
-const ADVANCED_PREVIOUS_TREATMENT_OPTIONS = [
-  { value: 'all', label: 'All' },
-  { value: 'Failed IO', label: 'Failed IO' },
-  { value: 'No prior BRAFi', label: 'No prior BRAFi' },
-  { value: 'IO Naive', label: 'IO Naive' },
-];
-
 // ============================================================================
 // Filter Select Component
 // ============================================================================
@@ -399,7 +382,7 @@ const ADVANCED_PREVIOUS_TREATMENT_OPTIONS = [
 interface FilterSelectProps {
   label: string;
   value: string;
-  options: { value: string; label: string }[];
+  options: { value: string; label: string; italic?: boolean }[];
   onChange: (value: string) => void;
   icon?: React.ReactNode;
   searchable?: boolean;
@@ -460,7 +443,7 @@ function FilterSelect({
                 }}
               >
                 <div className="flex items-center justify-between w-full">
-                  <span>{option.label}</span>
+                  <span className={option.italic ? 'italic' : ''}>{option.label}</span>
                   {value === option.value && <Check className="h-4 w-4 text-[var(--brand-primary)]" />}
                 </div>
               </DropdownMenuItem>
@@ -571,20 +554,16 @@ export default function CategoryAnalyticsPage() {
     modeParam === 'efficacy' || modeParam === 'safety' ? modeParam : 'all';
 
   // Filter states - initialized based on mode
-  const [company, setCompany] = useState('all');
   const [therapyType, setTherapyType] = useState('all');
   const [resourceType, setResourceType] = useState<'all' | 'conference' | 'publication'>('all');
-  const [fundingType, setFundingType] = useState<'all' | 'industry' | 'non-industry'>('all');
-  const [biomarker, setBiomarker] = useState('all');
-  // Store raw user selections
-  const [rawSelectedApproved, setRawSelectedApproved] = useState<string[]>([]);
-  const [rawSelectedNonApproved, setRawSelectedNonApproved] = useState<string[]>([]);
-  // Advanced filters (same dimensions as Landscape, separate dropdowns)
+  const [fundingType, setFundingType] = useState<'all' | 'industry' | 'non-industry'>('industry');
+  const [advancedLineOfTherapy, setAdvancedLineOfTherapy] = useState('all');
+  // Store raw treatment selections (merged approved + non-approved)
+  const [rawSelectedTreatments, setRawSelectedTreatments] = useState<string[]>([]);
+  // Advanced filters
   const [advancedModality, setAdvancedModality] = useState('all');
   const [advancedStage, setAdvancedStage] = useState('all');
   const [advancedBiomarker, setAdvancedBiomarker] = useState('all');
-  const [advancedLineOfTherapy, setAdvancedLineOfTherapy] = useState('all');
-  const [advancedPreviousTreatment, setAdvancedPreviousTreatment] = useState('all');
 
   // Initialize params with safe defaults to avoid hydration mismatch
   // These will be updated by useEffect based on mode
@@ -746,9 +725,35 @@ export default function CategoryAnalyticsPage() {
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 30 * 60 * 1000, // 30 minutes (formerly cacheTime)
   });
+
+  const { data: treatmentMetaRaw } = useQuery({
+    queryKey: ['analytics', 'treatmentMeta', apiFilters.cancer_type],
+    queryFn: () => analyticsApi.getTreatmentMeta(apiFilters.cancer_type ?? 'All'),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [windowHeight, setWindowHeight] = useState(700);
   const [chartType, setChartType] = useState<'bar' | 'diverging' | 'bubble' | 'dumbbell'>('bar');
+
+  // Compare treatments table state
+  const [compareSort, setCompareSort] = useState<CompareSortMode>('most-complete');
+  const [compareHideEmpty, setCompareHideEmpty] = useState(false);
+  const [compareSelections, setCompareSelections] = useState<CompareSelection[]>([]);
+  const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false);
+
+  // Clear selections when mode switches — metric namespace changes
+  useEffect(() => {
+    setCompareSelections([]);
+  }, [mode]);
+
+  const toggleCompareSelection = useCallback((sel: CompareSelection) => {
+    setCompareSelections(prev => {
+      const idx = prev.findIndex(s => s.treatmentName === sel.treatmentName && s.metricKey === sel.metricKey);
+      if (idx >= 0) return prev.filter((_, i) => i !== idx);
+      return [...prev, sel];
+    });
+  }, []);
 
   // Handle chart type changes - ensure proper filter states
   useEffect(() => {
@@ -771,16 +776,19 @@ export default function CategoryAnalyticsPage() {
       }
     } else if (mode === 'efficacy' && (chartType === 'diverging' || chartType === 'bubble' || chartType === 'dumbbell')) {
       if (chartType === 'bubble') {
-        setEfficacyParam('OBJECTIVE_RESPONSE_RATE'); // ORR
-        setEfficacyParamY('MEDIAN_PFS');             // Median PFS
-        setZAxisParam('NUMBER_OF_PATIENTS');         // Number of patients
+        setChartType('diverging');
+        if (efficacyParamY === 'none') {
+          setEfficacyParamY(efficacyParam === 'OBJECTIVE_RESPONSE_RATE' ? 'DISEASE_CONTROL_RATE' : 'OBJECTIVE_RESPONSE_RATE');
+        }
       } else if (efficacyParamY === 'none') {
         setEfficacyParamY(efficacyParam === 'OBJECTIVE_RESPONSE_RATE' ? 'DISEASE_CONTROL_RATE' : 'OBJECTIVE_RESPONSE_RATE');
       }
     } else if (mode === 'safety' && (chartType === 'diverging' || chartType === 'bubble' || chartType === 'dumbbell')) {
       if (chartType === 'bubble') {
-        if (zAxisParam.startsWith('P_VALUE_')) setZAxisParam('NUMBER_OF_PATIENTS');
-        setSafetyParamY('AE'); // Y-axis default: AE (%)
+        setChartType('diverging');
+        if (safetyParamY === 'none') {
+          setSafetyParamY(safetyParam === 'GRADE_3_PLUS_AE' ? 'TEAE' : 'GRADE_3_PLUS_AE');
+        }
       } else if (safetyParamY === 'none') {
         setSafetyParamY(safetyParam === 'GRADE_3_PLUS_AE' ? 'TEAE' : 'GRADE_3_PLUS_AE');
       }
@@ -937,23 +945,65 @@ export default function CategoryAnalyticsPage() {
     };
   }, [analyticsData, categoryName]);
 
-  // Derive valid selections by filtering raw selections against available therapies
-  // This automatically handles cleanup when available therapies change (e.g., category switch)
-  const selectedApproved = useMemo(
-    () => rawSelectedApproved.filter(t => availableTherapies.approved.includes(t)),
-    [rawSelectedApproved, availableTherapies.approved]
+  // All available treatments (approved + non-approved merged)
+  const allAvailableTreatments = useMemo(
+    () => [...availableTherapies.approved, ...availableTherapies.nonApproved].sort(),
+    [availableTherapies]
   );
 
-  const selectedNonApproved = useMemo(
-    () => rawSelectedNonApproved.filter(t => availableTherapies.nonApproved.includes(t)),
-    [rawSelectedNonApproved, availableTherapies.nonApproved]
+  // Validate raw selections against currently available treatments
+  const selectedTreatments = useMemo(
+    () => rawSelectedTreatments.filter(t => allAvailableTreatments.includes(t)).slice(0, MAX_COMPARE_TREATMENTS),
+    [rawSelectedTreatments, allAvailableTreatments]
   );
+
+  const compareTableData = useMemo(() => {
+    const trials = [
+      ...((analyticsData?.abstracts as unknown as TrialDataFile['abstracts']) ?? []),
+      ...((analyticsData?.publications as unknown as TrialDataFile['publications']) ?? []),
+    ];
+    return buildCompareTable(trials ?? [], allAvailableTreatments, mode, treatmentMetaRaw ?? []);
+  }, [analyticsData, allAvailableTreatments, mode, treatmentMetaRaw]);
+
+  const activeMetricKeys = useMemo(() => {
+    const keys: string[] = [];
+    if (mode === 'all') {
+      if (efficacyParam !== 'none') keys.push(efficacyParam);
+      if (safetyParam !== 'none') keys.push(safetyParam);
+    } else if (mode === 'efficacy') {
+      if (efficacyParam !== 'none') keys.push(efficacyParam);
+      if ((chartType === 'diverging' || chartType === 'dumbbell') && efficacyParamY !== 'none') keys.push(efficacyParamY);
+    } else if (mode === 'safety') {
+      if (safetyParam !== 'none') keys.push(safetyParam);
+      if ((chartType === 'diverging' || chartType === 'dumbbell') && safetyParamY !== 'none') keys.push(safetyParamY);
+    }
+    return keys;
+  }, [mode, chartType, efficacyParam, safetyParam, efficacyParamY, safetyParamY]);
+
+  // Derive chart overrides from cell selections. When any cells are selected, they
+  // take precedence over the dropdown-bound metric state for driving the chart.
+  const compareOverride = useMemo(() => {
+    if (compareSelections.length === 0) return null;
+    const treatments = Array.from(new Set(compareSelections.map(s => s.treatmentName)));
+    const efficacyMetrics: string[] = [];
+    const safetyMetrics: string[] = [];
+    for (const s of compareSelections) {
+      if (EFFICACY_METRICS[s.metricKey] && !efficacyMetrics.includes(s.metricKey)) efficacyMetrics.push(s.metricKey);
+      if (SAFETY_METRICS[s.metricKey] && !safetyMetrics.includes(s.metricKey)) safetyMetrics.push(s.metricKey);
+    }
+    return { treatments, efficacyMetrics, safetyMetrics };
+  }, [compareSelections]);
 
   // Transform data for chart (backend already filtered the data)
   const chartData = useMemo<HeadToHeadDataPoint[]>(() => {
     if (!analyticsData) return [];
-    if (!displayMetric) return [];
     if (!analyticsData.abstracts) return [];
+
+    const targetMetric =
+      compareOverride?.efficacyMetrics[0] ||
+      compareOverride?.safetyMetrics[0] ||
+      displayMetric;
+    if (!targetMetric) return [];
 
     // Backend has already filtered the data, so we just need to transform it
     // Transform backend data to TrialDataFile format for the transformer
@@ -968,12 +1018,12 @@ export default function CategoryAnalyticsPage() {
     };
 
     let data = transformHeadToHeadData(trialData, {
-      targetMetric: displayMetric as ChartMetric,
+      targetMetric: targetMetric as ChartMetric,
       minTrialCount: 1,
     });
 
     // Filter by selected therapies (this is still client-side as it's UI state)
-    const allSelected = [...selectedApproved, ...selectedNonApproved];
+    const allSelected = compareOverride?.treatments ?? selectedTreatments;
     if (allSelected.length > 0) {
       data = data.filter((d) => allSelected.includes(d.treatmentName));
     }
@@ -982,7 +1032,7 @@ export default function CategoryAnalyticsPage() {
     data.sort((a, b) => b.averageValue - a.averageValue);
 
     return data;
-  }, [analyticsData, displayMetric, selectedApproved, selectedNonApproved]);
+  }, [analyticsData, displayMetric, selectedTreatments, compareOverride]);
 
   // Transform data for diverging bar chart (efficacy vs safety, or efficacy vs efficacy, or safety vs safety)
   const divergingChartData = useMemo<EfficacySafetyDataPoint[]>(() => {
@@ -990,17 +1040,23 @@ export default function CategoryAnalyticsPage() {
     let efficacyMetric: ChartMetric;
     let safetyMetric: ChartMetric;
     if (mode === 'efficacy') {
-      if (efficacyParam === 'none' || efficacyParamY === 'none') return [];
-      efficacyMetric = efficacyParam as ChartMetric;
-      safetyMetric = efficacyParamY as ChartMetric;
+      const x = compareOverride?.efficacyMetrics[0] ?? efficacyParam;
+      const y = compareOverride?.efficacyMetrics[1] ?? efficacyParamY;
+      if (x === 'none' || y === 'none') return [];
+      efficacyMetric = x as ChartMetric;
+      safetyMetric = y as ChartMetric;
     } else if (mode === 'safety') {
-      if (safetyParam === 'none' || safetyParamY === 'none') return [];
-      efficacyMetric = safetyParam as ChartMetric;
-      safetyMetric = safetyParamY as ChartMetric;
+      const x = compareOverride?.safetyMetrics[0] ?? safetyParam;
+      const y = compareOverride?.safetyMetrics[1] ?? safetyParamY;
+      if (x === 'none' || y === 'none') return [];
+      efficacyMetric = x as ChartMetric;
+      safetyMetric = y as ChartMetric;
     } else {
-      if (efficacyParam === 'none' || safetyParam === 'none') return [];
-      efficacyMetric = efficacyParam as ChartMetric;
-      safetyMetric = safetyParam as ChartMetric;
+      const ex = compareOverride?.efficacyMetrics[0] ?? efficacyParam;
+      const sy = compareOverride?.safetyMetrics[0] ?? safetyParam;
+      if (ex === 'none' || sy === 'none') return [];
+      efficacyMetric = ex as ChartMetric;
+      safetyMetric = sy as ChartMetric;
     }
 
     const allTrials: TrialDataFile['abstracts'] = (analyticsData.abstracts as unknown as TrialDataFile['abstracts']) || [];
@@ -1018,13 +1074,13 @@ export default function CategoryAnalyticsPage() {
       minTrialCount: 1,
     });
 
-    const allSelected = [...selectedApproved, ...selectedNonApproved];
+    const allSelected = compareOverride?.treatments ?? selectedTreatments;
     if (allSelected.length > 0) {
       data = data.filter((d: EfficacySafetyDataPoint | BubbleChartDataPoint) => allSelected.includes(d.treatmentName));
     }
 
     return data;
-  }, [analyticsData, mode, efficacyParam, efficacyParamY, safetyParam, safetyParamY, selectedApproved, selectedNonApproved]);
+  }, [analyticsData, mode, efficacyParam, efficacyParamY, safetyParam, safetyParamY, selectedTreatments, compareOverride]);
 
   // Transform data for bubble chart (efficacy vs safety, or efficacy vs efficacy, or safety vs safety)
   const bubbleChartData = useMemo<BubbleChartDataPoint[]>(() => {
@@ -1032,17 +1088,23 @@ export default function CategoryAnalyticsPage() {
     let efficacyMetric: ChartMetric;
     let safetyMetric: ChartMetric;
     if (mode === 'efficacy') {
-      if (efficacyParam === 'none' || efficacyParamY === 'none') return [];
-      efficacyMetric = efficacyParam as ChartMetric;
-      safetyMetric = efficacyParamY as ChartMetric;
+      const x = compareOverride?.efficacyMetrics[0] ?? efficacyParam;
+      const y = compareOverride?.efficacyMetrics[1] ?? efficacyParamY;
+      if (x === 'none' || y === 'none') return [];
+      efficacyMetric = x as ChartMetric;
+      safetyMetric = y as ChartMetric;
     } else if (mode === 'safety') {
-      if (safetyParam === 'none' || safetyParamY === 'none') return [];
-      efficacyMetric = safetyParam as ChartMetric;
-      safetyMetric = safetyParamY as ChartMetric;
+      const x = compareOverride?.safetyMetrics[0] ?? safetyParam;
+      const y = compareOverride?.safetyMetrics[1] ?? safetyParamY;
+      if (x === 'none' || y === 'none') return [];
+      efficacyMetric = x as ChartMetric;
+      safetyMetric = y as ChartMetric;
     } else {
-      if (efficacyParam === 'none' || safetyParam === 'none') return [];
-      efficacyMetric = efficacyParam as ChartMetric;
-      safetyMetric = safetyParam as ChartMetric;
+      const ex = compareOverride?.efficacyMetrics[0] ?? efficacyParam;
+      const sy = compareOverride?.safetyMetrics[0] ?? safetyParam;
+      if (ex === 'none' || sy === 'none') return [];
+      efficacyMetric = ex as ChartMetric;
+      safetyMetric = sy as ChartMetric;
     }
 
     const allTrials: TrialDataFile['abstracts'] = (analyticsData.abstracts as unknown as TrialDataFile['abstracts']) || [];
@@ -1061,13 +1123,13 @@ export default function CategoryAnalyticsPage() {
       minTrialCount: 1,
     });
 
-    const allSelected = [...selectedApproved, ...selectedNonApproved];
+    const allSelected = compareOverride?.treatments ?? selectedTreatments;
     if (allSelected.length > 0) {
       data = data.filter((d: EfficacySafetyDataPoint | BubbleChartDataPoint) => allSelected.includes(d.treatmentName));
     }
 
     return data;
-  }, [analyticsData, mode, efficacyParam, efficacyParamY, safetyParam, safetyParamY, zAxisParam, selectedApproved, selectedNonApproved]);
+  }, [analyticsData, mode, efficacyParam, efficacyParamY, safetyParam, safetyParamY, zAxisParam, selectedTreatments, compareOverride]);
 
   // Dumbbell chart data: map bubble chart data (efficacy mode) to treatment + valueA (X) + valueB (Y) + hr (bubble size)
   const dumbbellChartData = useMemo<DumbbellDataPoint[]>(() => {
@@ -1092,7 +1154,7 @@ export default function CategoryAnalyticsPage() {
   }, [efficacyParam, safetyParam]);
 
   return (
-    <div className="flex flex-col min-h-screen w-full bg-slate-50">
+    <div className="flex flex-col h-screen w-full bg-slate-50 overflow-hidden">
       {/* Header */}
       <header className="bg-white border-b border-slate-200 sticky top-0 z-50 shadow-sm">
         <div className="w-full px-4 md:px-6">
@@ -1614,135 +1676,89 @@ export default function CategoryAnalyticsPage() {
       )}
 
       {/* Main Content */}
-      <div className="flex flex-1 overflow-hidden">
-        {/* Left Panel - Filters */}
-        <aside className="w-[480px] border-r border-slate-200 bg-white p-4 overflow-y-auto flex-shrink-0">
-          {/* Cancer Type Badge */}
-          <div className="mb-4 p-2.5 bg-[var(--brand-accent-light)] rounded-lg border border-[var(--brand-border)]">
-            <div className="text-[11px] font-medium text-[var(--brand-primary)] uppercase tracking-wider mb-0.5">Cancer Type</div>
-            <div className="text-sm font-semibold text-[var(--brand-text)]">{categoryName}</div>
-          </div>
-
-          {/* 2-Column Filter Grid */}
-          <div className="grid grid-cols-2 gap-3">
-            {/* Row 1 */}
-            <FilterSelect
-              label="Company"
-              value={company}
-              options={COMPANY_OPTIONS}
-              onChange={setCompany}
-            />
-            <FilterSelect
-              label="Type of Therapy"
-              value={therapyType}
-              options={THERAPY_TYPE_OPTIONS}
-              onChange={setTherapyType}
-            />
-
-            {/* Row 2 */}
-            <FilterSelect
-              label="Type of Resource"
-              value={resourceType}
-              options={RESOURCE_TYPE_OPTIONS}
-              onChange={(value) => setResourceType(value as 'all' | 'conference' | 'publication')}
-            />
-
-            {/* Row 3 - Therapy Selection */}
-            <TherapyMultiSelect
-              label="Approved Therapies"
-              maxLabel="Max 5"
-              options={availableTherapies.approved}
-              selected={selectedApproved}
-              onChange={setRawSelectedApproved}
-              maxSelect={5}
-            />
-            <TherapyMultiSelect
-              label="Non-Approved"
-              maxLabel="Max 5"
-              options={availableTherapies.nonApproved}
-              selected={selectedNonApproved}
-              onChange={setRawSelectedNonApproved}
-              maxSelect={5}
-            />
-
-            {/* Row 4 */}
-            <FilterSelect
-              label="Type of Funding"
-              value={fundingType}
-              options={FUNDING_TYPE_OPTIONS}
-              onChange={(value) => setFundingType(value as 'all' | 'industry' | 'non-industry')}
-            />
-
-            {/* Row 5 */}
-            <FilterSelect
-              label="Biomarker (YES or NO)"
-              value={biomarker}
-              options={BIOMARKER_OPTIONS}
-              onChange={setBiomarker}
-            />
-          </div>
-
-          {/* Advanced filters (same dimensions as Landscape page, separate filters) */}
-          <div className="mt-4 space-y-3">
-            <div className="text-[11px] font-medium text-[var(--brand-primary)] uppercase tracking-wider">
-              Advanced filters
+      <div className="flex flex-col flex-1 overflow-hidden">
+        {/* Horizontal Filter Bar */}
+        <div className="bg-white border-b border-slate-200 px-4 py-3 flex-shrink-0">
+          <div className="flex items-end gap-2 flex-wrap">
+            <div className="px-2.5 py-1.5 bg-[var(--brand-accent-light)] rounded-md border border-[var(--brand-border)] flex-shrink-0 self-end">
+              <div className="text-[10px] font-medium text-[var(--brand-primary)] uppercase tracking-wider">Cancer Type</div>
+              <div className="text-sm font-semibold text-[var(--brand-text)]">{categoryName}</div>
             </div>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="w-36">
               <FilterSelect
-                label="Modality"
-                value={advancedModality}
-                options={ADVANCED_MODALITY_OPTIONS}
-                onChange={setAdvancedModality}
-              />
-              <FilterSelect
-                label="Stage"
-                value={advancedStage}
-                options={ADVANCED_STAGE_OPTIONS}
-                onChange={setAdvancedStage}
-              />
-              <FilterSelect
-                label="Biomarker"
-                value={advancedBiomarker}
-                options={ADVANCED_BIOMARKER_OPTIONS}
-                onChange={setAdvancedBiomarker}
-              />
-              <FilterSelect
-                label="Line of therapy"
-                value={advancedLineOfTherapy}
-                options={ADVANCED_LINE_OF_THERAPY_OPTIONS}
-                onChange={setAdvancedLineOfTherapy}
-              />
-              <FilterSelect
-                label="Previous treatment"
-                value={advancedPreviousTreatment}
-                options={ADVANCED_PREVIOUS_TREATMENT_OPTIONS}
-                onChange={setAdvancedPreviousTreatment}
+                label="Funding"
+                value={fundingType}
+                options={FUNDING_TYPE_OPTIONS}
+                onChange={(value) => setFundingType(value as 'all' | 'industry' | 'non-industry')}
               />
             </div>
-          </div>
-
-          {/* Divider */}
-          <div className="my-4 border-t border-slate-200" />
-
-          {/* Action Buttons */}
-          <div className="flex gap-2">
+            <div className="w-40">
+              <FilterSelect label="Therapy" value={therapyType} options={THERAPY_TYPE_OPTIONS} onChange={setTherapyType} />
+            </div>
+            <div className="w-40">
+              <FilterSelect label="Line of treatment" value={advancedLineOfTherapy} options={ADVANCED_LINE_OF_THERAPY_OPTIONS} onChange={setAdvancedLineOfTherapy} />
+            </div>
+            <div className="w-40">
+              <FilterSelect
+                label="Resource"
+                value={resourceType}
+                options={RESOURCE_TYPE_OPTIONS}
+                onChange={(value) => setResourceType(value as 'all' | 'conference' | 'publication')}
+              />
+            </div>
+            <div className="w-48">
+              <TherapyMultiSelect
+                label="Treatments"
+                maxLabel="Max 5"
+                options={allAvailableTreatments}
+                selected={selectedTreatments}
+                onChange={setRawSelectedTreatments}
+                maxSelect={5}
+              />
+            </div>
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setAdvancedFiltersOpen(o => !o)}
+                className={cn(
+                  'flex h-10 items-center gap-1.5 rounded-md border-2 px-3 text-sm font-medium transition-all',
+                  advancedFiltersOpen
+                    ? 'border-[var(--brand-primary)] bg-[var(--brand-accent-light)] text-[var(--brand-primary)]'
+                    : 'border-[var(--brand-border)] bg-white text-gray-700 hover:border-[var(--brand-accent)]',
+                )}
+              >
+                Advanced
+                <ChevronDown className={cn('h-4 w-4 transition-transform', advancedFiltersOpen && 'rotate-180')} />
+              </button>
+              {advancedFiltersOpen && (
+                <>
+                  <div className="fixed inset-0 z-30" onClick={() => setAdvancedFiltersOpen(false)} />
+                  <div className="absolute right-0 top-full mt-2 z-40 w-[400px] rounded-lg border border-slate-200 bg-white shadow-lg p-4">
+                    <div className="text-[11px] font-medium text-[var(--brand-primary)] uppercase tracking-wider mb-3">
+                      Advanced filters
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <FilterSelect label="Modality" value={advancedModality} options={ADVANCED_MODALITY_OPTIONS} onChange={setAdvancedModality} />
+                      <FilterSelect label="Stage" value={advancedStage} options={ADVANCED_STAGE_OPTIONS} onChange={setAdvancedStage} />
+                      <FilterSelect label="Biomarker" value={advancedBiomarker} options={ADVANCED_BIOMARKER_OPTIONS} onChange={setAdvancedBiomarker} />
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+            <div className="flex-1 min-w-[8px]" />
             <Button
               variant="outline"
-              className="flex-1 border-[var(--brand-border)] text-[var(--brand-primary)] hover:bg-[var(--brand-accent-light)]"
+              className="h-10 border-[var(--brand-border)] text-[var(--brand-primary)] hover:bg-[var(--brand-accent-light)]"
               onClick={() => {
-                setCompany('all');
                 setTherapyType('all');
                 setResourceType('all');
-                setFundingType('all');
-                setBiomarker('all');
-                setRawSelectedApproved([]);
-                setRawSelectedNonApproved([]);
+                setFundingType('industry');
+                setAdvancedLineOfTherapy('all');
+                setRawSelectedTreatments([]);
                 setAdvancedModality('all');
                 setAdvancedStage('all');
                 setAdvancedBiomarker('all');
-                setAdvancedLineOfTherapy('all');
-                setAdvancedPreviousTreatment('all');
-                // Reset parameters based on mode
                 setEfficacyParamY('none');
                 setSafetyParamY('none');
                 if (mode === 'safety') {
@@ -1757,16 +1773,33 @@ export default function CategoryAnalyticsPage() {
                 }
               }}
             >
-              Reset Filters
+              Reset
             </Button>
-            <Button className="flex-1 bg-[var(--brand-primary)] hover:bg-[var(--brand-primary-hover)] text-white">
-              Apply Filters
+            <Button className="h-10 bg-[var(--brand-primary)] hover:bg-[var(--brand-primary-hover)] text-white">
+              Apply
             </Button>
           </div>
-        </aside>
+        </div>
+
+        {/* Split: Compare Table | Chart */}
+        <div className="flex flex-1 overflow-hidden gap-3 p-3 min-h-0">
+          <section className="flex-[0_0_60%] min-w-0 min-h-0 flex flex-col overflow-hidden">
+            <CompareTable
+              data={compareTableData}
+              mode={mode}
+              title={`Compare treatments — ${categoryName}`}
+              sort={compareSort}
+              onSortChange={setCompareSort}
+              hideEmpty={compareHideEmpty}
+              onHideEmptyChange={setCompareHideEmpty}
+              selections={compareSelections}
+              onToggleSelection={toggleCompareSelection}
+              activeMetricKeys={activeMetricKeys}
+            />
+          </section>
 
         {/* Right Panel - Chart */}
-        <main className="flex-1 flex flex-col overflow-hidden bg-white min-w-0">
+        <main className="flex-[0_0_40%] min-h-0 flex flex-col overflow-hidden bg-white min-w-0 rounded-lg border border-slate-200">
           {/* Compact Chart Header */}
           <div className="px-4 py-3 bg-slate-50 border-b border-slate-200 flex items-center justify-end gap-3 flex-shrink-0">
             {/* Chart type label + selector - Show in all Head to Head modes */}
@@ -1811,14 +1844,16 @@ export default function CategoryAnalyticsPage() {
                       <span>Diverging Chart</span>
                       {chartType === 'diverging' && <Check className="h-4 w-4 ml-auto text-[var(--brand-primary)]" />}
                     </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setChartType('bubble')}
-                      className="flex items-center gap-3 rounded-lg py-2.5 cursor-pointer focus:bg-[var(--brand-accent-light)] focus:text-[var(--brand-primary)]"
-                    >
-                      <CircleDot className="h-4 w-4 text-slate-500" />
-                      <span>Bubble Chart</span>
-                      {chartType === 'bubble' && <Check className="h-4 w-4 ml-auto text-[var(--brand-primary)]" />}
-                    </DropdownMenuItem>
+                    {mode === 'all' && (
+                      <DropdownMenuItem
+                        onClick={() => setChartType('bubble')}
+                        className="flex items-center gap-3 rounded-lg py-2.5 cursor-pointer focus:bg-[var(--brand-accent-light)] focus:text-[var(--brand-primary)]"
+                      >
+                        <CircleDot className="h-4 w-4 text-slate-500" />
+                        <span>Bubble Chart</span>
+                        {chartType === 'bubble' && <Check className="h-4 w-4 ml-auto text-[var(--brand-primary)]" />}
+                      </DropdownMenuItem>
+                    )}
                     {mode === 'efficacy' && (
                       <DropdownMenuItem
                         onClick={() => setChartType('dumbbell')}
@@ -1987,6 +2022,7 @@ export default function CategoryAnalyticsPage() {
             </div>
           </div>
         </main>
+        </div>
       </div>
       </main>
 
@@ -2043,14 +2079,16 @@ export default function CategoryAnalyticsPage() {
                           <span>Diverging Chart</span>
                           {chartType === 'diverging' && <Check className="h-4 w-4 ml-auto text-[var(--brand-primary)]" />}
                         </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => setChartType('bubble')}
-                          className="flex items-center gap-3 rounded-lg py-2.5 cursor-pointer focus:bg-[var(--brand-accent-light)] focus:text-[var(--brand-primary)]"
-                        >
-                          <CircleDot className="h-4 w-4 text-slate-500" />
-                          <span>Bubble Chart</span>
-                          {chartType === 'bubble' && <Check className="h-4 w-4 ml-auto text-[var(--brand-primary)]" />}
-                        </DropdownMenuItem>
+                        {mode === 'all' && (
+                          <DropdownMenuItem
+                            onClick={() => setChartType('bubble')}
+                            className="flex items-center gap-3 rounded-lg py-2.5 cursor-pointer focus:bg-[var(--brand-accent-light)] focus:text-[var(--brand-primary)]"
+                          >
+                            <CircleDot className="h-4 w-4 text-slate-500" />
+                            <span>Bubble Chart</span>
+                            {chartType === 'bubble' && <Check className="h-4 w-4 ml-auto text-[var(--brand-primary)]" />}
+                          </DropdownMenuItem>
+                        )}
                         {mode === 'efficacy' && (
                           <DropdownMenuItem
                             onClick={() => setChartType('dumbbell')}

--- a/web/src/app/dashboard/[category]/landscape/page.tsx
+++ b/web/src/app/dashboard/[category]/landscape/page.tsx
@@ -17,6 +17,7 @@ import Link from 'next/link';
 import { Logo } from '@/components/Logo';
 import { DashboardNavLink } from '@/components/nav/DashboardNavLink';
 import { DEFAULT_CANCER_TYPE_SLUG, PHASE_OPTIONS, STATUS_OPTIONS } from '@/lib/dashboard-constants';
+import { isOpenStudyStatus, selectTrialsWithOpenBias } from '@/lib/utils/trial-utils';
 
 /** Modality column headers in display order (reference). */
 const MODALITY_HEADERS = [
@@ -36,13 +37,6 @@ const MODALITY_HEADERS = [
 const MODALITY_OTHER = 'Other';
 
 const UNSPECIFIED_LABEL = 'Unspecified';
-const OPEN_STUDY_STATUSES = new Set([
-  'open',
-  'not yet recruiting',
-  'recruiting',
-  'active, not recruiting',
-]);
-
 /** Canonical group-by category values (match trials_extraction_prompts.py). Column order follows these lists. */
 const BIOMARKER_VALUES = [
   'BRAF (V600)',
@@ -102,10 +96,6 @@ function parseModalityValues(raw: string | null | undefined): string[] {
   return unique.length > 0 ? unique : [MODALITY_OTHER];
 }
 
-function isOpenStudyStatus(status: string | null | undefined): boolean {
-  return OPEN_STUDY_STATUSES.has((status ?? '').trim().toLowerCase());
-}
-
 function sortTrialsOpenStatusFirst(trials: DashboardTrialCard[]): DashboardTrialCard[] {
   return [...trials].sort((a, b) => {
     const aIsOpen = isOpenStudyStatus(a.study_status);
@@ -114,6 +104,7 @@ function sortTrialsOpenStatusFirst(trials: DashboardTrialCard[]): DashboardTrial
     return aIsOpen ? -1 : 1;
   });
 }
+
 
 /** Stable empty list for useMemo when no trials data yet. */
 const EMPTY_TRIALS: DashboardTrialCard[] = [];
@@ -952,7 +943,7 @@ function DashboardContent() {
                         ).map((groupLabel) => {
                           const groupTrials = trialsByModality.map[groupLabel] ?? [];
                           const visibleCount = visibleCountByGroup[groupLabel] ?? CARDS_PER_GROUP_INITIAL;
-                          const visibleTrials = groupTrials.slice(0, visibleCount);
+                          const visibleTrials = selectTrialsWithOpenBias(groupTrials, visibleCount);
                           const hasMoreClient = groupTrials.length > visibleCount;
                           const totalForModality = totalByModality[groupLabel];
                           const hasMoreServer = totalForModality != null
@@ -1073,7 +1064,7 @@ function DashboardContent() {
                         ).map((groupLabel) => {
                           const groupTrials = trialsByCustomGroup.map[groupLabel] ?? [];
                           const visibleCount = visibleCountByGroup[groupLabel] ?? CARDS_PER_GROUP_INITIAL;
-                          const visibleTrials = groupTrials.slice(0, visibleCount);
+                          const visibleTrials = selectTrialsWithOpenBias(groupTrials, visibleCount);
                           const hasMoreClient = groupTrials.length > visibleCount;
                           const totalForCategory = totalByGroup[groupLabel];
                           const hasMoreServer =

--- a/web/src/app/dashboard/[category]/page.tsx
+++ b/web/src/app/dashboard/[category]/page.tsx
@@ -125,6 +125,7 @@ export default function CancerDashboardSnapshot() {
     queryFn: () =>
       trialsApi.getDashboardTrials(categorySlug, {
         limit: 9,
+        open_fraction: 0.7,
         sponsor_type: ['Industry'],
       }),
     retry: false,
@@ -220,7 +221,6 @@ export default function CancerDashboardSnapshot() {
     if (!snapshotData?.bubble?.length) return [];
     return snapshotData.bubble.map((p) => ({
       treatmentName: p.treatmentName,
-      approvalStatus: p.approvalStatus,
       efficacy: p.efficacy,
       safety: p.safety,
       numberOfPatients: p.numberOfPatients ?? 0,
@@ -233,7 +233,6 @@ export default function CancerDashboardSnapshot() {
     if (!snapshotData?.bar?.length) return [];
     return snapshotData.bar.map((p) => ({
       treatmentName: p.treatmentName,
-      approvalStatus: p.approvalStatus,
       averageValue: p.averageValue,
       medianValue: p.averageValue,
       minValue: p.averageValue,
@@ -591,7 +590,7 @@ export default function CancerDashboardSnapshot() {
                     </div>
                   )}
                   <div className="grid grid-cols-3 gap-2 min-h-0 flex-1 overflow-hidden">
-                    {trialsData?.trials.slice(0, 9).map((trial) => (
+                    {(trialsData?.trials ?? []).map((trial) => (
                       <TrialCard
                         key={trial.nct_id}
                         trial={trial}

--- a/web/src/components/charts/BarChart.tsx
+++ b/web/src/components/charts/BarChart.tsx
@@ -47,11 +47,7 @@ interface BarShapeProps {
 // ============================================================================
 
 const COLORS = {
-  bar: {
-    approved: '#3b82f6',
-    investigational: '#8b5cf6',
-    unknown: '#64748b',
-  },
+  bar: '#3b82f6',
   dot: {
     fill: '#1f2937',
     stroke: '#9ca3af',
@@ -61,11 +57,7 @@ const COLORS = {
 };
 
 const DARK_COLORS = {
-  bar: {
-    approved: '#0ea5e9',
-    investigational: '#8b5cf6',
-    unknown: '#64748b',
-  },
+  bar: '#0ea5e9',
   dot: {
     fill: '#475569',
     stroke: '#e2e8f0',
@@ -168,9 +160,6 @@ function CustomTooltipContent({ tooltipData, metricLabel, metricUnit, isPinned }
 
   if (tooltipData.type === 'scatter') {
     const trial = tooltipData.data as ScatterPoint;
-    const sourceValue = trial.publicationName || trial.abstractId;
-    const isWebScrape = trial.abstractId?.startsWith('webscrape_');
-    const hasSourceUrl = !!trial.sourceUrl;
 
     return (
       <div
@@ -211,10 +200,12 @@ function CustomTooltipContent({ tooltipData, metricLabel, metricUnit, isPinned }
               </Link>
             </div>
           )}
-          {sourceValue && (
+          {(trial.sourceType === 'webscrape' ? !!trial.sourceUrl : !!(trial.abstractId || trial.publicationName)) && (
             <div className="flex justify-between text-[11px]">
-              <span className="text-slate-400">{trial.publicationName ? 'Publication' : 'Abstract ID'}</span>
-              {isWebScrape && hasSourceUrl ? (
+              <span className="text-slate-400">
+                {trial.sourceType === 'publication' ? 'Publication' : trial.sourceType === 'webscrape' ? 'Web Source' : 'Abstract'}
+              </span>
+              {trial.sourceType === 'webscrape' ? (
                 <a
                   href={trial.sourceUrl}
                   target="_blank"
@@ -222,24 +213,24 @@ function CustomTooltipContent({ tooltipData, metricLabel, metricUnit, isPinned }
                   className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <span className="text-[11px]">{sourceValue}</span>
+                  <span className="text-[11px]">{trial.sourceUrl}</span>
                   <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                   </svg>
                 </a>
-              ) : trial.abstractId ? (
+              ) : trial.sourceType === 'publication' ? (
+                <span className="text-slate-200 text-[11px]">{trial.publicationName}</span>
+              ) : (
                 <Link
                   href={`/trial/abstract/${trial.abstractId}`}
                   className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <span className="text-[11px]">{sourceValue}</span>
+                  <span className="text-[11px]">{trial.abstractId}</span>
                   <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>
                 </Link>
-              ) : (
-                <span className="text-slate-200 text-[11px]">{sourceValue}</span>
               )}
             </div>
           )}
@@ -264,18 +255,6 @@ function CustomTooltipContent({ tooltipData, metricLabel, metricUnit, isPinned }
       <div className="mb-2 pb-2 border-b border-slate-700">
         <div className="flex items-center justify-between gap-2">
           <h4 className="font-bold text-white text-xs">{treatment.treatmentName}</h4>
-          <span
-            className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wider shrink-0 ${
-              treatment.approvalStatus === 'Approved'
-                ? 'bg-emerald-900/50 text-emerald-300'
-                : treatment.approvalStatus === 'Investigational'
-                ? 'bg-violet-900/50 text-violet-300'
-                : 'bg-slate-700/50 text-slate-300'
-            }`}
-          >
-            {treatment.approvalStatus === 'Approved' && '★ '}
-            {treatment.approvalStatus}
-          </span>
         </div>
       </div>
       <div className="mb-2">
@@ -303,45 +282,38 @@ function CustomTooltipContent({ tooltipData, metricLabel, metricUnit, isPinned }
             </Link>
           </div>
         )}
-        {(firstTrial?.publicationName || firstTrial?.abstractId) && (
+        {firstTrial && (firstTrial.sourceType === 'webscrape' ? !!firstTrial.sourceUrl : !!(firstTrial.abstractId || firstTrial.publicationName)) && (
           <div className="flex justify-between text-[11px]">
-            <span className="text-slate-400">{firstTrial.publicationName ? 'Publication' : 'Abstract ID'}</span>
-            {(() => {
-              const sourceValue = firstTrial.publicationName || firstTrial.abstractId;
-              const isWebScrape = firstTrial.abstractId?.startsWith('webscrape_');
-              const hasSourceUrl = !!firstTrial.sourceUrl;
-              if (isWebScrape && hasSourceUrl) {
-                return (
-                  <a
-                    href={firstTrial.sourceUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="text-[11px]">{sourceValue}</span>
-                    <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                    </svg>
-                  </a>
-                );
-              }
-              if (firstTrial.abstractId) {
-                return (
-                  <Link
-                    href={`/trial/abstract/${firstTrial.abstractId}`}
-                    className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="text-[11px]">{sourceValue}</span>
-                    <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </Link>
-                );
-              }
-              return <span className="text-slate-200 text-[11px]">{sourceValue}</span>;
-            })()}
+            <span className="text-slate-400">
+              {firstTrial.sourceType === 'publication' ? 'Publication' : firstTrial.sourceType === 'webscrape' ? 'Web Source' : 'Abstract'}
+            </span>
+            {firstTrial.sourceType === 'webscrape' ? (
+              <a
+                href={firstTrial.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="text-[11px]">{firstTrial.sourceUrl}</span>
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            ) : firstTrial.sourceType === 'publication' ? (
+              <span className="text-slate-200 text-[11px]">{firstTrial.publicationName}</span>
+            ) : (
+              <Link
+                href={`/trial/abstract/${firstTrial.abstractId}`}
+                className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="text-[11px]">{firstTrial.abstractId}</span>
+                <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+            )}
           </div>
         )}
       </div>
@@ -851,14 +823,6 @@ export default function BarChart({
           <div className="flex items-center justify-between px-4 py-2 bg-slate-50 border-b border-slate-200 flex-shrink-0">
             <div className="flex items-center gap-4 text-xs">
               <div className="flex items-center gap-1.5">
-                <div className="w-3 h-3 rounded" style={{ background: colors.bar.approved }} />
-                <span className="text-slate-600 font-medium">Approved</span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <div className="w-3 h-3 rounded" style={{ background: colors.bar.investigational }} />
-                <span className="text-slate-600 font-medium">Investigational</span>
-              </div>
-              <div className="flex items-center gap-1.5">
                 <div 
                   className="w-3 h-3 rounded-full" 
                   style={{ background: colors.dot.fill, border: `2px solid ${colors.dot.stroke}` }} 
@@ -939,16 +903,10 @@ export default function BarChart({
                 }}
                 onMouseLeave={handleBarMouseLeave}
               >
-                {data.map((entry: HeadToHeadDataPoint, index: number) => (
+                {data.map((_entry: HeadToHeadDataPoint, index: number) => (
                   <Cell
                     key={`cell-${index}`}
-                    fill={
-                      entry.approvalStatus === 'Approved'
-                        ? colors.bar.approved
-                        : entry.approvalStatus === 'Investigational'
-                        ? colors.bar.investigational
-                        : colors.bar.unknown
-                    }
+                    fill={colors.bar}
                   />
                 ))}
               </Bar>
@@ -1001,14 +959,6 @@ export default function BarChart({
       <CardContent className="pt-4">
         {showLegend && (
           <div className="flex items-center justify-center gap-6 text-xs mb-4">
-            <div className="flex items-center gap-1.5">
-              <div className="w-3 h-3 rounded" style={{ background: colors.bar.approved }} />
-              <span className="text-slate-300">Approved</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <div className="w-3 h-3 rounded" style={{ background: colors.bar.investigational }} />
-              <span className="text-slate-300">Investigational</span>
-            </div>
             <div className="flex items-center gap-1.5">
               <div 
                 className="w-3 h-3 rounded-full" 
@@ -1078,16 +1028,10 @@ export default function BarChart({
                 }}
                 onMouseLeave={handleBarMouseLeave}
               >
-                {data.map((entry: HeadToHeadDataPoint, index: number) => (
+                {data.map((_entry: HeadToHeadDataPoint, index: number) => (
                   <Cell
                     key={`cell-${index}`}
-                    fill={
-                      entry.approvalStatus === 'Approved'
-                        ? colors.bar.approved
-                        : entry.approvalStatus === 'Investigational'
-                        ? colors.bar.investigational
-                        : colors.bar.unknown
-                    }
+                    fill={colors.bar}
                     fillOpacity={0.85}
                   />
                 ))}
@@ -1117,7 +1061,7 @@ export default function BarChart({
 
         {/* Summary Stats */}
         <div className="mt-6 pt-4 border-t border-slate-800">
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 gap-4">
             <div className="text-center">
               <p className="text-2xl font-bold text-white tabular-nums">
                 {data.length}
@@ -1132,22 +1076,6 @@ export default function BarChart({
               </p>
               <p className="text-xs text-slate-400 uppercase tracking-wider">
                 Trial Results
-              </p>
-            </div>
-            <div className="text-center">
-              <p className="text-2xl font-bold text-sky-400 tabular-nums">
-                {data.filter((d: HeadToHeadDataPoint) => d.approvalStatus === 'Approved').length}
-              </p>
-              <p className="text-xs text-slate-400 uppercase tracking-wider">
-                Approved
-              </p>
-            </div>
-            <div className="text-center">
-              <p className="text-2xl font-bold text-violet-400 tabular-nums">
-                {data.filter((d: HeadToHeadDataPoint) => d.approvalStatus === 'Investigational').length}
-              </p>
-              <p className="text-xs text-slate-400 uppercase tracking-wider">
-                Investigational
               </p>
             </div>
           </div>

--- a/web/src/components/charts/BubbleChart.tsx
+++ b/web/src/components/charts/BubbleChart.tsx
@@ -85,10 +85,6 @@ const TREATMENT_COLORS = [
 ];
 
 const COLORS = {
-  approved: '#10b981', // Green
-  investigational: '#8b5cf6', // Purple
-  developmentStopped: '#ef4444', // Red
-  unknown: '#64748b', // Gray
   grid: '#e2e8f0',
   axis: '#64748b',
 };
@@ -337,21 +333,6 @@ const CustomTooltip = ({
       <div className="mb-2 pb-2 border-b border-slate-700">
         <div className="flex items-center justify-between gap-2">
           <h4 className="font-bold text-white text-xs">{dataNonNull.treatmentName}</h4>
-          {dataNonNull.developmentStatus && (
-            <span
-              className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wider shrink-0 ${
-                dataNonNull.developmentStatus === 'Approved'
-                  ? 'bg-emerald-900/50 text-emerald-300'
-                  : dataNonNull.developmentStatus === 'Development stopped'
-                  ? 'bg-red-900/50 text-red-300'
-                  : 'bg-violet-900/50 text-violet-300'
-              }`}
-            >
-              {dataNonNull.developmentStatus === 'Approved' && '★ '}
-              {dataNonNull.developmentStatus === 'Development stopped' && 'Ø '}
-              {dataNonNull.developmentStatus}
-            </span>
-          )}
         </div>
         {dataNonNull.treatmentType && (
           <p className="text-[11px] text-slate-400 mt-0.5">{dataNonNull.treatmentType}</p>
@@ -414,47 +395,42 @@ const CustomTooltip = ({
             </Link>
           </div>
         )}
-        {(currentTrial.abstractId || currentTrial.publicationName) && (
+        {(currentTrial.sourceType === 'webscrape' ? !!currentTrial.sourceUrl : !!(currentTrial.abstractId || currentTrial.publicationName)) && (
           <div className="flex justify-between text-[11px]">
             <span className="text-slate-400">
-              {currentTrial.publicationName ? 'Publication' : 'Abstract ID'}
+              {currentTrial.sourceType === 'publication'
+                ? 'Publication'
+                : currentTrial.sourceType === 'webscrape'
+                ? 'Web Source'
+                : 'Abstract'}
             </span>
-            {(() => {
-              const sourceValue = currentTrial.publicationName || currentTrial.abstractId;
-              const isWebScrape = currentTrial.abstractId?.startsWith('webscrape_');
-              const hasSourceUrl = !!dataNonNull.sourceUrl;
-              if (isWebScrape && hasSourceUrl) {
-                return (
-                  <a
-                    href={dataNonNull.sourceUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="text-xs">{sourceValue}</span>
-                    <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                    </svg>
-                  </a>
-                );
-              }
-              if (currentTrial.abstractId) {
-                return (
-                  <Link
-                    href={`/trial/abstract/${currentTrial.abstractId}`}
-                    className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="text-[11px]">{sourceValue}</span>
-                    <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </Link>
-                );
-              }
-              return <span className="text-slate-200 text-[11px]">{sourceValue}</span>;
-            })()}
+            {currentTrial.sourceType === 'webscrape' ? (
+              <a
+                href={currentTrial.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="text-xs">{currentTrial.sourceUrl}</span>
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            ) : currentTrial.sourceType === 'publication' ? (
+              <span className="text-slate-200 text-[11px]">{currentTrial.publicationName}</span>
+            ) : (
+              <Link
+                href={`/trial/abstract/${currentTrial.abstractId}`}
+                className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="text-[11px]">{currentTrial.abstractId}</span>
+                <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+            )}
           </div>
         )}
         {dataNonNull.biomarker && (
@@ -1005,7 +981,7 @@ export default function BubbleChart({
 
   // Get color for each point based on treatment name
   const getColor = (item: BubbleChartDataPoint) => {
-    return treatmentColorMap.get(item.treatmentName) || colors.unknown;
+    return treatmentColorMap.get(item.treatmentName) || '#64748b';
   };
 
   // Custom tick formatters - handle all axis configurations and inversion

--- a/web/src/components/charts/DivergingBarChart.tsx
+++ b/web/src/components/charts/DivergingBarChart.tsx
@@ -182,21 +182,6 @@ const CustomTooltip = ({
       <div className="mb-2 pb-2 border-b border-slate-700">
         <div className="flex items-center justify-between gap-2">
           <h4 className="font-bold text-white text-xs">{label || dataNonNull.treatmentName}</h4>
-          {(dataNonNull.approvalStatus || dataNonNull.developmentStatus) && (
-            <span
-              className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wider shrink-0 ${
-                (dataNonNull.approvalStatus === 'Approved' || dataNonNull.developmentStatus === 'Approved')
-                  ? 'bg-emerald-900/50 text-emerald-300'
-                  : (dataNonNull.developmentStatus === 'Development stopped')
-                  ? 'bg-red-900/50 text-red-300'
-                  : 'bg-violet-900/50 text-violet-300'
-              }`}
-            >
-              {((dataNonNull.approvalStatus === 'Approved' || dataNonNull.developmentStatus === 'Approved') && '★ ')}
-              {(dataNonNull.developmentStatus === 'Development stopped' && 'Ø ')}
-              {(dataNonNull.approvalStatus || dataNonNull.developmentStatus)}
-            </span>
-          )}
         </div>
         {dataNonNull.treatmentType && (
           <p className="text-[11px] text-slate-400 mt-0.5">{dataNonNull.treatmentType}</p>
@@ -259,47 +244,42 @@ const CustomTooltip = ({
             </Link>
           </div>
         )}
-        {(currentTrial.abstractId || currentTrial.publicationName) && (
+        {(currentTrial.sourceType === 'webscrape' ? !!currentTrial.sourceUrl : !!(currentTrial.abstractId || currentTrial.publicationName)) && (
           <div className="flex justify-between text-[11px]">
             <span className="text-slate-400">
-              {currentTrial.publicationName ? 'Publication' : 'Abstract ID'}
+              {currentTrial.sourceType === 'publication'
+                ? 'Publication'
+                : currentTrial.sourceType === 'webscrape'
+                ? 'Web Source'
+                : 'Abstract'}
             </span>
-            {(() => {
-              const sourceValue = currentTrial.publicationName || currentTrial.abstractId;
-              const isWebScrape = currentTrial.abstractId?.startsWith('webscrape_');
-              const hasSourceUrl = !!dataNonNull.sourceUrl;
-              if (isWebScrape && hasSourceUrl) {
-                return (
-                  <a
-                    href={dataNonNull.sourceUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="text-xs">{sourceValue}</span>
-                    <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                    </svg>
-                  </a>
-                );
-              }
-              if (currentTrial.abstractId) {
-                return (
-                  <Link
-                    href={`/trial/abstract/${currentTrial.abstractId}`}
-                    className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <span className="text-[11px]">{sourceValue}</span>
-                    <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </Link>
-                );
-              }
-              return <span className="text-slate-200 text-[11px]">{sourceValue}</span>;
-            })()}
+            {currentTrial.sourceType === 'webscrape' ? (
+              <a
+                href={currentTrial.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="text-xs">{currentTrial.sourceUrl}</span>
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            ) : currentTrial.sourceType === 'publication' ? (
+              <span className="text-slate-200 text-[11px]">{currentTrial.publicationName}</span>
+            ) : (
+              <Link
+                href={`/trial/abstract/${currentTrial.abstractId}`}
+                className="text-sky-400 hover:text-sky-300 hover:underline cursor-pointer transition-colors inline-flex items-center gap-1"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="text-[11px]">{currentTrial.abstractId}</span>
+                <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+            )}
           </div>
         )}
         {dataNonNull.biomarker && (

--- a/web/src/components/compare/CompareTable.tsx
+++ b/web/src/components/compare/CompareTable.tsx
@@ -1,0 +1,436 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Check, ChevronDown, Activity, ShieldAlert } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  CompareCell,
+  CompareMode,
+  CompareRow,
+  CompareSelection,
+  CompareSortMode,
+  CompareTableData,
+  TreatmentMeta,
+} from '@/types/compare';
+import { CompareTableLegend } from './CompareTableLegend';
+
+interface CompareTableProps {
+  data: CompareTableData;
+  mode: CompareMode;
+  title: string;
+  sort: CompareSortMode;
+  onSortChange: (s: CompareSortMode) => void;
+  hideEmpty: boolean;
+  onHideEmptyChange: (b: boolean) => void;
+  selections: CompareSelection[];
+  onToggleSelection: (s: CompareSelection) => void;
+  activeMetricKeys: string[];
+}
+
+const SORT_LABELS: Record<CompareSortMode, string> = {
+  'most-complete': 'Most complete',
+  alphabetical: 'Alphabetical',
+};
+
+const EFFICACY_SUB_GROUP_ORDER = ['Study', 'PFS', 'OS', 'Response', 'EFS', 'RFS', 'MFS', 'Time-to'];
+const SAFETY_SUB_GROUP_ORDER = ['Study', 'AE', 'TEAE', 'TRAE', 'Specific AE', 'Grade 3+ AE', 'Grade 3+ TRAE', 'Grade 3+ TEAE'];
+
+function sortRows(rows: CompareRow[], _mode: CompareSortMode, subGroupOrder: string[]): CompareRow[] {
+  const definitionIndex = new Map(rows.map((r, i) => [r.metricKey, i]));
+  const copy = [...rows];
+  copy.sort((a, b) => {
+    const ia = subGroupOrder.indexOf(a.subGroup ?? '');
+    const ib = subGroupOrder.indexOf(b.subGroup ?? '');
+    const groupDiff = (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
+    if (groupDiff !== 0) return groupDiff;
+    return definitionIndex.get(a.metricKey)! - definitionIndex.get(b.metricKey)!;
+  });
+  return copy;
+}
+
+function CompareCellView({
+  cell,
+  selected,
+  onClick,
+  hasData,
+  active,
+  columnActive,
+}: {
+  cell: CompareCell;
+  selected: boolean;
+  onClick: () => void;
+  hasData: boolean;
+  active: boolean;
+  columnActive: boolean;
+}) {
+  const isEmpty = cell.status !== 'value';
+
+  if (isEmpty) {
+    return (
+      <div
+        className={cn(
+          'w-full h-[44px] flex items-center justify-center',
+          columnActive ? 'bg-[var(--brand-accent-light)]' : '',
+        )}
+        style={columnActive ? undefined : {
+          backgroundImage: 'repeating-linear-gradient(135deg, #f8fafc 0 4px, #ffffff 4px 8px)',
+        }}
+      >
+        <span className="text-[11px] text-slate-300 select-none tabular-nums">—</span>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!hasData || !active}
+      className={cn(
+        'relative group w-full h-[44px] px-3 text-left transition-colors duration-100',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-inset',
+        active && !selected && (columnActive ? 'hover:bg-[var(--brand-primary)]/15' : 'hover:bg-[var(--brand-accent-light)]'),
+        active && !selected ? 'cursor-pointer' : !active ? 'cursor-default' : '',
+        active && selected && columnActive && 'bg-[var(--brand-primary)] cursor-pointer',
+        active && selected && !columnActive && 'bg-[var(--brand-accent-light)] ring-2 ring-[var(--brand-primary)] ring-inset cursor-pointer',
+      )}
+    >
+      <span className={cn(
+        'font-mono font-bold text-[13px] tabular-nums',
+        active && selected && columnActive ? 'text-white' :
+        active && selected ? 'text-[var(--brand-primary)]' :
+        columnActive ? 'text-[var(--brand-primary)]' : 'text-slate-800',
+      )}>
+        {cell.displayValue}
+      </span>
+      {active && !selected && (
+        <span
+          className={cn(
+            'absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full transition-all duration-100',
+            columnActive
+              ? 'bg-[var(--brand-primary)]/30 group-hover:bg-[var(--brand-primary)]/70'
+              : 'bg-slate-300 group-hover:bg-[var(--brand-primary)]/50',
+          )}
+        />
+      )}
+    </button>
+  );
+}
+
+/* Each section (efficacy / safety) gets its own overflow-x-auto so the table
+   sizes to its own content rather than stretching to match the widest sibling.
+   This also means sticky-right Cov anchors correctly to each section's viewport. */
+function CompareSectionTable({
+  rows,
+  treatments,
+  selectionSet,
+  onToggleSelection,
+  activeMetricKeys,
+  treatmentMeta,
+}: {
+  rows: CompareRow[];
+  treatments: string[];
+  selectionSet: Set<string>;
+  onToggleSelection: (s: CompareSelection) => void;
+  activeMetricKeys: string[];
+  treatmentMeta: Record<string, TreatmentMeta>;
+}) {
+  const firstInGroup = new Set<string>();
+  let lastGroup = '';
+  for (const row of rows) {
+    const g = row.subGroup ?? '';
+    if (g !== lastGroup) {
+      firstInGroup.add(row.metricKey);
+      lastGroup = g;
+    }
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="caption-bottom text-sm border-collapse min-w-max">
+        <thead>
+          <tr className="border-b-2 border-slate-200">
+            <th
+              className="sticky left-0 z-20 bg-white text-left text-[10px] font-bold text-slate-500 uppercase tracking-[0.12em] px-4 pb-2 pt-2 border-r border-slate-200 align-bottom"
+              style={{ width: 180, minWidth: 180 }}
+            >
+              <span className="invisible block text-[8px] mb-1.5">{'\u00A0'}</span>
+              <span className="block leading-tight">Treatment</span>
+              <span className="invisible block text-[9px] mt-0.5">{'\u00A0'}</span>
+            </th>
+            <th
+              className="text-left text-[10px] font-bold text-slate-500 uppercase tracking-[0.12em] px-3 pb-2 pt-2 border-l border-slate-200 align-bottom"
+              style={{ width: 120, minWidth: 120 }}
+            >
+              <span className="invisible block text-[8px] mb-1.5">{'\u00A0'}</span>
+              <span className="block leading-tight">Modality</span>
+              <span className="invisible block text-[9px] mt-0.5">{'\u00A0'}</span>
+            </th>
+            <th
+              className="text-left text-[10px] font-bold text-slate-500 uppercase tracking-[0.12em] px-3 pb-2 pt-2 border-l border-slate-200 align-bottom"
+              style={{ width: 100, minWidth: 100 }}
+            >
+              <span className="invisible block text-[8px] mb-1.5">{'\u00A0'}</span>
+              <span className="block leading-tight">Line</span>
+              <span className="invisible block text-[9px] mt-0.5">{'\u00A0'}</span>
+            </th>
+            {rows.map(row => {
+              const isActive = activeMetricKeys.length === 0 || activeMetricKeys.includes(row.metricKey);
+              const isFirst = firstInGroup.has(row.metricKey);
+              const subGroup = row.subGroup ?? '';
+              return (
+                <th
+                  key={row.metricKey}
+                  className={cn(
+                    'text-left text-[10px] font-bold uppercase tracking-[0.08em] px-3 pb-2 pt-2 min-w-[110px] align-bottom transition-colors',
+                    isFirst ? 'border-l-2 border-l-slate-300' : 'border-l border-slate-100',
+                    isActive
+                      ? 'text-[var(--brand-primary)] bg-[var(--brand-accent-light)]'
+                      : 'text-slate-500 bg-white',
+                  )}
+                  title={row.label}
+                >
+                  <span className={cn(
+                    'block text-[8px] font-extrabold uppercase tracking-[0.15em] mb-1.5',
+                    isFirst && subGroup ? 'text-slate-400' : 'invisible',
+                  )}>
+                    {subGroup || '\u00A0'}
+                  </span>
+                  <span className="block truncate leading-tight">{row.label}</span>
+                  <span className={cn(
+                    'block text-[9px] font-normal normal-case tracking-normal opacity-60 mt-0.5',
+                    row.unit ? '' : 'invisible',
+                  )}>
+                    ({row.unit || '\u00A0'})
+                  </span>
+                </th>
+              );
+            })}
+            <th
+              className="sticky right-0 bg-white text-left text-[10px] font-bold text-slate-700 uppercase tracking-[0.12em] px-3 pb-2 pt-2 border-l border-slate-200 align-bottom"
+              style={{ width: 52, minWidth: 52 }}
+            >
+              <span className="invisible block text-[8px] mb-1.5">{'\u00A0'}</span>
+              <span className="block leading-tight">Cov</span>
+              <span className="invisible block text-[9px] mt-0.5">{'\u00A0'}</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {treatments.map(treatment => {
+            const cov = rows.filter(r => r.cells[treatment]?.status === 'value').length;
+            return (
+              <tr
+                key={treatment}
+                className="border-b border-slate-100 hover:bg-slate-50/70 transition-colors duration-75"
+              >
+                <td
+                  className="sticky left-0 z-10 bg-white px-4 py-0 border-r border-slate-200 align-top"
+                  style={{ width: 180, minWidth: 180 }}
+                >
+                  <span className="text-[13px] font-semibold text-slate-800 leading-snug block py-3 pr-2 break-words">
+                    {treatment}
+                  </span>
+                </td>
+                <td className="px-3 py-0 border-l border-slate-100 align-middle" style={{ width: 120, minWidth: 120 }}>
+                  <span className="text-[13px] font-semibold text-slate-800 leading-tight block py-3">
+                    {treatmentMeta[treatment]?.modality ?? '—'}
+                  </span>
+                </td>
+                <td className="px-3 py-0 border-l border-slate-100 align-middle" style={{ width: 100, minWidth: 100 }}>
+                  <span className="text-[13px] font-semibold text-slate-800 leading-tight block py-3">
+                    {treatmentMeta[treatment]?.lineOfTreatment ?? '—'}
+                  </span>
+                </td>
+                {rows.map(row => {
+                  const cell = row.cells[treatment];
+                  const key = `${treatment}::${row.metricKey}`;
+                  const isActive =
+                    activeMetricKeys.length === 0 || activeMetricKeys.includes(row.metricKey);
+                  const colActive = activeMetricKeys.length > 0 && isActive;
+                  const isFirst = firstInGroup.has(row.metricKey);
+                  return (
+                    <td
+                      key={row.metricKey}
+                      className={cn(
+                        'p-0 align-middle',
+                        isFirst ? 'border-l-2 border-l-slate-300' : 'border-l border-slate-100',
+                        colActive && 'bg-[var(--brand-accent-light)]',
+                      )}
+                    >
+                      <CompareCellView
+                        cell={cell}
+                        selected={selectionSet.has(key)}
+                        onClick={() =>
+                          onToggleSelection({ treatmentName: treatment, metricKey: row.metricKey })
+                        }
+                        hasData={rows.length > 0}
+                        active={isActive}
+                        columnActive={colActive}
+                      />
+                    </td>
+                  );
+                })}
+                <td
+                  className="sticky right-0 bg-white px-3 py-0 border-l border-slate-200 align-middle"
+                  style={{ width: 52, minWidth: 52 }}
+                >
+                  <span
+                    className={cn(
+                      'text-[11px] font-mono tabular-nums block text-center',
+                      cov > 0 ? 'text-[var(--brand-primary)] font-bold' : 'text-slate-300',
+                    )}
+                  >
+                    {cov}/{rows.length}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function CompareTable({
+  data,
+  mode,
+  title,
+  sort,
+  onSortChange,
+  hideEmpty,
+  onHideEmptyChange,
+  selections,
+  onToggleSelection,
+  activeMetricKeys,
+}: CompareTableProps) {
+  const { treatments } = data;
+  const total = treatments.length;
+
+  const visibleEfficacy = useMemo(() => {
+    const sorted = sortRows(data.efficacyRows, sort, EFFICACY_SUB_GROUP_ORDER);
+    return hideEmpty ? sorted.filter(r => r.coverage > 0) : sorted;
+  }, [data.efficacyRows, sort, hideEmpty]);
+
+  const visibleSafety = useMemo(() => {
+    const sorted = sortRows(data.safetyRows, sort, SAFETY_SUB_GROUP_ORDER);
+    return hideEmpty ? sorted.filter(r => r.coverage > 0) : sorted;
+  }, [data.safetyRows, sort, hideEmpty]);
+
+  const showEfficacy = mode === 'efficacy' || mode === 'all';
+  const showSafety = mode === 'safety' || mode === 'all';
+
+  const selectionSet = useMemo(
+    () => new Set(selections.map(s => `${s.treatmentName}::${s.metricKey}`)),
+    [selections],
+  );
+
+  return (
+    <div className="flex flex-col h-full w-full bg-white rounded-lg border border-slate-200 overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 gap-3 flex-shrink-0">
+        <h3 className="text-[15px] font-bold text-slate-900 tracking-tight truncate">{title}</h3>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <span className="text-[11px] text-slate-400 font-medium">Sort:</span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2.5 py-1 text-xs font-semibold text-slate-700 hover:border-slate-300 hover:bg-slate-50 transition-colors">
+                {SORT_LABELS[sort]}
+                <ChevronDown className="h-3 w-3 opacity-50" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+              {(Object.keys(SORT_LABELS) as CompareSortMode[]).map(key => (
+                <DropdownMenuItem
+                  key={key}
+                  className="text-sm cursor-pointer"
+                  onClick={() => onSortChange(key)}
+                >
+                  <div className="flex items-center justify-between w-full">
+                    <span>{SORT_LABELS[key]}</span>
+                    {sort === key && <Check className="h-3.5 w-3.5 text-[var(--brand-primary)]" />}
+                  </div>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <button
+            type="button"
+            onClick={() => onHideEmptyChange(!hideEmpty)}
+            className={cn(
+              'inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-semibold transition-colors',
+              hideEmpty
+                ? 'border-[var(--brand-primary)] bg-[var(--brand-accent-light)] text-[var(--brand-primary)]'
+                : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50',
+            )}
+          >
+            Hide empty: {hideEmpty ? 'On' : 'Off'}
+          </button>
+        </div>
+      </div>
+
+      {/* Sections */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {total === 0 ? (
+          <div className="flex items-center justify-center h-full py-16 text-sm text-slate-400 text-center px-6">
+            No treatments available.
+          </div>
+        ) : (
+          <div>
+            {showEfficacy && visibleEfficacy.length > 0 && (
+              <div>
+                <div className="flex items-center gap-2 px-4 py-2.5 bg-gradient-to-r from-emerald-50/80 to-transparent border-b border-slate-200 sticky top-0 z-30">
+                  <Activity className="h-3.5 w-3.5 text-emerald-600 flex-shrink-0" />
+                  <span className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-emerald-700">
+                    Efficacy Endpoints
+                  </span>
+                  <span className="text-[10px] text-slate-400">
+                    · {visibleEfficacy.length} metric{visibleEfficacy.length !== 1 ? 's' : ''}
+                  </span>
+                </div>
+                <CompareSectionTable
+                  rows={visibleEfficacy}
+                  treatments={treatments}
+                  selectionSet={selectionSet}
+                  onToggleSelection={onToggleSelection}
+                  activeMetricKeys={activeMetricKeys}
+                  treatmentMeta={data.treatmentMeta}
+                />
+              </div>
+            )}
+            {showSafety && visibleSafety.length > 0 && (
+              <div>
+                <div className="flex items-center gap-2 px-4 py-2.5 bg-gradient-to-r from-orange-50/80 to-transparent border-b border-slate-200 border-t border-slate-200 sticky top-0 z-30">
+                  <ShieldAlert className="h-3.5 w-3.5 text-orange-500 flex-shrink-0" />
+                  <span className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-orange-700">
+                    Safety
+                  </span>
+                  <span className="text-[10px] text-slate-400">
+                    · {visibleSafety.length} metric{visibleSafety.length !== 1 ? 's' : ''}
+                  </span>
+                </div>
+                <CompareSectionTable
+                  rows={visibleSafety}
+                  treatments={treatments}
+                  selectionSet={selectionSet}
+                  onToggleSelection={onToggleSelection}
+                  activeMetricKeys={activeMetricKeys}
+                  treatmentMeta={data.treatmentMeta}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <CompareTableLegend />
+    </div>
+  );
+}

--- a/web/src/components/compare/CompareTableLegend.tsx
+++ b/web/src/components/compare/CompareTableLegend.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as React from 'react';
+
+export function CompareTableLegend() {
+  return (
+    <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-slate-600 px-4 py-3 border-t border-slate-200">
+      <span className="flex items-center gap-1.5">
+        <span
+          aria-hidden
+          className="inline-block h-4 w-6 rounded-sm border border-slate-300"
+          style={{
+            backgroundImage:
+              'repeating-linear-gradient(45deg, #f1f5f9 0 4px, #ffffff 4px 8px)',
+          }}
+        />
+        <span>
+          <strong className="text-slate-700">NR</strong> — not reported
+        </span>
+      </span>
+      <span>
+        <strong className="text-slate-700">NE</strong> — not estimable / not reached
+      </span>
+      <span>
+        <strong className="text-slate-700">Cov</strong> — drugs with data / total
+      </span>
+    </div>
+  );
+}

--- a/web/src/components/dashboard/TrialCard.tsx
+++ b/web/src/components/dashboard/TrialCard.tsx
@@ -5,6 +5,7 @@ import type { DashboardTrialCard as DashboardTrialCardType } from '@/lib/api';
 import { User, Building2, FileText } from 'lucide-react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
+import { extractTrialAcronym } from '@/lib/utils/trial-utils';
 
 export interface TrialCardProps {
   trial: DashboardTrialCardType;
@@ -62,8 +63,11 @@ function phaseTagVariant(phase: string): string {
 
 export function TrialCard({ trial, className, category }: TrialCardProps) {
   const phaseShort = phaseToShort(trial.phase);
-  const rawName = (trial.trial_name || trial.title || '').trim();
-  const displayName = rawName && rawName.toLowerCase() !== 'unknown' ? rawName : trial.nct_id;
+  const trialAcronym = trial.trial_name?.trim();
+  const acronym = (trialAcronym && trialAcronym.toLowerCase() !== 'unknown')
+    ? trialAcronym
+    : extractTrialAcronym(trial.title);
+  const displayName = acronym ?? trial.nct_id;
   const href = category
     ? `/trial/nct/${trial.nct_id}?category=${category}`
     : `/trial/nct/${trial.nct_id}`;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -252,6 +252,69 @@ export const trialsApi = {
     const supabase = createClient();
     const dbCancerType = getDbCancerType(cancerType);
 
+    // Two-query path: fetch open + closed separately at DB level to guarantee ratio.
+    const OPEN_RAW = ['RECRUITING', 'NOT_YET_RECRUITING', 'ACTIVE_NOT_RECRUITING'];
+    const CLOSED_RAW = ['COMPLETED', 'TERMINATED', 'WITHDRAWN', 'SUSPENDED', 'ENROLLING_BY_INVITATION', 'UNKNOWN'];
+
+    if (filters.open_fraction !== undefined && filters.limit !== undefined) {
+      const wantOpen = Math.round(filters.limit * filters.open_fraction);
+      const wantClosed = filters.limit - wantOpen;
+      const biasSelect = '*, clinical_trials!inner(brief_title, phases, lead_sponsor_name, enrollment_count, overall_status, lead_sponsor_class)';
+
+      const [{ data: openData, error: openErr }, { data: closedData, error: closedErr }] = await Promise.all([
+        supabase.from('trial_landscape').select(biasSelect).contains('cancer_type', [dbCancerType]).in('clinical_trials.overall_status', OPEN_RAW).limit(wantOpen),
+        supabase.from('trial_landscape').select(biasSelect).contains('cancer_type', [dbCancerType]).in('clinical_trials.overall_status', CLOSED_RAW).limit(wantClosed),
+      ]);
+
+      if (openErr || closedErr) {
+        console.error('[getDashboardTrials] status-split error:', openErr || closedErr);
+        return { trials: [], total: 0 };
+      }
+
+      const merged = [...(openData || []), ...(closedData || [])];
+      const nctIds = merged.map((d: Record<string, unknown>) => d.nct_id).filter(Boolean);
+      const { data: outcomesData } = await supabase.from('trial_outcomes').select('nct_id').in('nct_id', nctIds);
+      const nctIdsWithOutcomes = new Set((outcomesData || []).map((o: { nct_id: string }) => o.nct_id));
+
+      let biasTrials: DashboardTrialCard[] = merged.map((d: Record<string, unknown>) => {
+        const ctEntry = Array.isArray(d.clinical_trials) ? (d.clinical_trials as Record<string, unknown>[])[0] : d.clinical_trials as Record<string, unknown>;
+        const rawPhases = Array.isArray(ctEntry?.phases) ? ctEntry.phases as string[] : [];
+        return {
+          nct_id: (d.nct_id as string) || '',
+          title: (ctEntry?.brief_title as string) || null,
+          drug_name: (d.treatment_name as string) || null,
+          sponsor_name: (ctEntry?.lead_sponsor_name as string) || null,
+          enrollment_count: (ctEntry?.enrollment_count as number) || null,
+          phase: rawPhases.map(normalizePhase).join(', ') || 'Unknown',
+          study_status: normalizeStatus((ctEntry?.overall_status as string) || 'UNKNOWN'),
+          sponsor_type: (ctEntry?.lead_sponsor_class as string) || 'Unknown',
+          approval_group: 'Investigational',
+          trial_name: (d.acronym as string) || null,
+          modality: (d.modality as string) || null,
+          treatment_name: (d.treatment_name as string) || null,
+          stage: (d.stage as string) || null,
+          biomarker: (d.biomarker as string) || null,
+          line_of_therapy: (d.line_of_therapy as string) || null,
+          previous_treatment_criteria: (d.previous_treatment_criteria as string) || null,
+          has_outcomes: nctIdsWithOutcomes.has(d.nct_id as string),
+        };
+      });
+
+      if (filters.sponsor_type && filters.sponsor_type.length > 0) {
+        const wantsIndustry = filters.sponsor_type.some(s => s.toLowerCase() === 'industry');
+        const wantsNonIndustry = filters.sponsor_type.some(s => s.toLowerCase() === 'non-industry');
+        biasTrials = biasTrials.filter(t => {
+          const isIndustry = (t.sponsor_type || '').toUpperCase() === 'INDUSTRY';
+          if (wantsIndustry && wantsNonIndustry) return true;
+          if (wantsIndustry) return isIndustry;
+          if (wantsNonIndustry) return !isIndustry;
+          return false;
+        });
+      }
+
+      return { trials: biasTrials, total: biasTrials.length };
+    }
+
     // Parallel: exact count (HEAD) + data rows — both share identical filters.
     let countQ = supabase.from('trial_landscape')
       .select('nct_id', { count: 'exact', head: true })
@@ -297,6 +360,7 @@ export const trialsApi = {
          study_status: normalizeStatus((ctEntry?.overall_status as string) || 'UNKNOWN'),
          sponsor_type: (ctEntry?.lead_sponsor_class as string) || 'Unknown',
          approval_group: 'Investigational',
+         trial_name: (d.acronym as string) || null,
          modality: (d.modality as string) || null,
          treatment_name: (d.treatment_name as string) || null,
          stage: (d.stage as string) || null,
@@ -775,6 +839,8 @@ export interface DashboardTrialsFilters {
   category_filter?: string;
   category_skip?: number;
   category_limit?: number;
+  /** When set with limit, fetches open/closed trials in separate DB queries to guarantee the ratio. */
+  open_fraction?: number;
 }
 
 export interface TherapeuticIndexResponse {
@@ -995,6 +1061,24 @@ export const analyticsApi = {
     };
   },
 
+  getTreatmentMeta: async (
+    cancerType: string,
+  ): Promise<Array<{ treatmentName: string; modality: string | null; lineOfTreatment: string | null }>> => {
+    const supabase = createClient();
+    const dbCancerType = getDbCancerType(cancerType);
+    const { data } = await supabase
+      .from('trial_landscape')
+      .select('treatment_name, modality, line_of_therapy')
+      .contains('cancer_type', [dbCancerType]);
+    return (data || [])
+      .filter((d: Record<string, unknown>) => d.treatment_name)
+      .map((d: Record<string, unknown>) => ({
+        treatmentName: d.treatment_name as string,
+        modality: (d.modality as string) || null,
+        lineOfTreatment: (d.line_of_therapy as string) || null,
+      }));
+  },
+
   getSnapshot: async (cancer_type: string, resource_type = 'all', bubbleLimit = 8, barLimit = 8): Promise<SnapshotResponse> => {
     void resource_type; // reserved for future filtering; keep signature stable
     // Reuse the same data + transformer pipeline as the analytics page so bubble
@@ -1020,7 +1104,6 @@ export const analyticsApi = {
       .slice(0, bubbleLimit)
       .map(p => ({
         treatmentName: p.treatmentName,
-        approvalStatus: (p.approvalStatus as 'Approved' | 'Investigational') || 'Investigational',
         efficacy: p.efficacy ?? 0,
         safety: p.safety ?? 0,
         numberOfPatients: p.numberOfPatients ?? null,
@@ -1034,7 +1117,6 @@ export const analyticsApi = {
       .slice(0, barLimit)
       .map(p => ({
         treatmentName: p.treatmentName,
-        approvalStatus: (p.approvalStatus as 'Approved' | 'Investigational') || 'Investigational',
         averageValue: p.efficacy ?? 0,
         trialCount: p.allTrials?.length ?? 1,
       }));
@@ -1048,7 +1130,6 @@ export const analyticsApi = {
 /** Pre-aggregated bubble data point (ORR + TRAE) returned by /api/analytics/snapshot */
 export interface SnapshotBubblePoint {
   treatmentName: string;
-  approvalStatus: 'Approved' | 'Investigational';
   efficacy: number;       // avg ORR
   safety: number;         // avg Grade 3+ TRAE
   numberOfPatients: number | null;
@@ -1058,7 +1139,6 @@ export interface SnapshotBubblePoint {
 /** Pre-aggregated bar data point (ORR) returned by /api/analytics/snapshot */
 export interface SnapshotBarPoint {
   treatmentName: string;
-  approvalStatus: 'Approved' | 'Investigational';
   averageValue: number;   // avg ORR
   trialCount: number;
 }

--- a/web/src/lib/chart-transformers.ts
+++ b/web/src/lib/chart-transformers.ts
@@ -9,37 +9,13 @@ import {
   HeadToHeadDataPoint,
   TrialDataPoint,
   ChartMetric,
-  ApprovalStatus,
+  SourceType,
   ArmResult,
   AttributeValue,
   EfficacySafetyDataPoint,
   BubbleChartDataPoint,
 } from '@/types/analytics';
 
-// ============================================================================
-// Approved Treatments Lookup (DEPRECATED - now handled by backend)
-// ============================================================================
-// NOTE: Approval status is now determined by the backend using indication-specific
-// classification. The backend adds an "approvalStatus" field to each arm.
-// This hardcoded list is kept only for backward compatibility with old data.
-// 
-// See: melanoma/src/app/approval_status_service.py
-
-const APPROVED_TREATMENTS = new Set([
-  'pembrolizumab',
-  'nivolumab',
-  'ipilimumab',
-  'dabrafenib',
-  'trametinib',
-  'vemurafenib',
-  'cobimetinib',
-  'encorafenib',
-  'binimetinib',
-  'atezolizumab',
-  'talimogene laherparepvec',
-  't-vec',
-  'lifileucel',
-]);
 
 // ============================================================================
 // Attribute Key Mapping (abstracts use AttributeType.X, publications use lowercase)
@@ -49,7 +25,7 @@ const APPROVED_TREATMENTS = new Set([
  * Get attribute value checking both uppercase (AttributeType.X) and lowercase (x) key formats
  * Publications use lowercase keys, abstracts use AttributeType.X format
  */
-function getAttribute(attributes: Record<string, AttributeInput>, metricName: string): AttributeInput {
+export function getAttribute(attributes: Record<string, AttributeInput>, metricName: string): AttributeInput {
   // Try AttributeType.X format first (used by abstracts)
   const uppercaseKey = `AttributeType.${metricName}`;
   if (attributes[uppercaseKey] !== undefined) {
@@ -93,7 +69,7 @@ function getAttribute(attributes: Record<string, AttributeInput>, metricName: st
 // Helper Functions
 // ============================================================================
 
-type AttributeInput = AttributeValue | string | number | boolean | null | undefined;
+export type AttributeInput = AttributeValue | string | number | boolean | null | undefined;
 
 /**
  * Deduplicate trials by treatment name, keeping the most recent year.
@@ -135,7 +111,7 @@ function deduplicateTrialsByTreatment<T extends { treatmentName: string; year?: 
 /**
  * Safely extract a numeric value from an attribute
  */
-function extractNumericValue(attr: AttributeInput): number | null {
+export function extractNumericValue(attr: AttributeInput): number | null {
   if (attr === null || attr === undefined) return null;
   
   // Boolean - not numeric
@@ -171,7 +147,7 @@ function extractNumericValue(attr: AttributeInput): number | null {
 /**
  * Safely extract a string value from an attribute
  */
-function extractStringValue(attr: AttributeInput): string {
+export function extractStringValue(attr: AttributeInput): string {
   if (attr === null || attr === undefined) return '';
   if (typeof attr === 'boolean') return attr ? 'true' : 'false';
   if (typeof attr === 'string') return attr;
@@ -190,7 +166,7 @@ function extractStringValue(attr: AttributeInput): string {
  * - Normalizes separators and whitespace
  * - Handles common variations
  */
-function normalizeTreatmentName(name: string): string {
+export function normalizeTreatmentName(name: string): string {
   if (!name) return 'Unknown';
   
   // Split by common combination separators
@@ -202,45 +178,6 @@ function normalizeTreatmentName(name: string): string {
   
   // Rejoin with consistent separator
   return parts.join(' + ');
-}
-
-/**
- * Determine approval status based on treatment name
- * DEPRECATED: Prefer using approval_status from backend when available
- * 
- * @param treatmentName - Name of the treatment
- * @param backendStatus - Approval status from backend (if available)
- * @returns Approval status
- */
-function getApprovalStatus(treatmentName: string, backendStatus?: string): ApprovalStatus {
-  // Prefer backend status if available (indication-specific, more accurate)
-  if (backendStatus) {
-    // Normalize backend status values
-    const normalized = backendStatus.toLowerCase();
-    if (normalized === 'approved') return 'Approved';
-    if (normalized === 'investigational' || normalized === 'control') return 'Investigational';
-  }
-  
-  // Fallback to old logic for backward compatibility
-  const normalized = treatmentName.toLowerCase();
-  
-  // Check if any approved treatment is in the name
-  for (const approved of APPROVED_TREATMENTS) {
-    if (normalized.includes(approved)) {
-      return 'Approved';
-    }
-  }
-  
-  // Check for combination therapies with approved drugs
-  if (normalized.includes('+')) {
-    const parts = normalized.split('+').map(p => p.trim());
-    const hasApproved = parts.some(part => 
-      Array.from(APPROVED_TREATMENTS).some(approved => part.includes(approved))
-    );
-    if (hasApproved) return 'Approved';
-  }
-  
-  return 'Investigational';
 }
 
 /**
@@ -357,10 +294,11 @@ export function transformHeadToHeadData(
       // Get abstract ID or publication ID directly from trial object
       // This matches the logic in TrialDataTable.tsx
       const abstractId = trial.abstract_id || trial.publication_id || '';
-      
+      const sourceType: SourceType = trial.abstract_id ? 'abstract' : trial.publication_id ? 'publication' : 'webscrape';
+
       // Get publication name from attributes (for publications)
       const publicationNameAttr = extractStringValue(getAttribute(arm.attributes, 'PUBLICATION_NAME'));
-      
+
       // Extract patient count
       const patientCount = extractNumericValue(getAttribute(arm.attributes, 'NUMBER_OF_PATIENTS'));
 
@@ -375,11 +313,7 @@ export function transformHeadToHeadData(
       if (patientCount !== null) {
         group.patients.push(patientCount);
       }
-      
-      // Get approval status from arm data if available (backend)
-      // Backend returns "Approved", "Investigational", "Control", or "Unknown"
-      const armApprovalStatus = arm.approval_status as ApprovalStatus | undefined;
-      
+
       group.trials.push({
         studyId,
         abstractId,
@@ -392,7 +326,7 @@ export function transformHeadToHeadData(
         nctNumber,
         numberOfPatients: patientCount,
         sourceUrl: trial.source_url || '',
-        approvalStatus: armApprovalStatus, // Backend approval status if available
+        sourceType,
       });
     }
   }
@@ -439,12 +373,8 @@ export function transformHeadToHeadData(
     const sum = values.reduce((a, b) => a + b, 0);
     const totalPatients = group.patients.reduce((a, b) => a + b, 0);
 
-    // Get approval status from first trial (backend) or fall back to name-based logic
-    const backendApprovalStatus = group.trials[0]?.approvalStatus;
-    
     result.push({
       treatmentName,
-      approvalStatus: getApprovalStatus(treatmentName, backendApprovalStatus),
       averageValue: sum / values.length,
       medianValue: calculateMedian(values),
       minValue: Math.min(...values),
@@ -595,7 +525,8 @@ export function transformEfficacySafetyData(
     publicationName?: string;
     citation?: string;
     phase?: string;
-    approvalStatus?: string;
+    sourceType?: SourceType;
+    sourceUrl?: string;
   }> = [];
 
   const grouped = new Map<string, {
@@ -642,14 +573,12 @@ export function transformEfficacySafetyData(
 
       // Store individual trial data
       const abstractId = trial.abstract_id || trial.publication_id || '';
+      const sourceType: SourceType = trial.abstract_id ? 'abstract' : trial.publication_id ? 'publication' : 'webscrape';
       const nctNumber = extractStringValue(getAttribute(arm.attributes, 'NCT_NUMBER'));
       const publicationName = extractStringValue(getAttribute(arm.attributes, 'PUBLICATION_NAME'));
       const conference = extractStringValue(getAttribute(arm.attributes, 'CONFERENCE'));
       const patientCount = extractNumericValue(getAttribute(arm.attributes, 'NUMBER_OF_PATIENTS'));
 
-      // Get approval status from arm data if available (backend)
-      const armApprovalStatus = arm.approval_status;
-      
       individualTrials.push({
         treatmentName,
         efficacy: efficacyValue,
@@ -661,7 +590,8 @@ export function transformEfficacySafetyData(
         publicationName: publicationName || undefined,
         citation: `${conference} ${yearStr}`,
         phase: phase || undefined,
-        approvalStatus: armApprovalStatus, // Backend approval status if available
+        sourceType,
+        sourceUrl: trial.source_url || undefined,
       });
 
       if (!grouped.has(treatmentName)) {
@@ -731,12 +661,8 @@ export function transformEfficacySafetyData(
       return a.safety - b.safety;
     });
 
-    // Get approval status from first trial (backend) or fall back to name-based logic
-    const backendApprovalStatus = allTrials[0]?.approvalStatus;
-    
     result.push({
       treatmentName,
-      approvalStatus: getApprovalStatus(treatmentName, backendApprovalStatus),
       efficacy: avgEfficacy,
       safety: avgSafety,
       numberOfPatients: totalPatients > 0 ? totalPatients : undefined,
@@ -815,20 +741,15 @@ export function transformBubbleChartData(
       const patientCount = extractNumericValue(getAttribute(arm.attributes, 'NUMBER_OF_PATIENTS')) || 0;
       const nctNumber = extractStringValue(getAttribute(arm.attributes, 'NCT_NUMBER'));
       const abstractId = trial.abstract_id || trial.publication_id || '';
+      const sourceType: SourceType = trial.abstract_id ? 'abstract' : trial.publication_id ? 'publication' : 'webscrape';
       const publicationName = extractStringValue(getAttribute(arm.attributes, 'PUBLICATION_NAME'));
       const conference = extractStringValue(getAttribute(arm.attributes, 'CONFERENCE'));
       const zValue = zMetric && zMetric !== 'NUMBER_OF_PATIENTS'
         ? (extractNumericValue(getAttribute(arm.attributes, zMetric)) ?? undefined)
         : undefined;
 
-      // Get approval status from backend if available
-      const armApprovalStatus = arm.approval_status;
-      const finalApprovalStatus = getApprovalStatus(treatmentName, armApprovalStatus);
-
       result.push({
         treatmentName,
-        approvalStatus: finalApprovalStatus,
-        developmentStatus: finalApprovalStatus === 'Approved' ? 'Approved' : 'Investigational',
         efficacy: efficacyValue,
         safety: safetyValue,
         numberOfPatients: patientCount,
@@ -840,6 +761,7 @@ export function transformBubbleChartData(
         phase: phase || undefined,
         year: yearStr || undefined,
         sourceUrl: trial.source_url || undefined,
+        sourceType,
       });
     }
   }
@@ -878,6 +800,8 @@ export function transformBubbleChartData(
       publicationName: trial.publicationName,
       citation: trial.citation,
       phase: trial.phase,
+      sourceType: trial.sourceType,
+      sourceUrl: trial.sourceUrl,
     }));
     point.currentTrialIndex = 0; // Most recent trial
   }

--- a/web/src/lib/compare-transformers.ts
+++ b/web/src/lib/compare-transformers.ts
@@ -1,0 +1,216 @@
+/**
+ * Compare Treatments Table Transformer
+ * Builds a metric-by-treatment matrix (up to 5 columns) from raw trial data.
+ */
+
+import {
+  ClinicalTrialRaw,
+  EFFICACY_METRICS,
+  SAFETY_METRICS,
+  MetricConfig,
+} from '@/types/analytics';
+import {
+  CompareCell,
+  CompareGroup,
+  CompareMode,
+  CompareRow,
+  CompareTableData,
+  TreatmentMeta,
+} from '@/types/compare';
+import {
+  AttributeInput,
+  extractNumericValue,
+  extractStringValue,
+  getAttribute,
+  normalizeTreatmentName,
+} from './chart-transformers';
+
+const NR_STRINGS = new Set(['nr', 'not reported', 'n/r', 'not available', 'na', 'n/a']);
+const NE_STRINGS = new Set(['ne', 'not estimable', 'not evaluable', 'not reached', 'nr*']);
+
+function classifySentinel(attr: AttributeInput): 'NR' | 'NE' | null {
+  const raw = extractStringValue(attr).trim().toLowerCase();
+  if (!raw) return null;
+  if (NE_STRINGS.has(raw)) return 'NE';
+  if (NR_STRINGS.has(raw)) return 'NR';
+  return null;
+}
+
+function formatValue(value: number, unit: string, integer?: boolean): string {
+  if (integer) return Math.round(value).toString();
+  const rounded = Math.abs(value) >= 100 ? value.toFixed(0) : value.toFixed(1);
+  if (unit === '%') return rounded;
+  return rounded;
+}
+
+interface ArmRecord {
+  value: number | null;
+  status: 'value' | 'NR' | 'NE';
+  year: number;
+  assessmentMethod?: string;
+}
+
+function pickBest(
+  records: ArmRecord[],
+  lowerIsBetter: boolean,
+): ArmRecord | null {
+  const withValues = records.filter(r => r.status === 'value' && r.value !== null);
+  if (withValues.length > 0) {
+    withValues.sort((a, b) => {
+      if (b.year !== a.year) return b.year - a.year;
+      const av = a.value as number;
+      const bv = b.value as number;
+      return lowerIsBetter ? av - bv : bv - av;
+    });
+    return withValues[0];
+  }
+  const ne = records.find(r => r.status === 'NE');
+  if (ne) return ne;
+  const nr = records.find(r => r.status === 'NR');
+  if (nr) return nr;
+  return null;
+}
+
+function buildRow(
+  metric: MetricConfig,
+  group: CompareGroup,
+  treatments: string[],
+  recordsByTreatment: Map<string, ArmRecord[]>,
+): CompareRow {
+  const cells: Record<string, CompareCell> = {};
+  let coverage = 0;
+
+  for (const treatment of treatments) {
+    const records = recordsByTreatment.get(treatment) ?? [];
+    const best = pickBest(records, metric.lowerIsBetter ?? false);
+
+    let status: CompareCell['status'] = 'NR';
+    let value: number | null = null;
+    let displayValue = 'NR';
+    let assessmentMethod: string | undefined;
+
+    if (best) {
+      status = best.status;
+      assessmentMethod = best.assessmentMethod;
+      if (best.status === 'value' && best.value !== null) {
+        value = best.value;
+        displayValue = formatValue(best.value, metric.unit, metric.integer);
+        coverage += 1;
+      } else if (best.status === 'NE') {
+        displayValue = 'NE';
+      }
+    }
+
+    cells[treatment] = {
+      treatmentName: treatment,
+      metricKey: metric.key,
+      value,
+      displayValue,
+      status,
+      assessmentMethod,
+      unit: metric.unit,
+    };
+  }
+
+  return {
+    metricKey: metric.key,
+    label: metric.label,
+    description: metric.description,
+    unit: metric.unit,
+    group,
+    subGroup: metric.subGroup,
+    cells,
+    coverage,
+  };
+}
+
+function collectArmRecords(
+  trials: ClinicalTrialRaw[],
+  treatments: string[],
+  metricKey: string,
+): Map<string, ArmRecord[]> {
+  const normalizedTargets = new Map(treatments.map(t => [normalizeTreatmentName(t), t]));
+  const recordsByTreatment = new Map<string, ArmRecord[]>();
+  for (const t of treatments) recordsByTreatment.set(t, []);
+
+  for (const trial of trials) {
+    for (const arm of Object.values(trial.arm_results)) {
+      const normalized = normalizeTreatmentName(arm.arm_name);
+      const original = normalizedTargets.get(normalized) ?? (treatments.includes(arm.arm_name) ? arm.arm_name : null);
+      if (!original) continue;
+
+      const attr = getAttribute(arm.attributes, metricKey);
+      const yearStr =
+        extractStringValue(getAttribute(arm.attributes, 'PUBLISHED_YEAR')) ||
+        extractStringValue(getAttribute(arm.attributes, 'PUBLICATION_YEAR'));
+      const year = parseInt(yearStr, 10) || 0;
+      const assessmentMethod =
+        extractStringValue(getAttribute(arm.attributes, 'ASSESSMENT_METHOD')) ||
+        extractStringValue(getAttribute(arm.attributes, 'RESPONSE_ASSESSMENT_METHOD')) ||
+        undefined;
+
+      const numeric = extractNumericValue(attr);
+      if (numeric !== null) {
+        recordsByTreatment.get(original)!.push({
+          value: numeric,
+          status: 'value',
+          year,
+          assessmentMethod: assessmentMethod || undefined,
+        });
+        continue;
+      }
+
+      const sentinel = classifySentinel(attr);
+      if (sentinel) {
+        recordsByTreatment.get(original)!.push({
+          value: null,
+          status: sentinel,
+          year,
+        });
+      }
+    }
+  }
+
+  return recordsByTreatment;
+}
+
+export function buildCompareTable(
+  trials: ClinicalTrialRaw[],
+  selectedTreatments: string[],
+  mode: CompareMode,
+  rawMeta?: Array<{ treatmentName: string; modality: string | null; lineOfTreatment: string | null }>,
+): CompareTableData {
+  const treatments = selectedTreatments;
+
+  const efficacyRows: CompareRow[] = [];
+  const safetyRows: CompareRow[] = [];
+
+  const treatmentMeta: Record<string, TreatmentMeta> = {};
+  if (rawMeta) {
+    const metaByNorm = new Map(rawMeta.map(m => [normalizeTreatmentName(m.treatmentName), m]));
+    for (const t of treatments) {
+      const found = metaByNorm.get(normalizeTreatmentName(t));
+      treatmentMeta[t] = { modality: found?.modality ?? null, lineOfTreatment: found?.lineOfTreatment ?? null };
+    }
+  }
+
+  if (treatments.length === 0) {
+    return { treatments, efficacyRows, safetyRows, treatmentMeta };
+  }
+
+  if (mode === 'efficacy' || mode === 'all') {
+    for (const metric of Object.values(EFFICACY_METRICS)) {
+      const recs = collectArmRecords(trials, treatments, metric.key);
+      efficacyRows.push(buildRow(metric, 'efficacy', treatments, recs));
+    }
+  }
+
+  if (mode === 'safety' || mode === 'all') {
+    for (const metric of Object.values(SAFETY_METRICS)) {
+      const recs = collectArmRecords(trials, treatments, metric.key);
+      safetyRows.push(buildRow(metric, 'safety', treatments, recs));
+    }
+  }
+
+  return { treatments, efficacyRows, safetyRows, treatmentMeta };
+}

--- a/web/src/lib/utils/trial-utils.ts
+++ b/web/src/lib/utils/trial-utils.ts
@@ -1,4 +1,63 @@
-import { Document } from '@/lib/api';
+import { Document, type DashboardTrialCard } from '@/lib/api';
+
+const OPEN_STUDY_STATUSES = new Set([
+  'open',
+  'not yet recruiting',
+  'recruiting',
+  'active, not recruiting',
+]);
+
+export function isOpenStudyStatus(status: string | null | undefined): boolean {
+  return OPEN_STUDY_STATUSES.has((status ?? '').trim().toLowerCase());
+}
+
+export function selectTrialsWithOpenBias(
+  trials: DashboardTrialCard[],
+  count: number,
+  openFraction = 0.7
+): DashboardTrialCard[] {
+  const open = trials.filter((t) => isOpenStudyStatus(t.study_status));
+  const closed = trials.filter((t) => !isOpenStudyStatus(t.study_status));
+  const wantOpen = Math.min(Math.round(count * openFraction), open.length);
+  const wantClosed = Math.min(count - wantOpen, closed.length);
+  const actualOpen = Math.min(open.length, count - wantClosed);
+  return [...open.slice(0, actualOpen), ...closed.slice(0, wantClosed)];
+}
+
+const CANCER_ABBREVS = new Set([
+  'NSCLC', 'SCLC', 'BC', 'MBC', 'ABC', 'CRC', 'MCRC', 'HCC', 'RCC', 'MRCC',
+  'AML', 'CLL', 'CML', 'NHL', 'MM', 'MDS', 'DLBCL', 'FL', 'MCL', 'GBM',
+  'TNBC', 'ER+', 'HR+', 'HER2+', 'HER2-', 'PD-L1', 'EGFR', 'ALK', 'KRAS',
+  'BRAF', 'MEK', 'IO', 'TKI', 'VEGF', 'CTDNA', 'TMB', 'MSI', 'DMMR',
+  'PMMR', 'MSS', 'MSI-H', 'TMB-H', 'ER', 'PR', 'OS', 'PFS', 'ORR', 'DOR',
+  'DCR', 'CBR', 'TTP', 'EFS', 'RFS', 'DFS', 'TTR', 'CR', 'SD', 'PD', 'NE',
+  'BCC', 'SCC', 'NPC', 'BTC', 'OC', 'EC', 'GC', 'GEJ', 'ESCC', 'PDAC',
+  'NET', 'NEC', 'MCC', 'GIST', 'PNET', 'LGG', 'HGG', 'IDH',
+  'ASCO', 'ESMO', 'AACR', 'WHO', 'ECOG', 'R/R', 'R/M', 'UC', 'UBC',
+]);
+
+/**
+ * Extract a trial acronym/name from the end of a brief title.
+ * Titles often append the trial name in parentheses or brackets, e.g.:
+ *   "A Phase 3 Study of Pembrolizumab in TNBC (KEYNOTE-522)"
+ * Returns null if no bracket is found or the candidate looks like a cancer/biomarker abbreviation.
+ */
+export function extractTrialAcronym(title: string | null): string | null {
+  if (!title) return null;
+  const match = title.match(/[\[(]\s*([^\])]+?)\s*[\])]\s*$/);
+  if (!match) return null;
+  const candidate = match[1].trim();
+  if (CANCER_ABBREVS.has(candidate.toUpperCase())) return null;
+  if (candidate.length <= 2) return null;
+  // Digit or hyphen → almost certainly a trial code (KEYNOTE-522, IMpower110)
+  if (/[\d-]/.test(candidate)) return candidate;
+  // Mixed-case word → proper noun trial name (CheckMate, Destiny)
+  if (candidate.length > 3 && candidate !== candidate.toUpperCase() && candidate !== candidate.toLowerCase()) return candidate;
+  // All-caps longer than 5 chars → likely trial acronym (FLAURA, MONARCH)
+  if (candidate === candidate.toUpperCase() && candidate.length > 5) return candidate;
+  // Short all-caps (3–5): denylist already filtered risky ones; accept the rest
+  return candidate;
+}
 
 export interface ExtractedTrialMetadata {
   nctId: string;

--- a/web/src/types/analytics.ts
+++ b/web/src/types/analytics.ts
@@ -67,7 +67,7 @@ export interface TrialDataFile {
 // Transformed Data Types (for chart components)
 // ============================================================================
 
-export type ApprovalStatus = 'Approved' | 'Investigational' | 'Unknown';
+export type SourceType = 'abstract' | 'publication' | 'webscrape';
 
 export interface TrialDataPoint {
   studyId: string;
@@ -80,13 +80,12 @@ export interface TrialDataPoint {
   year: string;
   nctNumber: string;
   numberOfPatients: number | null;
-  sourceUrl?: string; // For web-scraped trials
-  approvalStatus?: ApprovalStatus; // Added by backend or derived from arm approval_status
+  sourceUrl?: string;
+  sourceType?: SourceType;
 }
 
 export interface HeadToHeadDataPoint {
   treatmentName: string;
-  approvalStatus: ApprovalStatus;
   averageValue: number;
   medianValue: number;
   minValue: number;
@@ -111,180 +110,188 @@ export interface MetricConfig {
   unit: string;
   description: string;
   lowerIsBetter?: boolean;
+  subGroup?: string;
+  integer?: boolean;
 }
 
 // Efficacy metrics configuration - keys match backend AttributeType names
 export const EFFICACY_METRICS: Record<string, MetricConfig> = {
+  // Study metadata
+  NUMBER_OF_PATIENTS: { key: 'NUMBER_OF_PATIENTS', label: 'N', unit: '', description: 'Number of patients enrolled', subGroup: 'Study', integer: true },
+
   // Survival Metrics - PFS
-  MEDIAN_PFS: { key: 'MEDIAN_PFS', label: 'mPFS', unit: 'months', description: 'Median Progression-Free Survival' },
-  MEDIAN_FOLLOWUP_PFS: { key: 'MEDIAN_FOLLOWUP_PFS', label: 'PFS FU', unit: 'months', description: 'Median follow-up for measuring PFS' },
-  P_VALUE_PFS: { key: 'P_VALUE_PFS', label: 'p (PFS)', unit: '', description: 'p-value of median PFS', lowerIsBetter: true },
-  HR_PFS: { key: 'HR_PFS', label: 'HR (PFS)', unit: '', description: 'Hazard Ratio for PFS', lowerIsBetter: true },
-  
+  MEDIAN_PFS: { key: 'MEDIAN_PFS', label: 'mPFS', unit: 'months', description: 'Median Progression-Free Survival', subGroup: 'PFS' },
+  MEDIAN_FOLLOWUP_PFS: { key: 'MEDIAN_FOLLOWUP_PFS', label: 'PFS FU', unit: 'months', description: 'Median follow-up for measuring PFS', subGroup: 'PFS' },
+  P_VALUE_PFS: { key: 'P_VALUE_PFS', label: 'p (PFS)', unit: '', description: 'p-value of median PFS', lowerIsBetter: true, subGroup: 'PFS' },
+  HR_PFS: { key: 'HR_PFS', label: 'HR (PFS)', unit: '', description: 'Hazard Ratio for PFS', lowerIsBetter: true, subGroup: 'PFS' },
+
   // Survival Metrics - OS
-  MEDIAN_OS: { key: 'MEDIAN_OS', label: 'mOS', unit: 'months', description: 'Median Overall Survival' },
-  MEDIAN_FOLLOWUP_OS: { key: 'MEDIAN_FOLLOWUP_OS', label: 'OS FU', unit: 'months', description: 'Median follow-up for measuring OS' },
-  P_VALUE_OS: { key: 'P_VALUE_OS', label: 'p (OS)', unit: '', description: 'p-value of OS', lowerIsBetter: true },
-  HR_OS: { key: 'HR_OS', label: 'HR (OS)', unit: '', description: 'Hazard Ratio for OS', lowerIsBetter: true },
-  
+  MEDIAN_OS: { key: 'MEDIAN_OS', label: 'mOS', unit: 'months', description: 'Median Overall Survival', subGroup: 'OS' },
+  MEDIAN_FOLLOWUP_OS: { key: 'MEDIAN_FOLLOWUP_OS', label: 'OS FU', unit: 'months', description: 'Median follow-up for measuring OS', subGroup: 'OS' },
+  P_VALUE_OS: { key: 'P_VALUE_OS', label: 'p (OS)', unit: '', description: 'p-value of OS', lowerIsBetter: true, subGroup: 'OS' },
+  HR_OS: { key: 'HR_OS', label: 'HR (OS)', unit: '', description: 'Hazard Ratio for OS', lowerIsBetter: true, subGroup: 'OS' },
+
   // Response Metrics
-  OBJECTIVE_RESPONSE_RATE: { key: 'OBJECTIVE_RESPONSE_RATE', label: 'ORR', unit: '%', description: 'Objective Response Rate' },
-  COMPLETE_RESPONSE: { key: 'COMPLETE_RESPONSE', label: 'CR', unit: '%', description: 'Complete Response' },
-  PATHOLOGICAL_COMPLETE_RESPONSE: { key: 'PATHOLOGICAL_COMPLETE_RESPONSE', label: 'pCR', unit: '%', description: 'Pathological Complete Response' },
-  COMPLETE_METABOLIC_RESPONSE: { key: 'COMPLETE_METABOLIC_RESPONSE', label: 'CMR', unit: '%', description: 'Complete Metabolic Response' },
-  DISEASE_CONTROL_RATE: { key: 'DISEASE_CONTROL_RATE', label: 'DCR', unit: '%', description: 'Disease Control Rate' },
-  CLINICAL_BENEFIT_RATE: { key: 'CLINICAL_BENEFIT_RATE', label: 'CBR', unit: '%', description: 'Clinical Benefit Rate' },
-  MEDIAN_DOR: { key: 'MEDIAN_DOR', label: 'mDOR', unit: 'months', description: 'Median Duration of Response' },
-  DOR_RATE: { key: 'DOR_RATE', label: 'DOR', unit: '%', description: 'Duration of Response Rate' },
-  
+  OBJECTIVE_RESPONSE_RATE: { key: 'OBJECTIVE_RESPONSE_RATE', label: 'ORR', unit: '%', description: 'Objective Response Rate', subGroup: 'Response' },
+  COMPLETE_RESPONSE: { key: 'COMPLETE_RESPONSE', label: 'CR', unit: '%', description: 'Complete Response', subGroup: 'Response' },
+  PATHOLOGICAL_COMPLETE_RESPONSE: { key: 'PATHOLOGICAL_COMPLETE_RESPONSE', label: 'pCR', unit: '%', description: 'Pathological Complete Response', subGroup: 'Response' },
+  COMPLETE_METABOLIC_RESPONSE: { key: 'COMPLETE_METABOLIC_RESPONSE', label: 'CMR', unit: '%', description: 'Complete Metabolic Response', subGroup: 'Response' },
+  DISEASE_CONTROL_RATE: { key: 'DISEASE_CONTROL_RATE', label: 'DCR', unit: '%', description: 'Disease Control Rate', subGroup: 'Response' },
+  CLINICAL_BENEFIT_RATE: { key: 'CLINICAL_BENEFIT_RATE', label: 'CBR', unit: '%', description: 'Clinical Benefit Rate', subGroup: 'Response' },
+  MEDIAN_DOR: { key: 'MEDIAN_DOR', label: 'mDOR', unit: 'months', description: 'Median Duration of Response', subGroup: 'Response' },
+  DOR_RATE: { key: 'DOR_RATE', label: 'DOR', unit: '%', description: 'Duration of Response Rate', subGroup: 'Response' },
+
   // PFS Rate at various timepoints
-  PFS_RATE_6M: { key: 'PFS_RATE_6M', label: 'PFS 6M', unit: '%', description: 'PFS rate at 6 months' },
-  PFS_RATE_9M: { key: 'PFS_RATE_9M', label: 'PFS 9M', unit: '%', description: 'PFS rate at 9 months' },
-  PFS_RATE_12M: { key: 'PFS_RATE_12M', label: 'PFS 12M', unit: '%', description: 'PFS rate at 12 months' },
-  PFS_RATE_18M: { key: 'PFS_RATE_18M', label: 'PFS 18M', unit: '%', description: 'PFS rate at 18 months' },
-  PFS_RATE_24M: { key: 'PFS_RATE_24M', label: 'PFS 24M', unit: '%', description: 'PFS rate at 24 months' },
-  PFS_RATE_36M: { key: 'PFS_RATE_36M', label: 'PFS 36M', unit: '%', description: 'PFS rate at 36 months' },
-  PFS_RATE_48M: { key: 'PFS_RATE_48M', label: 'PFS 48M', unit: '%', description: 'PFS rate at 48 months' },
-  
+  PFS_RATE_6M: { key: 'PFS_RATE_6M', label: 'PFS 6M', unit: '%', description: 'PFS rate at 6 months', subGroup: 'PFS' },
+  PFS_RATE_9M: { key: 'PFS_RATE_9M', label: 'PFS 9M', unit: '%', description: 'PFS rate at 9 months', subGroup: 'PFS' },
+  PFS_RATE_12M: { key: 'PFS_RATE_12M', label: 'PFS 12M', unit: '%', description: 'PFS rate at 12 months', subGroup: 'PFS' },
+  PFS_RATE_18M: { key: 'PFS_RATE_18M', label: 'PFS 18M', unit: '%', description: 'PFS rate at 18 months', subGroup: 'PFS' },
+  PFS_RATE_24M: { key: 'PFS_RATE_24M', label: 'PFS 24M', unit: '%', description: 'PFS rate at 24 months', subGroup: 'PFS' },
+  PFS_RATE_36M: { key: 'PFS_RATE_36M', label: 'PFS 36M', unit: '%', description: 'PFS rate at 36 months', subGroup: 'PFS' },
+  PFS_RATE_48M: { key: 'PFS_RATE_48M', label: 'PFS 48M', unit: '%', description: 'PFS rate at 48 months', subGroup: 'PFS' },
+
   // OS Rate at various timepoints
-  OS_RATE_6M: { key: 'OS_RATE_6M', label: 'OS 6M', unit: '%', description: 'OS rate at 6 months' },
-  OS_RATE_9M: { key: 'OS_RATE_9M', label: 'OS 9M', unit: '%', description: 'OS rate at 9 months' },
-  OS_RATE_12M: { key: 'OS_RATE_12M', label: 'OS 12M', unit: '%', description: 'OS rate at 12 months' },
-  OS_RATE_18M: { key: 'OS_RATE_18M', label: 'OS 18M', unit: '%', description: 'OS rate at 18 months' },
-  OS_RATE_24M: { key: 'OS_RATE_24M', label: 'OS 24M', unit: '%', description: 'OS rate at 24 months' },
-  OS_RATE_36M: { key: 'OS_RATE_36M', label: 'OS 36M', unit: '%', description: 'OS rate at 36 months' },
-  OS_RATE_48M: { key: 'OS_RATE_48M', label: 'OS 48M', unit: '%', description: 'OS rate at 48 months' },
-  
+  OS_RATE_6M: { key: 'OS_RATE_6M', label: 'OS 6M', unit: '%', description: 'OS rate at 6 months', subGroup: 'OS' },
+  OS_RATE_9M: { key: 'OS_RATE_9M', label: 'OS 9M', unit: '%', description: 'OS rate at 9 months', subGroup: 'OS' },
+  OS_RATE_12M: { key: 'OS_RATE_12M', label: 'OS 12M', unit: '%', description: 'OS rate at 12 months', subGroup: 'OS' },
+  OS_RATE_18M: { key: 'OS_RATE_18M', label: 'OS 18M', unit: '%', description: 'OS rate at 18 months', subGroup: 'OS' },
+  OS_RATE_24M: { key: 'OS_RATE_24M', label: 'OS 24M', unit: '%', description: 'OS rate at 24 months', subGroup: 'OS' },
+  OS_RATE_36M: { key: 'OS_RATE_36M', label: 'OS 36M', unit: '%', description: 'OS rate at 36 months', subGroup: 'OS' },
+  OS_RATE_48M: { key: 'OS_RATE_48M', label: 'OS 48M', unit: '%', description: 'OS rate at 48 months', subGroup: 'OS' },
+
   // Other Survival Metrics
-  EFS: { key: 'EFS', label: 'EFS', unit: 'months', description: 'Event-Free Survival' },
-  P_VALUE_EFS: { key: 'P_VALUE_EFS', label: 'p (EFS)', unit: '', description: 'p-value of EFS', lowerIsBetter: true },
-  HR_EFS: { key: 'HR_EFS', label: 'HR (EFS)', unit: '', description: 'Hazard Ratio for EFS', lowerIsBetter: true },
-  RFS: { key: 'RFS', label: 'RFS', unit: 'months', description: 'Recurrence-Free Survival' },
-  P_VALUE_RFS: { key: 'P_VALUE_RFS', label: 'p (RFS)', unit: '', description: 'p-value of RFS', lowerIsBetter: true },
-  LENGTH_RFS: { key: 'LENGTH_RFS', label: 'RFS FU', unit: 'months', description: 'Length of measuring RFS' },
-  HR_RFS: { key: 'HR_RFS', label: 'HR (RFS)', unit: '', description: 'Hazard Ratio for RFS', lowerIsBetter: true },
-  MFS: { key: 'MFS', label: 'MFS', unit: 'months', description: 'Metastasis-Free Survival' },
-  LENGTH_MFS: { key: 'LENGTH_MFS', label: 'MFS FU', unit: 'months', description: 'Length of measuring MFS' },
-  HR_MFS: { key: 'HR_MFS', label: 'HR (MFS)', unit: '', description: 'Hazard Ratio for MFS', lowerIsBetter: true },
-  
+  EFS: { key: 'EFS', label: 'EFS', unit: 'months', description: 'Event-Free Survival', subGroup: 'EFS' },
+  HR_EFS: { key: 'HR_EFS', label: 'HR (EFS)', unit: '', description: 'Hazard Ratio for EFS', lowerIsBetter: true, subGroup: 'EFS' },
+  P_VALUE_EFS: { key: 'P_VALUE_EFS', label: 'p (EFS)', unit: '', description: 'p-value of EFS', lowerIsBetter: true, subGroup: 'EFS' },
+  RFS: { key: 'RFS', label: 'RFS', unit: 'months', description: 'Recurrence-Free Survival', subGroup: 'RFS' },
+  HR_RFS: { key: 'HR_RFS', label: 'HR (RFS)', unit: '', description: 'Hazard Ratio for RFS', lowerIsBetter: true, subGroup: 'RFS' },
+  P_VALUE_RFS: { key: 'P_VALUE_RFS', label: 'p (RFS)', unit: '', description: 'p-value of RFS', lowerIsBetter: true, subGroup: 'RFS' },
+  LENGTH_RFS: { key: 'LENGTH_RFS', label: 'RFS FU', unit: 'months', description: 'Length of measuring RFS', subGroup: 'RFS' },
+  MFS: { key: 'MFS', label: 'MFS', unit: 'months', description: 'Metastasis-Free Survival', subGroup: 'MFS' },
+  HR_MFS: { key: 'HR_MFS', label: 'HR (MFS)', unit: '', description: 'Hazard Ratio for MFS', lowerIsBetter: true, subGroup: 'MFS' },
+  LENGTH_MFS: { key: 'LENGTH_MFS', label: 'MFS FU', unit: 'months', description: 'Length of measuring MFS', subGroup: 'MFS' },
+
   // Time Metrics
-  TTR: { key: 'TTR', label: 'TTR', unit: 'months', description: 'Time to Response' },
-  TTP: { key: 'TTP', label: 'TTP', unit: 'months', description: 'Time to Progression' },
-  TTNT: { key: 'TTNT', label: 'TTNT', unit: 'months', description: 'Time to Next Treatment' },
-  TTF: { key: 'TTF', label: 'TTF', unit: 'months', description: 'Time to Treatment Failure' },
+  TTR: { key: 'TTR', label: 'TTR', unit: 'months', description: 'Time to Response', subGroup: 'Time-to' },
+  TTP: { key: 'TTP', label: 'TTP', unit: 'months', description: 'Time to Progression', subGroup: 'Time-to' },
+  TTNT: { key: 'TTNT', label: 'TTNT', unit: 'months', description: 'Time to Next Treatment', subGroup: 'Time-to' },
+  TTF: { key: 'TTF', label: 'TTF', unit: 'months', description: 'Time to Treatment Failure', subGroup: 'Time-to' },
 };
 
 // Safety metrics configuration - keys match backend AttributeType names
 export const SAFETY_METRICS: Record<string, MetricConfig> = {
+  // Study metadata
+  NUMBER_OF_PATIENTS: { key: 'NUMBER_OF_PATIENTS', label: 'N', unit: '', description: 'Number of patients enrolled', subGroup: 'Study', integer: true },
+
   // General AE
-  AE: { key: 'AE', label: 'AE', unit: '%', description: 'Adverse Events', lowerIsBetter: true },
-  GRADE_3_PLUS_AE: { key: 'GRADE_3_PLUS_AE', label: 'G3+ AE', unit: '%', description: 'Grade 3+ Adverse Events', lowerIsBetter: true },
-  AE_LEADING_TO_DISCONTINUATION: { key: 'AE_LEADING_TO_DISCONTINUATION', label: 'AE Disc', unit: '%', description: 'AE leading to discontinuation', lowerIsBetter: true },
-  SERIOUS_AE: { key: 'SERIOUS_AE', label: 'SAE', unit: '%', description: 'Serious Adverse Events', lowerIsBetter: true },
-  IMMUNE_RELATED_AE: { key: 'IMMUNE_RELATED_AE', label: 'irAE', unit: '%', description: 'Immune-related AE', lowerIsBetter: true },
-  SERIOUS_IMMUNE_RELATED_AE: { key: 'SERIOUS_IMMUNE_RELATED_AE', label: 'Serious irAE', unit: '%', description: 'Serious Immune-related AE', lowerIsBetter: true },
-  AE_LEADING_TO_DEATH: { key: 'AE_LEADING_TO_DEATH', label: 'AE Death', unit: '%', description: 'AE leading to death', lowerIsBetter: true },
-  
+  AE: { key: 'AE', label: 'AE', unit: '%', description: 'Adverse Events', lowerIsBetter: true, subGroup: 'AE' },
+  GRADE_3_PLUS_AE: { key: 'GRADE_3_PLUS_AE', label: 'G3+ AE', unit: '%', description: 'Grade 3+ Adverse Events', lowerIsBetter: true, subGroup: 'AE' },
+  AE_LEADING_TO_DISCONTINUATION: { key: 'AE_LEADING_TO_DISCONTINUATION', label: 'AE Disc', unit: '%', description: 'AE leading to discontinuation', lowerIsBetter: true, subGroup: 'AE' },
+  SERIOUS_AE: { key: 'SERIOUS_AE', label: 'SAE', unit: '%', description: 'Serious Adverse Events', lowerIsBetter: true, subGroup: 'AE' },
+  IMMUNE_RELATED_AE: { key: 'IMMUNE_RELATED_AE', label: 'irAE', unit: '%', description: 'Immune-related AE', lowerIsBetter: true, subGroup: 'AE' },
+  SERIOUS_IMMUNE_RELATED_AE: { key: 'SERIOUS_IMMUNE_RELATED_AE', label: 'Serious irAE', unit: '%', description: 'Serious Immune-related AE', lowerIsBetter: true, subGroup: 'AE' },
+  AE_LEADING_TO_DEATH: { key: 'AE_LEADING_TO_DEATH', label: 'AE Death', unit: '%', description: 'AE leading to death', lowerIsBetter: true, subGroup: 'AE' },
+
   // TEAE (Treatment-Emergent AE)
-  TEAE: { key: 'TEAE', label: 'TEAE', unit: '%', description: 'Treatment-Emergent AE', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE: { key: 'GRADE_3_PLUS_TEAE', label: 'G3+ TEAE', unit: '%', description: 'Grade 3+ TEAE', lowerIsBetter: true },
-  GRADE_3_TEAE: { key: 'GRADE_3_TEAE', label: 'G3 TEAE', unit: '%', description: 'Grade 3 TEAE', lowerIsBetter: true },
-  GRADE_4_TEAE: { key: 'GRADE_4_TEAE', label: 'G4 TEAE', unit: '%', description: 'Grade 4 TEAE', lowerIsBetter: true },
-  GRADE_5_TEAE: { key: 'GRADE_5_TEAE', label: 'G5 TEAE', unit: '%', description: 'Grade 5 TEAE', lowerIsBetter: true },
-  TEAE_LEADING_TO_DISCONTINUATION: { key: 'TEAE_LEADING_TO_DISCONTINUATION', label: 'TEAE Disc', unit: '%', description: 'TEAE leading to discontinuation', lowerIsBetter: true },
-  TEAE_LEADING_TO_DEATH: { key: 'TEAE_LEADING_TO_DEATH', label: 'TEAE Death', unit: '%', description: 'TEAE leading to death', lowerIsBetter: true },
-  SERIOUS_TEAE: { key: 'SERIOUS_TEAE', label: 'STEAE', unit: '%', description: 'Serious TEAE', lowerIsBetter: true },
-  TEAE_IMMUNE_RELATED: { key: 'TEAE_IMMUNE_RELATED', label: 'TEAE irAE', unit: '%', description: 'TEAE Immune-related AE', lowerIsBetter: true },
-  
+  TEAE: { key: 'TEAE', label: 'TEAE', unit: '%', description: 'Treatment-Emergent AE', lowerIsBetter: true, subGroup: 'TEAE' },
+  GRADE_3_PLUS_TEAE: { key: 'GRADE_3_PLUS_TEAE', label: 'G3+ TEAE', unit: '%', description: 'Grade 3+ TEAE', lowerIsBetter: true, subGroup: 'TEAE' },
+  GRADE_3_TEAE: { key: 'GRADE_3_TEAE', label: 'G3 TEAE', unit: '%', description: 'Grade 3 TEAE', lowerIsBetter: true, subGroup: 'TEAE' },
+  GRADE_4_TEAE: { key: 'GRADE_4_TEAE', label: 'G4 TEAE', unit: '%', description: 'Grade 4 TEAE', lowerIsBetter: true, subGroup: 'TEAE' },
+  GRADE_5_TEAE: { key: 'GRADE_5_TEAE', label: 'G5 TEAE', unit: '%', description: 'Grade 5 TEAE', lowerIsBetter: true, subGroup: 'TEAE' },
+  TEAE_LEADING_TO_DISCONTINUATION: { key: 'TEAE_LEADING_TO_DISCONTINUATION', label: 'TEAE Disc', unit: '%', description: 'TEAE leading to discontinuation', lowerIsBetter: true, subGroup: 'TEAE' },
+  TEAE_LEADING_TO_DEATH: { key: 'TEAE_LEADING_TO_DEATH', label: 'TEAE Death', unit: '%', description: 'TEAE leading to death', lowerIsBetter: true, subGroup: 'TEAE' },
+  SERIOUS_TEAE: { key: 'SERIOUS_TEAE', label: 'STEAE', unit: '%', description: 'Serious TEAE', lowerIsBetter: true, subGroup: 'TEAE' },
+  TEAE_IMMUNE_RELATED: { key: 'TEAE_IMMUNE_RELATED', label: 'TEAE irAE', unit: '%', description: 'TEAE Immune-related AE', lowerIsBetter: true, subGroup: 'TEAE' },
+
   // TRAE (Treatment-Related AE)
-  TRAE: { key: 'TRAE', label: 'TRAE', unit: '%', description: 'Treatment-Related AE', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE: { key: 'GRADE_3_PLUS_TRAE', label: 'G3+ TRAE', unit: '%', description: 'Grade 3+ TRAE', lowerIsBetter: true },
-  GRADE_3_TRAE: { key: 'GRADE_3_TRAE', label: 'G3 TRAE', unit: '%', description: 'Grade 3 TRAE', lowerIsBetter: true },
-  GRADE_4_TRAE: { key: 'GRADE_4_TRAE', label: 'G4 TRAE', unit: '%', description: 'Grade 4 TRAE', lowerIsBetter: true },
-  GRADE_5_TRAE: { key: 'GRADE_5_TRAE', label: 'G5 TRAE', unit: '%', description: 'Grade 5 TRAE', lowerIsBetter: true },
-  TRAE_LEADING_TO_DISCONTINUATION: { key: 'TRAE_LEADING_TO_DISCONTINUATION', label: 'TRAE Disc', unit: '%', description: 'TRAE leading to discontinuation', lowerIsBetter: true },
-  TRAE_LEADING_TO_DEATH: { key: 'TRAE_LEADING_TO_DEATH', label: 'TRAE Death', unit: '%', description: 'TRAE leading to death', lowerIsBetter: true },
-  TRAE_IMMUNE_RELATED: { key: 'TRAE_IMMUNE_RELATED', label: 'TRAE irAE', unit: '%', description: 'TRAE Immune-related AE', lowerIsBetter: true },
-  SERIOUS_TRAE: { key: 'SERIOUS_TRAE', label: 'STRAE', unit: '%', description: 'Serious TRAE', lowerIsBetter: true },
-  
+  TRAE: { key: 'TRAE', label: 'TRAE', unit: '%', description: 'Treatment-Related AE', lowerIsBetter: true, subGroup: 'TRAE' },
+  GRADE_3_PLUS_TRAE: { key: 'GRADE_3_PLUS_TRAE', label: 'G3+ TRAE', unit: '%', description: 'Grade 3+ TRAE', lowerIsBetter: true, subGroup: 'TRAE' },
+  GRADE_3_TRAE: { key: 'GRADE_3_TRAE', label: 'G3 TRAE', unit: '%', description: 'Grade 3 TRAE', lowerIsBetter: true, subGroup: 'TRAE' },
+  GRADE_4_TRAE: { key: 'GRADE_4_TRAE', label: 'G4 TRAE', unit: '%', description: 'Grade 4 TRAE', lowerIsBetter: true, subGroup: 'TRAE' },
+  GRADE_5_TRAE: { key: 'GRADE_5_TRAE', label: 'G5 TRAE', unit: '%', description: 'Grade 5 TRAE', lowerIsBetter: true, subGroup: 'TRAE' },
+  TRAE_LEADING_TO_DISCONTINUATION: { key: 'TRAE_LEADING_TO_DISCONTINUATION', label: 'TRAE Disc', unit: '%', description: 'TRAE leading to discontinuation', lowerIsBetter: true, subGroup: 'TRAE' },
+  TRAE_LEADING_TO_DEATH: { key: 'TRAE_LEADING_TO_DEATH', label: 'TRAE Death', unit: '%', description: 'TRAE leading to death', lowerIsBetter: true, subGroup: 'TRAE' },
+  TRAE_IMMUNE_RELATED: { key: 'TRAE_IMMUNE_RELATED', label: 'TRAE irAE', unit: '%', description: 'TRAE Immune-related AE', lowerIsBetter: true, subGroup: 'TRAE' },
+  SERIOUS_TRAE: { key: 'SERIOUS_TRAE', label: 'STRAE', unit: '%', description: 'Serious TRAE', lowerIsBetter: true, subGroup: 'TRAE' },
+
   // Specific AE Types
-  CRS: { key: 'CRS', label: 'CRS', unit: '%', description: 'Cytokine Release Syndrome', lowerIsBetter: true },
-  WBC_DECREASED: { key: 'WBC_DECREASED', label: 'WBC↓', unit: '%', description: 'White Blood Cell Decreased', lowerIsBetter: true },
+  CRS: { key: 'CRS', label: 'CRS', unit: '%', description: 'Cytokine Release Syndrome', lowerIsBetter: true, subGroup: 'Specific AE' },
+  WBC_DECREASED: { key: 'WBC_DECREASED', label: 'WBC↓', unit: '%', description: 'White Blood Cell Decreased', lowerIsBetter: true, subGroup: 'Specific AE' },
   
   // Grade 3+ Specific AEs
-  GRADE_3_PLUS_AE_CRS: { key: 'GRADE_3_PLUS_AE_CRS', label: 'G3+ CRS', unit: '%', description: 'Grade 3+ Cytokine Release Syndrome', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_THROMBOCYTOPENIA: { key: 'GRADE_3_PLUS_AE_THROMBOCYTOPENIA', label: 'G3+ Thrombocytopenia', unit: '%', description: 'Grade 3+ Thrombocytopenia', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_NEUTROPENIA: { key: 'GRADE_3_PLUS_AE_NEUTROPENIA', label: 'G3+ Neutropenia', unit: '%', description: 'Grade 3+ Neutropenia', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_LEUKOPENIA: { key: 'GRADE_3_PLUS_AE_LEUKOPENIA', label: 'G3+ Leukopenia', unit: '%', description: 'Grade 3+ Leukopenia', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_NAUSEA: { key: 'GRADE_3_PLUS_AE_NAUSEA', label: 'G3+ Nausea', unit: '%', description: 'Grade 3+ Nausea', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_ANEMIA: { key: 'GRADE_3_PLUS_AE_ANEMIA', label: 'G3+ Anemia', unit: '%', description: 'Grade 3+ Anemia', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_DIARRHEA: { key: 'GRADE_3_PLUS_AE_DIARRHEA', label: 'G3+ Diarrhea', unit: '%', description: 'Grade 3+ Diarrhea', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_COLITIS: { key: 'GRADE_3_PLUS_AE_COLITIS', label: 'G3+ Colitis', unit: '%', description: 'Grade 3+ Colitis', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_HYPERGLYCEMIA: { key: 'GRADE_3_PLUS_AE_HYPERGLYCEMIA', label: 'G3+ Hyperglycemia', unit: '%', description: 'Grade 3+ Hyperglycemia', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_NEUTROPHIL_COUNT_DECREASED: { key: 'GRADE_3_PLUS_AE_NEUTROPHIL_COUNT_DECREASED', label: 'G3+ Neutrophil↓', unit: '%', description: 'Grade 3+ Neutrophil Count Decreased', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_DYSPNEA: { key: 'GRADE_3_PLUS_AE_DYSPNEA', label: 'G3+ Dyspnea', unit: '%', description: 'Grade 3+ Dyspnea', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_PYREXIA: { key: 'GRADE_3_PLUS_AE_PYREXIA', label: 'G3+ Pyrexia', unit: '%', description: 'Grade 3+ Pyrexia', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_BLEEDING: { key: 'GRADE_3_PLUS_AE_BLEEDING', label: 'G3+ Bleeding', unit: '%', description: 'Grade 3+ Bleeding', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_PRURITUS: { key: 'GRADE_3_PLUS_AE_PRURITUS', label: 'G3+ Pruritus', unit: '%', description: 'Grade 3+ Pruritus', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_RASH: { key: 'GRADE_3_PLUS_AE_RASH', label: 'G3+ Rash', unit: '%', description: 'Grade 3+ Rash', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_PNEUMONIA: { key: 'GRADE_3_PLUS_AE_PNEUMONIA', label: 'G3+ Pneumonia', unit: '%', description: 'Grade 3+ Pneumonia', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_THYROIDITIS: { key: 'GRADE_3_PLUS_AE_THYROIDITIS', label: 'G3+ Thyroiditis', unit: '%', description: 'Grade 3+ Thyroiditis', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_HYPOPHYSITIS: { key: 'GRADE_3_PLUS_AE_HYPOPHYSITIS', label: 'G3+ Hypophysitis', unit: '%', description: 'Grade 3+ Hypophysitis', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_HEPATITIS: { key: 'GRADE_3_PLUS_AE_HEPATITIS', label: 'G3+ Hepatitis', unit: '%', description: 'Grade 3+ Hepatitis', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_PNEUMONITIS: { key: 'GRADE_3_PLUS_AE_PNEUMONITIS', label: 'G3+ Pneumonitis', unit: '%', description: 'Grade 3+ Pneumonitis', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_ALANINE_AMINOTRANSFERASE: { key: 'GRADE_3_PLUS_AE_ALANINE_AMINOTRANSFERASE', label: 'G3+ ALT', unit: '%', description: 'Grade 3+ Alanine Aminotransferase', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_WBC_DECREASED: { key: 'GRADE_3_PLUS_AE_WBC_DECREASED', label: 'G3+ WBC↓', unit: '%', description: 'Grade 3+ WBC Decreased', lowerIsBetter: true },
-  GRADE_3_PLUS_AE_IMMUNE_RELATED: { key: 'GRADE_3_PLUS_AE_IMMUNE_RELATED', label: 'G3+ irAE', unit: '%', description: 'Grade 3+ Immune-related AE', lowerIsBetter: true },
+  GRADE_3_PLUS_AE_CRS: { key: 'GRADE_3_PLUS_AE_CRS', label: 'G3+ CRS', unit: '%', description: 'Grade 3+ Cytokine Release Syndrome', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_THROMBOCYTOPENIA: { key: 'GRADE_3_PLUS_AE_THROMBOCYTOPENIA', label: 'G3+ Thrombocytopenia', unit: '%', description: 'Grade 3+ Thrombocytopenia', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_NEUTROPENIA: { key: 'GRADE_3_PLUS_AE_NEUTROPENIA', label: 'G3+ Neutropenia', unit: '%', description: 'Grade 3+ Neutropenia', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_LEUKOPENIA: { key: 'GRADE_3_PLUS_AE_LEUKOPENIA', label: 'G3+ Leukopenia', unit: '%', description: 'Grade 3+ Leukopenia', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_NAUSEA: { key: 'GRADE_3_PLUS_AE_NAUSEA', label: 'G3+ Nausea', unit: '%', description: 'Grade 3+ Nausea', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_ANEMIA: { key: 'GRADE_3_PLUS_AE_ANEMIA', label: 'G3+ Anemia', unit: '%', description: 'Grade 3+ Anemia', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_DIARRHEA: { key: 'GRADE_3_PLUS_AE_DIARRHEA', label: 'G3+ Diarrhea', unit: '%', description: 'Grade 3+ Diarrhea', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_COLITIS: { key: 'GRADE_3_PLUS_AE_COLITIS', label: 'G3+ Colitis', unit: '%', description: 'Grade 3+ Colitis', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_HYPERGLYCEMIA: { key: 'GRADE_3_PLUS_AE_HYPERGLYCEMIA', label: 'G3+ Hyperglycemia', unit: '%', description: 'Grade 3+ Hyperglycemia', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_NEUTROPHIL_COUNT_DECREASED: { key: 'GRADE_3_PLUS_AE_NEUTROPHIL_COUNT_DECREASED', label: 'G3+ Neutrophil↓', unit: '%', description: 'Grade 3+ Neutrophil Count Decreased', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_DYSPNEA: { key: 'GRADE_3_PLUS_AE_DYSPNEA', label: 'G3+ Dyspnea', unit: '%', description: 'Grade 3+ Dyspnea', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_PYREXIA: { key: 'GRADE_3_PLUS_AE_PYREXIA', label: 'G3+ Pyrexia', unit: '%', description: 'Grade 3+ Pyrexia', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_BLEEDING: { key: 'GRADE_3_PLUS_AE_BLEEDING', label: 'G3+ Bleeding', unit: '%', description: 'Grade 3+ Bleeding', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_PRURITUS: { key: 'GRADE_3_PLUS_AE_PRURITUS', label: 'G3+ Pruritus', unit: '%', description: 'Grade 3+ Pruritus', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_RASH: { key: 'GRADE_3_PLUS_AE_RASH', label: 'G3+ Rash', unit: '%', description: 'Grade 3+ Rash', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_PNEUMONIA: { key: 'GRADE_3_PLUS_AE_PNEUMONIA', label: 'G3+ Pneumonia', unit: '%', description: 'Grade 3+ Pneumonia', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_THYROIDITIS: { key: 'GRADE_3_PLUS_AE_THYROIDITIS', label: 'G3+ Thyroiditis', unit: '%', description: 'Grade 3+ Thyroiditis', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_HYPOPHYSITIS: { key: 'GRADE_3_PLUS_AE_HYPOPHYSITIS', label: 'G3+ Hypophysitis', unit: '%', description: 'Grade 3+ Hypophysitis', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_HEPATITIS: { key: 'GRADE_3_PLUS_AE_HEPATITIS', label: 'G3+ Hepatitis', unit: '%', description: 'Grade 3+ Hepatitis', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_PNEUMONITIS: { key: 'GRADE_3_PLUS_AE_PNEUMONITIS', label: 'G3+ Pneumonitis', unit: '%', description: 'Grade 3+ Pneumonitis', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_ALANINE_AMINOTRANSFERASE: { key: 'GRADE_3_PLUS_AE_ALANINE_AMINOTRANSFERASE', label: 'G3+ ALT', unit: '%', description: 'Grade 3+ Alanine Aminotransferase', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_WBC_DECREASED: { key: 'GRADE_3_PLUS_AE_WBC_DECREASED', label: 'G3+ WBC↓', unit: '%', description: 'Grade 3+ WBC Decreased', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
+  GRADE_3_PLUS_AE_IMMUNE_RELATED: { key: 'GRADE_3_PLUS_AE_IMMUNE_RELATED', label: 'G3+ irAE', unit: '%', description: 'Grade 3+ Immune-related AE', lowerIsBetter: true, subGroup: 'Grade 3+ AE' },
   
   // Grade 3+ TRAE Specific
-  GRADE_3_PLUS_TRAE_IMMUNE_RELATED: { key: 'GRADE_3_PLUS_TRAE_IMMUNE_RELATED', label: 'G3+ TRAE irAE', unit: '%', description: 'Grade 3+ TRAE Immune-related AE', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_CRS: { key: 'GRADE_3_PLUS_TRAE_CRS', label: 'G3+ TRAE CRS', unit: '%', description: 'Grade 3+ TRAE CRS', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_THROMBOCYTOPENIA: { key: 'GRADE_3_PLUS_TRAE_THROMBOCYTOPENIA', label: 'G3+ TRAE Thrombocytopenia', unit: '%', description: 'Grade 3+ TRAE Thrombocytopenia', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_NEUTROPENIA: { key: 'GRADE_3_PLUS_TRAE_NEUTROPENIA', label: 'G3+ TRAE Neutropenia', unit: '%', description: 'Grade 3+ TRAE Neutropenia', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_LEUKOPENIA: { key: 'GRADE_3_PLUS_TRAE_LEUKOPENIA', label: 'G3+ TRAE Leukopenia', unit: '%', description: 'Grade 3+ TRAE Leukopenia', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_NAUSEA: { key: 'GRADE_3_PLUS_TRAE_NAUSEA', label: 'G3+ TRAE Nausea', unit: '%', description: 'Grade 3+ TRAE Nausea', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_ANEMIA: { key: 'GRADE_3_PLUS_TRAE_ANEMIA', label: 'G3+ TRAE Anemia', unit: '%', description: 'Grade 3+ TRAE Anemia', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_DIARRHEA: { key: 'GRADE_3_PLUS_TRAE_DIARRHEA', label: 'G3+ TRAE Diarrhea', unit: '%', description: 'Grade 3+ TRAE Diarrhea', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_COLITIS: { key: 'GRADE_3_PLUS_TRAE_COLITIS', label: 'G3+ TRAE Colitis', unit: '%', description: 'Grade 3+ TRAE Colitis', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_HYPERGLYCEMIA: { key: 'GRADE_3_PLUS_TRAE_HYPERGLYCEMIA', label: 'G3+ TRAE Hyperglycemia', unit: '%', description: 'Grade 3+ TRAE Hyperglycemia', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_NEUTROPHIL_COUNT_DECREASED: { key: 'GRADE_3_PLUS_TRAE_NEUTROPHIL_COUNT_DECREASED', label: 'G3+ TRAE Neutrophil↓', unit: '%', description: 'Grade 3+ TRAE Neutrophil Decreased', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_DYSPNEA: { key: 'GRADE_3_PLUS_TRAE_DYSPNEA', label: 'G3+ TRAE Dyspnea', unit: '%', description: 'Grade 3+ TRAE Dyspnea', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_PYREXIA: { key: 'GRADE_3_PLUS_TRAE_PYREXIA', label: 'G3+ TRAE Pyrexia', unit: '%', description: 'Grade 3+ TRAE Pyrexia', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_BLEEDING: { key: 'GRADE_3_PLUS_TRAE_BLEEDING', label: 'G3+ TRAE Bleeding', unit: '%', description: 'Grade 3+ TRAE Bleeding', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_PRURITUS: { key: 'GRADE_3_PLUS_TRAE_PRURITUS', label: 'G3+ TRAE Pruritus', unit: '%', description: 'Grade 3+ TRAE Pruritus', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_RASH: { key: 'GRADE_3_PLUS_TRAE_RASH', label: 'G3+ TRAE Rash', unit: '%', description: 'Grade 3+ TRAE Rash', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_PNEUMONIA: { key: 'GRADE_3_PLUS_TRAE_PNEUMONIA', label: 'G3+ TRAE Pneumonia', unit: '%', description: 'Grade 3+ TRAE Pneumonia', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_THYROIDITIS: { key: 'GRADE_3_PLUS_TRAE_THYROIDITIS', label: 'G3+ TRAE Thyroiditis', unit: '%', description: 'Grade 3+ TRAE Thyroiditis', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_HYPOPHYSITIS: { key: 'GRADE_3_PLUS_TRAE_HYPOPHYSITIS', label: 'G3+ TRAE Hypophysitis', unit: '%', description: 'Grade 3+ TRAE Hypophysitis', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_HEPATITIS: { key: 'GRADE_3_PLUS_TRAE_HEPATITIS', label: 'G3+ TRAE Hepatitis', unit: '%', description: 'Grade 3+ TRAE Hepatitis', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_PNEUMONITIS: { key: 'GRADE_3_PLUS_TRAE_PNEUMONITIS', label: 'G3+ TRAE Pneumonitis', unit: '%', description: 'Grade 3+ TRAE Pneumonitis', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_ALANINE_AMINOTRANSFERASE: { key: 'GRADE_3_PLUS_TRAE_ALANINE_AMINOTRANSFERASE', label: 'G3+ TRAE ALT', unit: '%', description: 'Grade 3+ TRAE ALT', lowerIsBetter: true },
-  GRADE_3_PLUS_TRAE_WBC_DECREASED: { key: 'GRADE_3_PLUS_TRAE_WBC_DECREASED', label: 'G3+ TRAE WBC↓', unit: '%', description: 'Grade 3+ TRAE WBC Decreased', lowerIsBetter: true },
+  GRADE_3_PLUS_TRAE_IMMUNE_RELATED: { key: 'GRADE_3_PLUS_TRAE_IMMUNE_RELATED', label: 'G3+ TRAE irAE', unit: '%', description: 'Grade 3+ TRAE Immune-related AE', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_CRS: { key: 'GRADE_3_PLUS_TRAE_CRS', label: 'G3+ TRAE CRS', unit: '%', description: 'Grade 3+ TRAE CRS', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_THROMBOCYTOPENIA: { key: 'GRADE_3_PLUS_TRAE_THROMBOCYTOPENIA', label: 'G3+ TRAE Thrombocytopenia', unit: '%', description: 'Grade 3+ TRAE Thrombocytopenia', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_NEUTROPENIA: { key: 'GRADE_3_PLUS_TRAE_NEUTROPENIA', label: 'G3+ TRAE Neutropenia', unit: '%', description: 'Grade 3+ TRAE Neutropenia', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_LEUKOPENIA: { key: 'GRADE_3_PLUS_TRAE_LEUKOPENIA', label: 'G3+ TRAE Leukopenia', unit: '%', description: 'Grade 3+ TRAE Leukopenia', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_NAUSEA: { key: 'GRADE_3_PLUS_TRAE_NAUSEA', label: 'G3+ TRAE Nausea', unit: '%', description: 'Grade 3+ TRAE Nausea', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_ANEMIA: { key: 'GRADE_3_PLUS_TRAE_ANEMIA', label: 'G3+ TRAE Anemia', unit: '%', description: 'Grade 3+ TRAE Anemia', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_DIARRHEA: { key: 'GRADE_3_PLUS_TRAE_DIARRHEA', label: 'G3+ TRAE Diarrhea', unit: '%', description: 'Grade 3+ TRAE Diarrhea', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_COLITIS: { key: 'GRADE_3_PLUS_TRAE_COLITIS', label: 'G3+ TRAE Colitis', unit: '%', description: 'Grade 3+ TRAE Colitis', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_HYPERGLYCEMIA: { key: 'GRADE_3_PLUS_TRAE_HYPERGLYCEMIA', label: 'G3+ TRAE Hyperglycemia', unit: '%', description: 'Grade 3+ TRAE Hyperglycemia', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_NEUTROPHIL_COUNT_DECREASED: { key: 'GRADE_3_PLUS_TRAE_NEUTROPHIL_COUNT_DECREASED', label: 'G3+ TRAE Neutrophil↓', unit: '%', description: 'Grade 3+ TRAE Neutrophil Decreased', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_DYSPNEA: { key: 'GRADE_3_PLUS_TRAE_DYSPNEA', label: 'G3+ TRAE Dyspnea', unit: '%', description: 'Grade 3+ TRAE Dyspnea', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_PYREXIA: { key: 'GRADE_3_PLUS_TRAE_PYREXIA', label: 'G3+ TRAE Pyrexia', unit: '%', description: 'Grade 3+ TRAE Pyrexia', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_BLEEDING: { key: 'GRADE_3_PLUS_TRAE_BLEEDING', label: 'G3+ TRAE Bleeding', unit: '%', description: 'Grade 3+ TRAE Bleeding', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_PRURITUS: { key: 'GRADE_3_PLUS_TRAE_PRURITUS', label: 'G3+ TRAE Pruritus', unit: '%', description: 'Grade 3+ TRAE Pruritus', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_RASH: { key: 'GRADE_3_PLUS_TRAE_RASH', label: 'G3+ TRAE Rash', unit: '%', description: 'Grade 3+ TRAE Rash', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_PNEUMONIA: { key: 'GRADE_3_PLUS_TRAE_PNEUMONIA', label: 'G3+ TRAE Pneumonia', unit: '%', description: 'Grade 3+ TRAE Pneumonia', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_THYROIDITIS: { key: 'GRADE_3_PLUS_TRAE_THYROIDITIS', label: 'G3+ TRAE Thyroiditis', unit: '%', description: 'Grade 3+ TRAE Thyroiditis', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_HYPOPHYSITIS: { key: 'GRADE_3_PLUS_TRAE_HYPOPHYSITIS', label: 'G3+ TRAE Hypophysitis', unit: '%', description: 'Grade 3+ TRAE Hypophysitis', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_HEPATITIS: { key: 'GRADE_3_PLUS_TRAE_HEPATITIS', label: 'G3+ TRAE Hepatitis', unit: '%', description: 'Grade 3+ TRAE Hepatitis', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_PNEUMONITIS: { key: 'GRADE_3_PLUS_TRAE_PNEUMONITIS', label: 'G3+ TRAE Pneumonitis', unit: '%', description: 'Grade 3+ TRAE Pneumonitis', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_ALANINE_AMINOTRANSFERASE: { key: 'GRADE_3_PLUS_TRAE_ALANINE_AMINOTRANSFERASE', label: 'G3+ TRAE ALT', unit: '%', description: 'Grade 3+ TRAE ALT', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
+  GRADE_3_PLUS_TRAE_WBC_DECREASED: { key: 'GRADE_3_PLUS_TRAE_WBC_DECREASED', label: 'G3+ TRAE WBC↓', unit: '%', description: 'Grade 3+ TRAE WBC Decreased', lowerIsBetter: true, subGroup: 'Grade 3+ TRAE' },
   
   // Grade 3+ TEAE Specific
-  GRADE_3_PLUS_TEAE_IMMUNE_RELATED: { key: 'GRADE_3_PLUS_TEAE_IMMUNE_RELATED', label: 'G3+ TEAE irAE', unit: '%', description: 'Grade 3+ TEAE Immune-related AE', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_CRS: { key: 'GRADE_3_PLUS_TEAE_CRS', label: 'G3+ TEAE CRS', unit: '%', description: 'Grade 3+ TEAE CRS', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_THROMBOCYTOPENIA: { key: 'GRADE_3_PLUS_TEAE_THROMBOCYTOPENIA', label: 'G3+ TEAE Thrombocytopenia', unit: '%', description: 'Grade 3+ TEAE Thrombocytopenia', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_NEUTROPENIA: { key: 'GRADE_3_PLUS_TEAE_NEUTROPENIA', label: 'G3+ TEAE Neutropenia', unit: '%', description: 'Grade 3+ TEAE Neutropenia', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_LEUKOPENIA: { key: 'GRADE_3_PLUS_TEAE_LEUKOPENIA', label: 'G3+ TEAE Leukopenia', unit: '%', description: 'Grade 3+ TEAE Leukopenia', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_NAUSEA: { key: 'GRADE_3_PLUS_TEAE_NAUSEA', label: 'G3+ TEAE Nausea', unit: '%', description: 'Grade 3+ TEAE Nausea', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_ANEMIA: { key: 'GRADE_3_PLUS_TEAE_ANEMIA', label: 'G3+ TEAE Anemia', unit: '%', description: 'Grade 3+ TEAE Anemia', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_DIARRHEA: { key: 'GRADE_3_PLUS_TEAE_DIARRHEA', label: 'G3+ TEAE Diarrhea', unit: '%', description: 'Grade 3+ TEAE Diarrhea', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_COLITIS: { key: 'GRADE_3_PLUS_TEAE_COLITIS', label: 'G3+ TEAE Colitis', unit: '%', description: 'Grade 3+ TEAE Colitis', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_HYPERGLYCEMIA: { key: 'GRADE_3_PLUS_TEAE_HYPERGLYCEMIA', label: 'G3+ TEAE Hyperglycemia', unit: '%', description: 'Grade 3+ TEAE Hyperglycemia', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_NEUTROPHIL_COUNT_DECREASED: { key: 'GRADE_3_PLUS_TEAE_NEUTROPHIL_COUNT_DECREASED', label: 'G3+ TEAE Neutrophil↓', unit: '%', description: 'Grade 3+ TEAE Neutrophil Decreased', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_DYSPNEA: { key: 'GRADE_3_PLUS_TEAE_DYSPNEA', label: 'G3+ TEAE Dyspnea', unit: '%', description: 'Grade 3+ TEAE Dyspnea', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_PYREXIA: { key: 'GRADE_3_PLUS_TEAE_PYREXIA', label: 'G3+ TEAE Pyrexia', unit: '%', description: 'Grade 3+ TEAE Pyrexia', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_BLEEDING: { key: 'GRADE_3_PLUS_TEAE_BLEEDING', label: 'G3+ TEAE Bleeding', unit: '%', description: 'Grade 3+ TEAE Bleeding', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_PRURITUS: { key: 'GRADE_3_PLUS_TEAE_PRURITUS', label: 'G3+ TEAE Pruritus', unit: '%', description: 'Grade 3+ TEAE Pruritus', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_RASH: { key: 'GRADE_3_PLUS_TEAE_RASH', label: 'G3+ TEAE Rash', unit: '%', description: 'Grade 3+ TEAE Rash', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_PNEUMONIA: { key: 'GRADE_3_PLUS_TEAE_PNEUMONIA', label: 'G3+ TEAE Pneumonia', unit: '%', description: 'Grade 3+ TEAE Pneumonia', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_THYROIDITIS: { key: 'GRADE_3_PLUS_TEAE_THYROIDITIS', label: 'G3+ TEAE Thyroiditis', unit: '%', description: 'Grade 3+ TEAE Thyroiditis', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_HYPOPHYSITIS: { key: 'GRADE_3_PLUS_TEAE_HYPOPHYSITIS', label: 'G3+ TEAE Hypophysitis', unit: '%', description: 'Grade 3+ TEAE Hypophysitis', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_HEPATITIS: { key: 'GRADE_3_PLUS_TEAE_HEPATITIS', label: 'G3+ TEAE Hepatitis', unit: '%', description: 'Grade 3+ TEAE Hepatitis', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_PNEUMONITIS: { key: 'GRADE_3_PLUS_TEAE_PNEUMONITIS', label: 'G3+ TEAE Pneumonitis', unit: '%', description: 'Grade 3+ TEAE Pneumonitis', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_ALANINE_AMINOTRANSFERASE: { key: 'GRADE_3_PLUS_TEAE_ALANINE_AMINOTRANSFERASE', label: 'G3+ TEAE ALT', unit: '%', description: 'Grade 3+ TEAE ALT', lowerIsBetter: true },
-  GRADE_3_PLUS_TEAE_WBC_DECREASED: { key: 'GRADE_3_PLUS_TEAE_WBC_DECREASED', label: 'G3+ TEAE WBC↓', unit: '%', description: 'Grade 3+ TEAE WBC Decreased', lowerIsBetter: true },
+  GRADE_3_PLUS_TEAE_IMMUNE_RELATED: { key: 'GRADE_3_PLUS_TEAE_IMMUNE_RELATED', label: 'G3+ TEAE irAE', unit: '%', description: 'Grade 3+ TEAE Immune-related AE', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_CRS: { key: 'GRADE_3_PLUS_TEAE_CRS', label: 'G3+ TEAE CRS', unit: '%', description: 'Grade 3+ TEAE CRS', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_THROMBOCYTOPENIA: { key: 'GRADE_3_PLUS_TEAE_THROMBOCYTOPENIA', label: 'G3+ TEAE Thrombocytopenia', unit: '%', description: 'Grade 3+ TEAE Thrombocytopenia', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_NEUTROPENIA: { key: 'GRADE_3_PLUS_TEAE_NEUTROPENIA', label: 'G3+ TEAE Neutropenia', unit: '%', description: 'Grade 3+ TEAE Neutropenia', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_LEUKOPENIA: { key: 'GRADE_3_PLUS_TEAE_LEUKOPENIA', label: 'G3+ TEAE Leukopenia', unit: '%', description: 'Grade 3+ TEAE Leukopenia', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_NAUSEA: { key: 'GRADE_3_PLUS_TEAE_NAUSEA', label: 'G3+ TEAE Nausea', unit: '%', description: 'Grade 3+ TEAE Nausea', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_ANEMIA: { key: 'GRADE_3_PLUS_TEAE_ANEMIA', label: 'G3+ TEAE Anemia', unit: '%', description: 'Grade 3+ TEAE Anemia', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_DIARRHEA: { key: 'GRADE_3_PLUS_TEAE_DIARRHEA', label: 'G3+ TEAE Diarrhea', unit: '%', description: 'Grade 3+ TEAE Diarrhea', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_COLITIS: { key: 'GRADE_3_PLUS_TEAE_COLITIS', label: 'G3+ TEAE Colitis', unit: '%', description: 'Grade 3+ TEAE Colitis', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_HYPERGLYCEMIA: { key: 'GRADE_3_PLUS_TEAE_HYPERGLYCEMIA', label: 'G3+ TEAE Hyperglycemia', unit: '%', description: 'Grade 3+ TEAE Hyperglycemia', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_NEUTROPHIL_COUNT_DECREASED: { key: 'GRADE_3_PLUS_TEAE_NEUTROPHIL_COUNT_DECREASED', label: 'G3+ TEAE Neutrophil↓', unit: '%', description: 'Grade 3+ TEAE Neutrophil Decreased', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_DYSPNEA: { key: 'GRADE_3_PLUS_TEAE_DYSPNEA', label: 'G3+ TEAE Dyspnea', unit: '%', description: 'Grade 3+ TEAE Dyspnea', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_PYREXIA: { key: 'GRADE_3_PLUS_TEAE_PYREXIA', label: 'G3+ TEAE Pyrexia', unit: '%', description: 'Grade 3+ TEAE Pyrexia', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_BLEEDING: { key: 'GRADE_3_PLUS_TEAE_BLEEDING', label: 'G3+ TEAE Bleeding', unit: '%', description: 'Grade 3+ TEAE Bleeding', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_PRURITUS: { key: 'GRADE_3_PLUS_TEAE_PRURITUS', label: 'G3+ TEAE Pruritus', unit: '%', description: 'Grade 3+ TEAE Pruritus', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_RASH: { key: 'GRADE_3_PLUS_TEAE_RASH', label: 'G3+ TEAE Rash', unit: '%', description: 'Grade 3+ TEAE Rash', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_PNEUMONIA: { key: 'GRADE_3_PLUS_TEAE_PNEUMONIA', label: 'G3+ TEAE Pneumonia', unit: '%', description: 'Grade 3+ TEAE Pneumonia', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_THYROIDITIS: { key: 'GRADE_3_PLUS_TEAE_THYROIDITIS', label: 'G3+ TEAE Thyroiditis', unit: '%', description: 'Grade 3+ TEAE Thyroiditis', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_HYPOPHYSITIS: { key: 'GRADE_3_PLUS_TEAE_HYPOPHYSITIS', label: 'G3+ TEAE Hypophysitis', unit: '%', description: 'Grade 3+ TEAE Hypophysitis', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_HEPATITIS: { key: 'GRADE_3_PLUS_TEAE_HEPATITIS', label: 'G3+ TEAE Hepatitis', unit: '%', description: 'Grade 3+ TEAE Hepatitis', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_PNEUMONITIS: { key: 'GRADE_3_PLUS_TEAE_PNEUMONITIS', label: 'G3+ TEAE Pneumonitis', unit: '%', description: 'Grade 3+ TEAE Pneumonitis', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_ALANINE_AMINOTRANSFERASE: { key: 'GRADE_3_PLUS_TEAE_ALANINE_AMINOTRANSFERASE', label: 'G3+ TEAE ALT', unit: '%', description: 'Grade 3+ TEAE ALT', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
+  GRADE_3_PLUS_TEAE_WBC_DECREASED: { key: 'GRADE_3_PLUS_TEAE_WBC_DECREASED', label: 'G3+ TEAE WBC↓', unit: '%', description: 'Grade 3+ TEAE WBC Decreased', lowerIsBetter: true, subGroup: 'Grade 3+ TEAE' },
 };
 
 export const ALL_METRICS: Record<string, MetricConfig> = {
@@ -321,7 +328,6 @@ export interface EfficacySafetyDataPoint {
   treatmentType?: string; // e.g., "Immunotherapy", "Chemo", "Targeted"
   efficacy: number; // ORR or other efficacy metric (%)
   safety: number; // Grade 3+ AE rate (%)
-  approvalStatus?: ApprovalStatus;
   numberOfPatients?: number;
   trialCount?: number;
   // Store all trials for this treatment (for tooltip switching)
@@ -335,6 +341,8 @@ export interface EfficacySafetyDataPoint {
     publicationName?: string;
     citation?: string;
     phase?: string;
+    sourceType?: SourceType;
+    sourceUrl?: string;
   }>;
   currentTrialIndex?: number;
 }
@@ -351,8 +359,6 @@ export interface BubbleChartDataPoint {
   numberOfPatients: number; // Determines bubble size
   /** Z-axis value when Z is not NUMBER_OF_PATIENTS (e.g. HR_PFS, HR_OS) */
   zValue?: number;
-  approvalStatus?: ApprovalStatus;
-  developmentStatus?: 'Approved' | 'Development stopped' | 'Investigational';
   nctNumber?: string;
   abstractId?: string;
   publicationName?: string;
@@ -360,6 +366,7 @@ export interface BubbleChartDataPoint {
   phase?: string;
   year?: string;
   sourceUrl?: string;
+  sourceType?: SourceType;
   // Additional metadata for tooltips
   notes?: string;
   biomarker?: string;
@@ -374,6 +381,8 @@ export interface BubbleChartDataPoint {
     publicationName?: string;
     citation?: string;
     phase?: string;
+    sourceType?: SourceType;
+    sourceUrl?: string;
   }>;
   currentTrialIndex?: number; // Index of currently displayed trial in allTrials array
 }

--- a/web/src/types/compare.ts
+++ b/web/src/types/compare.ts
@@ -1,0 +1,49 @@
+/**
+ * Compare Treatments Table Types
+ * Drives the side-by-side matrix view on the analytics page.
+ */
+
+export type CompareSortMode = 'most-complete' | 'alphabetical';
+export type CompareGroup = 'efficacy' | 'safety';
+export type CompareCellStatus = 'value' | 'NR' | 'NE';
+export type CompareMode = 'efficacy' | 'safety' | 'all';
+
+export interface CompareCell {
+  treatmentName: string;
+  metricKey: string;
+  value: number | null;
+  displayValue: string;
+  status: CompareCellStatus;
+  assessmentMethod?: string;
+  unit: string;
+}
+
+export interface CompareRow {
+  metricKey: string;
+  label: string;
+  description: string;
+  unit: string;
+  group: CompareGroup;
+  subGroup?: string;
+  cells: Record<string, CompareCell>;
+  coverage: number;
+}
+
+export interface TreatmentMeta {
+  modality: string | null;
+  lineOfTreatment: string | null;
+}
+
+export interface CompareTableData {
+  treatments: string[];
+  efficacyRows: CompareRow[];
+  safetyRows: CompareRow[];
+  treatmentMeta: Record<string, TreatmentMeta>;
+}
+
+export interface CompareSelection {
+  treatmentName: string;
+  metricKey: string;
+}
+
+export const MAX_COMPARE_TREATMENTS = 5;


### PR DESCRIPTION
## Summary

- **Efficacy/Safety comparison table** — new `CompareTable` component lets users select treatments side-by-side and compare efficacy (PFS, OS, ORR, EFS, RFS, MFS) and safety (AE, TEAE, TRAE, Grade 3+ breakdowns) metrics across arms. Supports sort, hide-empty toggle, and per-cell selection highlighting.
- **Compare types + transformers** — `types/compare.ts` defines the data model; `lib/compare-transformers.ts` maps `trial_outcomes` rows into the table structure.
- **Analytics page refactor** — removed unused filter constant blocks (`COMPANY_OPTIONS`, `BIOMARKER_OPTIONS`, `ADVANCED_PREVIOUS_TREATMENT_OPTIONS`) and integrated compare mode toggle into the analytics view.
- **April 2026 ingestion** — `upload_to_supabase.py` gains 35 new `ATTRIBUTE_MAPPING` entries (CI bounds for HR metrics, AE/TEAE/TRAE dose interruption/reduction/hospitalization, IRR, Grade 3+ AE/TEAE/TRAE expansions) and fixes `AE_LEADING_TO_DEATH` key rename.

## Test plan
- [ ] Load `/dashboard/melanoma/analytics` — no console errors
- [ ] Toggle between Efficacy and Safety compare modes — table renders correctly
- [ ] Select/deselect treatment columns — highlighting updates
- [ ] Sort by "Most complete" and "Alphabetical" — rows reorder correctly
- [ ] "Hide empty rows" toggle — sparse metrics disappear
- [ ] Confirm existing landscape/trial-card views unaffected
