### PR TITLE
feat(web): add oncology research agent at /agent

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,8 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.71",
+        "@ai-sdk/react": "^3.0.170",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@supabase/ssr": "^0.9.0",
@@ -15,16 +17,21 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-query-devtools": "^5.90.2",
         "@tanstack/react-table": "^8.21.3",
+        "ai": "^6.0.168",
         "axios": "^1.13.2",
         "clsx": "^2.1.1",
         "framer-motion": "^12.33.0",
         "lucide-react": "^0.554.0",
         "next": "^16.2.1",
         "next-auth": "^5.0.0-beta.30",
-        "react": "19.2.0",
-        "react-dom": "19.2.0",
+        "p-retry": "^8.0.0",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1",
+        "react-markdown": "^10.1.0",
         "recharts": "^3.5.1",
-        "tailwind-merge": "^3.4.0"
+        "remark-gfm": "^4.0.1",
+        "tailwind-merge": "^3.4.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -38,6 +45,86 @@
         "lint-staged": "^16.4.0",
         "tailwindcss": "^4",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.170",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.170.tgz",
+      "integrity": "sha512-YUDn+mK0c8iUz14rCBf1A0zg6SV5b5aSVUz+azF1bdBd1SFXVI19dKYR+PQSpZY+0+z+zs252AAsacUqiO98Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.23",
+        "ai": "6.0.168",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1386,6 +1473,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -2033,9 +2129,9 @@
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -2584,12 +2680,38 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2605,6 +2727,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
@@ -2618,7 +2755,6 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.6.tgz",
       "integrity": "sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2635,6 +2771,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -2894,6 +3036,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -3164,6 +3312,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3186,6 +3343,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -3509,6 +3684,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3671,6 +3856,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3686,6 +3881,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/cli-cursor": {
@@ -3775,6 +4010,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -3831,7 +4076,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -4020,7 +4264,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4039,6 +4282,19 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4092,6 +4348,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4107,6 +4372,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -4893,6 +5171,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4907,6 +5195,21 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -5416,6 +5719,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -5431,6 +5774,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/husky": {
@@ -5505,6 +5858,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -5527,6 +5886,30 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5687,6 +6070,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5762,6 +6155,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -5786,6 +6189,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -5813,6 +6228,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -6050,6 +6477,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6527,6 +6960,16 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6569,6 +7012,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6576,6 +7029,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/merge2": {
@@ -6587,6 +7322,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -6681,7 +7979,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -7075,6 +8372,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-8.0.0.tgz",
+      "integrity": "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7087,6 +8399,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7215,6 +8552,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -7256,9 +8603,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7266,16 +8613,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-is": {
@@ -7284,6 +8631,33 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -7466,6 +8840,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/reselect": {
@@ -7903,6 +9343,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -8064,6 +9514,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -8101,6 +9565,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-jsx": {
@@ -8152,6 +9634,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -8181,6 +9676,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {
@@ -8259,6 +9766,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8448,6 +9975,93 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -8574,6 +10188,34 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -8830,7 +10472,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -8848,6 +10489,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -13,10 +13,13 @@
     "src/**/*.{ts,tsx}": ["eslint --max-warnings=0"]
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.71",
+    "@ai-sdk/react": "^3.0.170",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.1",
+    "ai": "^6.0.168",
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-query-devtools": "^5.90.2",
     "@tanstack/react-table": "^8.21.3",
@@ -26,10 +29,14 @@
     "lucide-react": "^0.554.0",
     "next": "^16.2.1",
     "next-auth": "^5.0.0-beta.30",
-    "react": "19.2.0",
-    "react-dom": "19.2.0",
+    "p-retry": "^8.0.0",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1",
+    "react-markdown": "^10.1.0",
     "recharts": "^3.5.1",
-    "tailwind-merge": "^3.4.0"
+    "remark-gfm": "^4.0.1",
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/web/src/app/agent/page.tsx
+++ b/web/src/app/agent/page.tsx
@@ -1,0 +1,44 @@
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+import { Logo } from '@/components/Logo';
+import { UserMenu } from '@/components/user-menu';
+import { DashboardNavLink } from '@/components/nav/DashboardNavLink';
+import { ChatPanel } from '@/components/agent/ChatPanel';
+import { ROUTES } from '@/lib/constants';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AgentPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`${ROUTES.LOGIN}?callbackUrl=${encodeURIComponent(ROUTES.AGENT)}`);
+  }
+
+  return (
+    <div className="flex h-screen w-full flex-col overflow-hidden bg-[var(--brand-bg)]">
+      <header className="sticky top-0 z-50 shrink-0 border-b border-slate-200 bg-white shadow-sm">
+        <div className="w-full px-6 sm:px-10 lg:px-16">
+          <div className="flex h-14 items-center justify-between gap-3 sm:h-16">
+            <Link href={ROUTES.HOME} className="brand flex-shrink-0 hover:opacity-80 transition-opacity">
+              <Logo height={32} />
+              <span className="brand-text dashboard-brand-text">
+                bi<span className="brand-o">o</span>nocular
+              </span>
+            </Link>
+            <div className="flex items-center gap-3">
+              <DashboardNavLink />
+              <UserMenu />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-hidden">
+        <ChatPanel />
+      </main>
+    </div>
+  );
+}

--- a/web/src/app/api/agent/chat/route.ts
+++ b/web/src/app/api/agent/chat/route.ts
@@ -1,0 +1,105 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import {
+  convertToModelMessages,
+  stepCountIs,
+  streamText,
+  type ModelMessage,
+  type UIMessage,
+} from 'ai';
+import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
+import { checkAgentRateLimit } from '@/lib/agent/rate-limit';
+import { agentTools } from '@/lib/agent/tools';
+import { ONCOLOGY_SYSTEM_PROMPT } from '@/lib/agent/prompts';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+interface ChatRequestBody {
+  messages: UIMessage[];
+  sessionId?: string;
+}
+
+export async function POST(req: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const allowed = await checkAgentRateLimit(user.id);
+  if (!allowed) {
+    return new Response('Rate limit exceeded — 20 requests per minute', { status: 429 });
+  }
+
+  const { messages, sessionId }: ChatRequestBody = await req.json();
+  const modelMessages: ModelMessage[] = await convertToModelMessages(messages);
+
+  // Cache the system prompt + tool definitions. Anthropic caches break on changes,
+  // so the system prompt lives in the messages array with cacheControl rather than
+  // as a top-level `system` string.
+  const systemMessage: ModelMessage = {
+    role: 'system',
+    content: ONCOLOGY_SYSTEM_PROMPT,
+    providerOptions: {
+      anthropic: { cacheControl: { type: 'ephemeral' } },
+    },
+  };
+
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-6'),
+    messages: [systemMessage, ...modelMessages],
+    tools: agentTools(user.id),
+    stopWhen: stepCountIs(4), // raise to 8 after Render Pro upgrade
+    onFinish: async ({ usage }) => {
+      try {
+        await persistSession({
+          userId: user.id,
+          sessionId,
+          messages,
+          usage,
+        });
+      } catch (err) {
+        // Don't fail the response if persistence breaks — just log.
+        console.error('persistSession failed', err);
+      }
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+
+interface PersistArgs {
+  userId: string;
+  sessionId: string | undefined;
+  messages: UIMessage[];
+  usage: unknown;
+}
+
+async function persistSession({ userId, sessionId, messages, usage }: PersistArgs) {
+  const supabase = createServiceClient();
+  const firstUserMessage = messages.find((m) => m.role === 'user');
+  const titleSource = firstUserMessage?.parts.find((p) => p.type === 'text');
+  const title = titleSource && 'text' in titleSource
+    ? String(titleSource.text).slice(0, 80)
+    : 'Untitled chat';
+
+  if (sessionId) {
+    await supabase
+      .from('chat_sessions')
+      .update({
+        messages,
+        token_usage: usage,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', sessionId)
+      .eq('user_id', userId);
+  } else {
+    await supabase.from('chat_sessions').insert({
+      user_id: userId,
+      title,
+      messages,
+      token_usage: usage,
+    });
+  }
+}

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useSession } from "@/lib/supabase/hooks";
 import { Logo } from '@/components/Logo';
 import { UserMenu } from '@/components/user-menu';
 import { DashboardNavLink } from '@/components/nav/DashboardNavLink';
+import { AgentNavLink } from '@/components/nav/AgentNavLink';
 import { Search, Activity, ArrowRight } from 'lucide-react';
 
 const CANCER_TYPES = [
@@ -39,6 +40,7 @@ export default function MainDashboardPage() {
               </span>
             </Link>
             <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
+              <AgentNavLink />
               <DashboardNavLink />
               {session?.user && (
                 <UserMenu

--- a/web/src/components/agent/ChatPanel.tsx
+++ b/web/src/components/agent/ChatPanel.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { Send, Loader2, Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { MessageBubble } from './MessageBubble';
+import { ToolCard } from './ToolCard';
+
+const COLD_START_DELAY_MS = 5000;
+
+interface MessageTextPart { type: 'text'; text: string }
+interface MessageToolPart {
+  type: string;
+  toolCallId: string;
+  state: 'input-streaming' | 'input-available' | 'output-available' | 'output-error';
+  input?: unknown;
+  output?: unknown;
+  errorText?: string;
+}
+type MessagePart = MessageTextPart | MessageToolPart;
+
+function isToolPart(part: { type: string }): part is MessageToolPart {
+  return part.type.startsWith('tool-');
+}
+
+export function ChatPanel() {
+  const { messages, sendMessage, status, error } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/agent/chat' }),
+  });
+
+  const [input, setInput] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Cold-start hint: track elapsed-since-request-start in state so render is pure.
+  // setElapsed only fires inside callbacks (setInterval, cleanup), never in the
+  // synchronous effect body — required by react-hooks/purity + set-state-in-effect.
+  const [elapsed, setElapsed] = useState(0);
+  const isBusyForHint = status === 'submitted' || status === 'streaming';
+
+  useEffect(() => {
+    if (!isBusyForHint) return;
+    const start = Date.now();
+    const id = setInterval(() => setElapsed(Date.now() - start), 500);
+    return () => {
+      clearInterval(id);
+      setElapsed(0);
+    };
+  }, [isBusyForHint]);
+
+  const lastMsg = messages[messages.length - 1];
+  const hasAssistantText =
+    lastMsg?.role === 'assistant' &&
+    lastMsg.parts.some(
+      (p) => p.type === 'text' && (p as MessageTextPart).text.length > 0
+    );
+  const showColdStartHint =
+    isBusyForHint && !hasAssistantText && elapsed > COLD_START_DELAY_MS;
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [messages]);
+
+  const isBusy = status === 'submitted' || status === 'streaming';
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = input.trim();
+    if (!trimmed || isBusy) return;
+    sendMessage({ text: trimmed });
+    setInput('');
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-[var(--brand-bg)]">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-6 sm:px-8">
+        <div className="mx-auto flex max-w-3xl flex-col gap-4">
+          {messages.length === 0 ? (
+            <EmptyState onPick={(q) => setInput(q)} />
+          ) : (
+            messages.map((message) => (
+              <div key={message.id} className="flex flex-col gap-2">
+                {(message.parts as MessagePart[]).map((part, i) => {
+                  if (part.type === 'text') {
+                    return (
+                      <MessageBubble
+                        key={`${message.id}-${i}`}
+                        role={message.role as 'user' | 'assistant'}
+                        text={(part as MessageTextPart).text}
+                      />
+                    );
+                  }
+                  if (isToolPart(part)) {
+                    return (
+                      <ToolCard
+                        key={`${message.id}-${i}-${part.toolCallId}`}
+                        toolName={part.type.replace(/^tool-/, '')}
+                        state={part.state}
+                        input={part.input}
+                        output={part.output}
+                        errorText={part.errorText}
+                      />
+                    );
+                  }
+                  return null;
+                })}
+              </div>
+            ))
+          )}
+
+          {isBusy && (
+            <div className="flex items-center gap-2 text-sm text-slate-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Thinking…</span>
+            </div>
+          )}
+
+          {showColdStartHint && (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+              Waking the server (free tier sleeps after idle). First request after a long pause
+              can take up to a minute.
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error.message || 'Something went wrong. Please try again.'}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="border-t border-slate-200 bg-white px-4 py-3 sm:px-8"
+      >
+        <div className="mx-auto flex max-w-3xl items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleSubmit(e as unknown as React.FormEvent);
+              }
+            }}
+            placeholder="Ask about a trial, drug, target, or cancer indication…"
+            rows={1}
+            className={cn(
+              'flex-1 resize-none rounded-xl border border-slate-300 bg-white px-3 py-2',
+              'text-sm text-slate-900 placeholder:text-slate-400',
+              'focus:outline-none focus:ring-2 focus:ring-[var(--primary)]'
+            )}
+            disabled={isBusy}
+          />
+          <button
+            type="submit"
+            disabled={isBusy || !input.trim()}
+            className={cn(
+              'inline-flex h-10 w-10 items-center justify-center rounded-xl',
+              'bg-[var(--primary)] text-white transition',
+              'hover:bg-[var(--accent-dark)]',
+              'disabled:cursor-not-allowed disabled:opacity-50'
+            )}
+            aria-label="Send"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function EmptyState({ onPick }: { onPick: (q: string) => void }) {
+  const examples = [
+    'What are the active phase 3 trials in uveal melanoma?',
+    'Compare encorafenib vs dabrafenib mechanism and approval status.',
+    'Which targets have the strongest genetic association with cutaneous melanoma?',
+  ];
+  return (
+    <div className="flex flex-col items-center gap-6 py-16 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[var(--brand-accent-light)]">
+        <Sparkles className="h-6 w-6 text-[var(--primary)]" />
+      </div>
+      <div>
+        <h2 className="text-lg font-semibold text-slate-900">Bionocular Research Agent</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Oncology questions across trials, literature, compounds, targets, and our proprietary data.
+        </p>
+      </div>
+      <div className="grid w-full max-w-xl gap-2">
+        {examples.map((q) => (
+          <button
+            key={q}
+            type="button"
+            onClick={() => onPick(q)}
+            className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-left text-sm text-slate-700 hover:border-[var(--primary)] hover:text-slate-900"
+          >
+            {q}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/agent/MessageBubble.tsx
+++ b/web/src/components/agent/MessageBubble.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { cn } from '@/lib/utils';
+
+export interface MessageBubbleProps {
+  role: 'user' | 'assistant' | 'system';
+  text: string;
+}
+
+export function MessageBubble({ role, text }: MessageBubbleProps) {
+  const isUser = role === 'user';
+
+  return (
+    <div
+      className={cn(
+        'rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm',
+        isUser
+          ? 'bg-[var(--primary)] text-white max-w-[85%] self-end'
+          : 'bg-white border border-slate-200 text-slate-800 max-w-[90%] self-start'
+      )}
+    >
+      {isUser ? (
+        <p className="whitespace-pre-wrap">{text}</p>
+      ) : (
+        <div
+          className={cn(
+            'prose prose-sm max-w-none',
+            'prose-p:my-2 prose-headings:my-3 prose-ul:my-2 prose-ol:my-2',
+            'prose-code:px-1 prose-code:py-0.5 prose-code:bg-slate-100 prose-code:rounded prose-code:before:content-none prose-code:after:content-none'
+          )}
+        >
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/agent/ToolCard.tsx
+++ b/web/src/components/agent/ToolCard.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { CheckCircle2, Loader2, AlertCircle, Wrench } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type ToolState = 'input-streaming' | 'input-available' | 'output-available' | 'output-error';
+
+export interface ToolCardProps {
+  toolName: string;
+  state: ToolState;
+  input?: unknown;
+  output?: unknown;
+  errorText?: string;
+}
+
+const PRETTY_NAMES: Record<string, string> = {
+  search_pubmed:           'PubMed search',
+  search_clinical_trials:  'ClinicalTrials.gov search',
+  search_chembl:           'ChEMBL search',
+  query_open_targets:      'Open Targets query',
+  query_proprietary_data:  'Proprietary data query',
+  store_finding:           'Save finding',
+};
+
+export function ToolCard({ toolName, state, input, output, errorText }: ToolCardProps) {
+  const display = PRETTY_NAMES[toolName] ?? toolName;
+  const isError = state === 'output-error';
+  const isDone  = state === 'output-available';
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border bg-slate-50/80 px-3 py-2 text-xs',
+        isError
+          ? 'border-red-200 bg-red-50'
+          : isDone
+            ? 'border-emerald-200'
+            : 'border-slate-200'
+      )}
+    >
+      <div className="flex items-center gap-2 font-medium">
+        {isError ? (
+          <AlertCircle className="h-4 w-4 text-red-500" />
+        ) : isDone ? (
+          <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+        ) : (
+          <Loader2 className="h-4 w-4 animate-spin text-slate-500" />
+        )}
+        <Wrench className="h-3.5 w-3.5 text-slate-400" />
+        <span className="text-slate-700">{display}</span>
+      </div>
+
+      {input != null && state !== 'input-streaming' ? (
+        <details className="mt-1.5">
+          <summary className="cursor-pointer text-slate-500 hover:text-slate-700">
+            Input
+          </summary>
+          <pre className="mt-1 overflow-x-auto rounded bg-white p-2 text-[11px] text-slate-700">
+            {JSON.stringify(input, null, 2)}
+          </pre>
+        </details>
+      ) : null}
+
+      {output != null && isDone ? (
+        <details className="mt-1.5">
+          <summary className="cursor-pointer text-slate-500 hover:text-slate-700">
+            Result
+          </summary>
+          <pre className="mt-1 max-h-60 overflow-auto rounded bg-white p-2 text-[11px] text-slate-700">
+            {JSON.stringify(output, null, 2)}
+          </pre>
+        </details>
+      ) : null}
+
+      {isError && errorText ? (
+        <div className="mt-1.5 text-red-600">{errorText}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/nav/AgentNavLink.tsx
+++ b/web/src/components/nav/AgentNavLink.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Link from 'next/link';
+import { Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { ROUTES } from '@/lib/constants';
+
+export interface AgentNavLinkProps {
+  className?: string;
+}
+
+export function AgentNavLink({ className }: AgentNavLinkProps) {
+  return (
+    <Link
+      href={ROUTES.AGENT}
+      aria-label="Open AI agent"
+      className={cn(
+        'inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium',
+        'border-[var(--primary)] bg-white text-[var(--primary)]',
+        'transition-all duration-200 ease-out',
+        'hover:bg-[var(--brand-accent-light)] hover:shadow-md',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-white',
+        'min-h-[36px] sm:min-h-[38px]',
+        'active:scale-[0.98]',
+        className
+      )}
+    >
+      <Sparkles className="h-4 w-4 shrink-0 sm:h-[18px] sm:w-[18px]" aria-hidden />
+      <span>AI Agent</span>
+    </Link>
+  );
+}

--- a/web/src/lib/agent/prompts.ts
+++ b/web/src/lib/agent/prompts.ts
@@ -1,0 +1,36 @@
+export const ONCOLOGY_SYSTEM_PROMPT = `You are Bionocular's oncology research assistant. You serve clinical researchers, medical affairs teams, and oncology drug developers.
+
+DOMAIN
+- You only answer oncology-related questions: cancer biology, clinical trials, treatments, biomarkers, regulatory milestones, competitive landscape, and pipeline intelligence.
+- If a user asks something off-topic (general programming, non-oncology medicine, current events, personal advice), politely decline in one sentence and steer them back to oncology research.
+
+TOOL USE — STRICT ROUTING ORDER
+For every factual claim, you must consult tools rather than answer from memory. Use this priority order:
+
+1. query_proprietary_data — ALWAYS check this first for trial outcomes, landscape, competitive intelligence, anything Bionocular tracks internally. The user is paying for this differentiated data.
+2. search_clinical_trials — for live trial status, eligibility, sponsor, phase, sites. Source: ClinicalTrials.gov.
+3. search_pubmed — for peer-reviewed literature, abstracts, primary research. Source: PubMed/NCBI.
+4. search_chembl — for compound chemistry, bioactivity, mechanism of action, drug-target affinity. Source: ChEMBL.
+5. query_open_targets — for genetic/molecular target-disease associations, known drug evidence, pathway data. Source: Open Targets.
+6. web_search — for recent oncology industry news, conference coverage, deal/regulatory headlines, and clinical updates not yet indexed in PubMed. Restricted to OncLive, BioSpace, Targeted Oncology, and Cancer Network. Use only when the question is news-flavored or when the other tools return nothing useful.
+
+Combine tools when a question spans sources. Prefer one focused tool call over many speculative ones.
+
+CITATIONS — REQUIRED
+Every claim derived from a tool must carry an inline citation:
+- Trials: NCT IDs, e.g. (NCT04234567)
+- Literature: PMIDs, e.g. (PMID: 35123456)
+- Compounds: ChEMBL IDs, e.g. (CHEMBL25)
+- Targets: Open Targets ID or Ensembl ID
+- Proprietary: cite the source field returned by query_proprietary_data
+
+If a tool returns no results, say so explicitly. Never fabricate citations.
+
+SAVING FINDINGS
+When the user explicitly asks to save, bookmark, or remember a finding, call store_finding with a clear title, concise summary, and the citations array. Do not call store_finding unprompted.
+
+STYLE
+- Concise. Researchers value precision over prose.
+- Use markdown: short paragraphs, bullet lists, tables when comparing trials or compounds.
+- Surface uncertainty: "the published evidence is limited to N=12 patients"; "this trial is recruiting but no readout yet".
+- Never give medical advice to a patient. If a query reads like a patient asking about their own treatment, refer them to their oncologist.`;

--- a/web/src/lib/agent/rate-limit.ts
+++ b/web/src/lib/agent/rate-limit.ts
@@ -1,0 +1,17 @@
+import { createServiceClient } from '@/lib/supabase/service';
+
+/**
+ * Postgres-backed sliding-window rate limit. 20 requests per 60s per user
+ * (defaults baked into the SQL function). Returns true if the request is
+ * allowed and was recorded.
+ *
+ * Multi-instance safe — counter lives in Supabase Postgres, not memory.
+ */
+export async function checkAgentRateLimit(userId: string): Promise<boolean> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase.rpc('check_agent_rate_limit', {
+    p_user_id: userId,
+  });
+  if (error) throw new Error(`Rate limit check failed: ${error.message}`);
+  return data === true;
+}

--- a/web/src/lib/agent/tools/chembl.ts
+++ b/web/src/lib/agent/tools/chembl.ts
@@ -1,0 +1,50 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { fetchJson } from './fetch-with-retry';
+
+const CHEMBL = 'https://www.ebi.ac.uk/chembl/api/data';
+
+interface ChemblMolecule {
+  molecule_chembl_id: string;
+  pref_name: string | null;
+  max_phase: number | null;
+  molecule_type: string | null;
+  first_approval: number | null;
+  molecule_synonyms?: Array<{ molecule_synonym: string; syn_type: string }>;
+}
+
+interface ChemblSearchResponse {
+  molecules?: ChemblMolecule[];
+  page_meta?: { total_count?: number };
+}
+
+export const searchChemblTool = tool({
+  description:
+    'Search ChEMBL for drugs, compounds, and bioactivity. Use for: mechanism of action, ' +
+    'compound chemistry, approval status (max_phase), drug-target affinity. Best when you have ' +
+    'a compound name (generic or brand) or a known target.',
+  inputSchema: z.object({
+    query: z.string().describe('Compound name, e.g. "encorafenib", "trastuzumab"'),
+    limit: z.number().int().min(1).max(20).default(5),
+  }),
+  providerOptions: {
+    anthropic: { cacheControl: { type: 'ephemeral' } },
+  },
+  execute: async ({ query, limit }) => {
+    const url = `${CHEMBL}/molecule/search.json?q=${encodeURIComponent(query)}&limit=${limit}`;
+    const data = await fetchJson<ChemblSearchResponse>(url);
+
+    return {
+      query,
+      total: data.page_meta?.total_count ?? 0,
+      molecules: (data.molecules ?? []).map((m) => ({
+        chemblId:      m.molecule_chembl_id,
+        prefName:      m.pref_name,
+        maxPhase:      m.max_phase,
+        moleculeType:  m.molecule_type,
+        firstApproval: m.first_approval,
+        synonyms:      (m.molecule_synonyms ?? []).slice(0, 5).map((s) => s.molecule_synonym),
+      })),
+    };
+  },
+});

--- a/web/src/lib/agent/tools/clinical-trials.ts
+++ b/web/src/lib/agent/tools/clinical-trials.ts
@@ -1,0 +1,92 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { fetchJson } from './fetch-with-retry';
+import { normalizePhase, normalizeStatus } from '@/lib/clinical-trials-enums';
+
+const CT_API = 'https://clinicaltrials.gov/api/v2/studies';
+
+interface CtStudy {
+  protocolSection?: {
+    identificationModule?: { nctId?: string; briefTitle?: string };
+    statusModule?: { overallStatus?: string };
+    designModule?: { phases?: string[] };
+    sponsorCollaboratorsModule?: { leadSponsor?: { name?: string } };
+    conditionsModule?: { conditions?: string[] };
+    armsInterventionsModule?: { interventions?: Array<{ name?: string; type?: string }> };
+    eligibilityModule?: { eligibilityCriteria?: string };
+  };
+}
+
+interface CtResponse {
+  studies?: CtStudy[];
+  totalCount?: number;
+}
+
+export const searchClinicalTrialsTool = tool({
+  description:
+    'Search ClinicalTrials.gov for live trial status, eligibility, sponsors. Use for: trial ' +
+    'recruitment status, phase distribution by indication, competitor pipelines, eligibility ' +
+    'criteria. Filters: condition (e.g. "melanoma"), intervention (drug name), phase, status.',
+  inputSchema: z.object({
+    condition: z.string().optional().describe('Disease/cancer type (e.g. "uveal melanoma")'),
+    intervention: z.string().optional().describe('Drug or treatment name'),
+    phase: z.enum(['EARLY_PHASE1', 'PHASE1', 'PHASE2', 'PHASE3', 'PHASE4', 'NA']).optional(),
+    status: z.enum([
+      'RECRUITING',
+      'NOT_YET_RECRUITING',
+      'ACTIVE_NOT_RECRUITING',
+      'COMPLETED',
+      'TERMINATED',
+      'SUSPENDED',
+      'WITHDRAWN',
+      'ENROLLING_BY_INVITATION',
+      'UNKNOWN',
+    ]).optional(),
+    pageSize: z.number().int().min(1).max(20).default(10),
+  }),
+  providerOptions: {
+    anthropic: { cacheControl: { type: 'ephemeral' } },
+  },
+  execute: async ({ condition, intervention, phase, status, pageSize }) => {
+    const params = new URLSearchParams({
+      pageSize: String(pageSize),
+      format: 'json',
+      countTotal: 'true',
+    });
+    if (condition)    params.set('query.cond',  condition);
+    if (intervention) params.set('query.intr',  intervention);
+    if (phase)        params.set('filter.advanced', `AREA[Phase]${phase}`);
+    if (status)       params.set('filter.overallStatus', status);
+
+    const data = await fetchJson<CtResponse>(`${CT_API}?${params.toString()}`);
+
+    const trials = (data.studies ?? []).map((s) => {
+      const id  = s.protocolSection?.identificationModule;
+      const st  = s.protocolSection?.statusModule;
+      const dm  = s.protocolSection?.designModule;
+      const sp  = s.protocolSection?.sponsorCollaboratorsModule;
+      const cm  = s.protocolSection?.conditionsModule;
+      const ai  = s.protocolSection?.armsInterventionsModule;
+      const el  = s.protocolSection?.eligibilityModule;
+
+      return {
+        nctId:         id?.nctId ?? '',
+        title:         id?.briefTitle ?? '',
+        status:        normalizeStatus(st?.overallStatus ?? 'UNKNOWN'),
+        phases:        (dm?.phases ?? []).map(normalizePhase),
+        sponsor:       sp?.leadSponsor?.name ?? '',
+        conditions:    cm?.conditions ?? [],
+        interventions: (ai?.interventions ?? []).map((i) => ({
+          name: i.name ?? '',
+          type: i.type ?? '',
+        })),
+        eligibility:   el?.eligibilityCriteria?.slice(0, 600) ?? '',
+      };
+    });
+
+    return {
+      total: data.totalCount ?? trials.length,
+      trials,
+    };
+  },
+});

--- a/web/src/lib/agent/tools/fetch-with-retry.ts
+++ b/web/src/lib/agent/tools/fetch-with-retry.ts
@@ -1,0 +1,28 @@
+import pRetry from 'p-retry';
+
+export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  return pRetry(
+    async () => {
+      const res = await fetch(url, init);
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`HTTP ${res.status} ${url} — ${body.slice(0, 200)}`);
+      }
+      return res.json() as Promise<T>;
+    },
+    { retries: 3, minTimeout: 500, factor: 2 }
+  );
+}
+
+export async function fetchText(url: string, init?: RequestInit): Promise<string> {
+  return pRetry(
+    async () => {
+      const res = await fetch(url, init);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status} ${url}`);
+      }
+      return res.text();
+    },
+    { retries: 3, minTimeout: 500, factor: 2 }
+  );
+}

--- a/web/src/lib/agent/tools/index.ts
+++ b/web/src/lib/agent/tools/index.ts
@@ -1,0 +1,29 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { searchPubmedTool } from './pubmed';
+import { searchClinicalTrialsTool } from './clinical-trials';
+import { searchChemblTool } from './chembl';
+import { queryOpenTargetsTool } from './open-targets';
+import { buildSupabaseTools } from './supabase';
+
+const ONCOLOGY_NEWS_DOMAINS = [
+  'onclive.com',
+  'biospace.com',
+  'targetedonc.com',
+  'cancernetwork.com',
+];
+
+export function agentTools(userId: string) {
+  return {
+    search_pubmed:           searchPubmedTool,
+    search_clinical_trials:  searchClinicalTrialsTool,
+    search_chembl:           searchChemblTool,
+    query_open_targets:      queryOpenTargetsTool,
+    web_search: anthropic.tools.webSearch_20250305({
+      maxUses: 3,
+      allowedDomains: ONCOLOGY_NEWS_DOMAINS,
+    }),
+    ...buildSupabaseTools(userId),
+  };
+}
+
+export type AgentTools = ReturnType<typeof agentTools>;

--- a/web/src/lib/agent/tools/open-targets.ts
+++ b/web/src/lib/agent/tools/open-targets.ts
@@ -1,0 +1,130 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { fetchJson } from './fetch-with-retry';
+
+const OT_GRAPHQL = 'https://api.platform.opentargets.org/api/v4/graphql';
+
+const DISEASE_TARGETS_QUERY = `
+  query DiseaseTargets($efoId: String!, $size: Int!) {
+    disease(efoId: $efoId) {
+      id
+      name
+      associatedTargets(page: { index: 0, size: $size }) {
+        rows {
+          target { id approvedSymbol approvedName }
+          score
+          datatypeScores { id score }
+        }
+      }
+      knownDrugs(size: $size) {
+        rows {
+          drug { id name }
+          mechanismOfAction
+          phase
+          status
+          ctIds
+        }
+      }
+    }
+  }
+`;
+
+const SEARCH_DISEASE_QUERY = `
+  query SearchDisease($q: String!) {
+    search(queryString: $q, entityNames: ["disease"], page: { index: 0, size: 5 }) {
+      hits { id name entity }
+    }
+  }
+`;
+
+interface GraphqlResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}
+
+interface SearchData {
+  search: { hits: Array<{ id: string; name: string; entity: string }> };
+}
+
+interface DiseaseData {
+  disease: {
+    id: string;
+    name: string;
+    associatedTargets: {
+      rows: Array<{
+        target: { id: string; approvedSymbol: string; approvedName: string };
+        score: number;
+        datatypeScores: Array<{ id: string; score: number }>;
+      }>;
+    };
+    knownDrugs: {
+      rows: Array<{
+        drug: { id: string; name: string };
+        mechanismOfAction: string;
+        phase: number;
+        status: string;
+        ctIds: string[];
+      }>;
+    } | null;
+  };
+}
+
+async function gql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const data = await fetchJson<GraphqlResponse<T>>(OT_GRAPHQL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (data.errors?.length) {
+    throw new Error(`Open Targets GraphQL error: ${data.errors.map((e) => e.message).join('; ')}`);
+  }
+  if (!data.data) throw new Error('Open Targets returned no data');
+  return data.data;
+}
+
+export const queryOpenTargetsTool = tool({
+  description:
+    'Query Open Targets for disease-target-drug associations and genetic evidence. Pass a disease ' +
+    'name (e.g. "cutaneous melanoma") and the tool resolves it to an EFO ID, then returns top ' +
+    'associated targets and known drugs with mechanism + phase. Best for understanding the ' +
+    'biological landscape of a cancer indication.',
+  inputSchema: z.object({
+    disease: z.string().describe('Disease name (e.g. "uveal melanoma")'),
+    size: z.number().int().min(1).max(15).default(8),
+  }),
+  providerOptions: {
+    anthropic: { cacheControl: { type: 'ephemeral' } },
+  },
+  execute: async ({ disease, size }) => {
+    const search = await gql<SearchData>(SEARCH_DISEASE_QUERY, { q: disease });
+    const hit = search.search.hits[0];
+    if (!hit) {
+      return { disease, resolved: null, targets: [], drugs: [] };
+    }
+
+    const result = await gql<DiseaseData>(DISEASE_TARGETS_QUERY, {
+      efoId: hit.id,
+      size,
+    });
+
+    return {
+      disease,
+      resolved: { efoId: result.disease.id, name: result.disease.name },
+      targets: result.disease.associatedTargets.rows.map((r) => ({
+        targetId:        r.target.id,
+        symbol:          r.target.approvedSymbol,
+        name:            r.target.approvedName,
+        overallScore:    r.score,
+        evidenceByType:  r.datatypeScores,
+      })),
+      drugs: (result.disease.knownDrugs?.rows ?? []).map((d) => ({
+        drugId:            d.drug.id,
+        name:              d.drug.name,
+        mechanismOfAction: d.mechanismOfAction,
+        phase:             d.phase,
+        status:            d.status,
+        nctIds:            d.ctIds,
+      })),
+    };
+  },
+});

--- a/web/src/lib/agent/tools/pubmed.ts
+++ b/web/src/lib/agent/tools/pubmed.ts
@@ -1,0 +1,75 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { getServerEnv } from '@/lib/env';
+import { fetchJson, fetchText } from './fetch-with-retry';
+
+const ESEARCH = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi';
+const EFETCH  = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi';
+
+interface ESearchResponse {
+  esearchresult: { idlist: string[]; count: string };
+}
+
+interface PubmedHit {
+  pmid: string;
+  title: string;
+  abstract: string;
+  authors: string[];
+  journal: string;
+  year: string;
+}
+
+function parsePubmedXml(xml: string): PubmedHit[] {
+  const articles = xml.split('<PubmedArticle>').slice(1);
+  return articles.map((chunk) => {
+    const pmid     = chunk.match(/<PMID[^>]*>([^<]+)<\/PMID>/)?.[1] ?? '';
+    const title    = chunk.match(/<ArticleTitle>([\s\S]*?)<\/ArticleTitle>/)?.[1]?.replace(/<[^>]+>/g, '') ?? '';
+    const abstract = [...chunk.matchAll(/<AbstractText[^>]*>([\s\S]*?)<\/AbstractText>/g)]
+      .map((m) => m[1].replace(/<[^>]+>/g, '').trim())
+      .join('\n');
+    const journal  = chunk.match(/<Title>([^<]+)<\/Title>/)?.[1] ?? '';
+    const year     = chunk.match(/<PubDate>[\s\S]*?<Year>(\d{4})<\/Year>/)?.[1] ?? '';
+    const authors  = [...chunk.matchAll(/<Author[^>]*>[\s\S]*?<LastName>([^<]+)<\/LastName>[\s\S]*?<ForeName>([^<]+)<\/ForeName>/g)]
+      .map((m) => `${m[2]} ${m[1]}`)
+      .slice(0, 5);
+    return { pmid, title, abstract, authors, journal, year };
+  });
+}
+
+export const searchPubmedTool = tool({
+  description:
+    'Search PubMed for peer-reviewed oncology literature. Use for primary research, abstracts, ' +
+    'systematic reviews, mechanistic studies. Prefer specific cancer-type and intervention terms ' +
+    '(e.g. "BRAF V600E melanoma resistance encorafenib"). Returns PMID, title, abstract, authors, ' +
+    'journal, year.',
+  inputSchema: z.object({
+    query: z.string().describe('PubMed query string. Use MeSH terms or free text.'),
+    maxResults: z.number().int().min(1).max(20).default(5),
+  }),
+  providerOptions: {
+    anthropic: { cacheControl: { type: 'ephemeral' } },
+  },
+  execute: async ({ query, maxResults }) => {
+    const { pubmedApiKey } = getServerEnv();
+    const keyParam = pubmedApiKey ? `&api_key=${pubmedApiKey}` : '';
+
+    const search = await fetchJson<ESearchResponse>(
+      `${ESEARCH}?db=pubmed&term=${encodeURIComponent(query)}&retmode=json&retmax=${maxResults}${keyParam}`
+    );
+
+    const ids = search.esearchresult.idlist;
+    if (ids.length === 0) {
+      return { results: [], total: 0, query };
+    }
+
+    const xml = await fetchText(
+      `${EFETCH}?db=pubmed&id=${ids.join(',')}&retmode=xml${keyParam}`
+    );
+
+    return {
+      query,
+      total: parseInt(search.esearchresult.count, 10),
+      results: parsePubmedXml(xml),
+    };
+  },
+});

--- a/web/src/lib/agent/tools/supabase.ts
+++ b/web/src/lib/agent/tools/supabase.ts
@@ -1,0 +1,77 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { createServiceClient } from '@/lib/supabase/service';
+
+const ALLOWED_TABLES = ['clinical_trials', 'trial_outcomes', 'trial_landscape'] as const;
+type AllowedTable = typeof ALLOWED_TABLES[number];
+
+export function buildSupabaseTools(userId: string) {
+  return {
+    query_proprietary_data: tool({
+      description:
+        "Query Bionocular's proprietary trial database. ALWAYS try this first before public " +
+        'sources. Tables: ' +
+        '`clinical_trials` (live trial registry mirror with our enrichments), ' +
+        '`trial_outcomes` (extracted efficacy/safety endpoints from abstracts and publications), ' +
+        '`trial_landscape` (denormalized view joining trials, outcomes, cancer-type tags). ' +
+        'Filter by NCT ID, cancer_type, sponsor, phase, or any column. Returns up to 25 rows.',
+      inputSchema: z.object({
+        table: z.enum(ALLOWED_TABLES),
+        filters: z
+          .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+          .optional()
+          .describe('Equality filters keyed by column. e.g. { cancer_type: "Cutaneous Melanoma" }'),
+        limit: z.number().int().min(1).max(25).default(10),
+      }),
+      providerOptions: {
+        anthropic: { cacheControl: { type: 'ephemeral' } },
+      },
+      execute: async ({ table, filters, limit }) => {
+        const supabase = createServiceClient();
+        let q = supabase.from(table as AllowedTable).select('*').limit(limit);
+        if (filters) {
+          for (const [k, v] of Object.entries(filters)) {
+            q = q.eq(k, v);
+          }
+        }
+        const { data, error } = await q;
+        if (error) throw new Error(`Supabase query failed: ${error.message}`);
+        return { table, count: data?.length ?? 0, rows: data ?? [] };
+      },
+    }),
+
+    store_finding: tool({
+      description:
+        'Persist a research finding for the user. Call only when the user explicitly asks to ' +
+        'save, bookmark, or remember something. Provide a concise title, a 1-3 sentence summary, ' +
+        'and the citations array (NCT IDs, PMIDs, ChEMBL IDs, etc).',
+      inputSchema: z.object({
+        findingType: z.enum(['trial', 'literature', 'compound', 'target', 'landscape', 'other']),
+        title: z.string().min(3).max(200),
+        summary: z.string().min(10).max(2000),
+        sourceTool: z.string().describe('Which tool produced this (e.g. "search_clinical_trials")'),
+        citations: z.array(z.string()).default([]),
+      }),
+      providerOptions: {
+        anthropic: { cacheControl: { type: 'ephemeral' } },
+      },
+      execute: async ({ findingType, title, summary, sourceTool, citations }) => {
+        const supabase = createServiceClient();
+        const { data, error } = await supabase
+          .from('agent_findings')
+          .insert({
+            user_id: userId,
+            finding_type: findingType,
+            title,
+            summary,
+            source_tool: sourceTool,
+            citations,
+          })
+          .select('id')
+          .single();
+        if (error) throw new Error(`store_finding failed: ${error.message}`);
+        return { ok: true, id: data.id };
+      },
+    }),
+  };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -55,36 +55,8 @@ export function getDbCancerType(slug: string): string {
   return map[slug] || slug;
 }
 
-/** ClinicalTrials.gov API v2 phase enum → human-readable label */
-const PHASE_MAP: Record<string, string> = {
-  'EARLY_PHASE1': 'Early Phase 1',
-  'PHASE1':       'Phase 1',
-  'PHASE2':       'Phase 2',
-  'PHASE3':       'Phase 3',
-  'PHASE4':       'Phase 4',
-  'NA':           'Not applicable',
-};
-
-/** ClinicalTrials.gov API v2 status enum → human-readable label */
-const STATUS_MAP: Record<string, string> = {
-  'RECRUITING':              'Recruiting',
-  'NOT_YET_RECRUITING':      'Not yet recruiting',
-  'ACTIVE_NOT_RECRUITING':   'Active, not recruiting',
-  'COMPLETED':               'Completed',
-  'TERMINATED':              'Terminated',
-  'SUSPENDED':               'Suspended',
-  'WITHDRAWN':               'Withdrawn',
-  'ENROLLING_BY_INVITATION': 'Enrolling by invitation',
-  'UNKNOWN':                 'Unknown',
-};
-
-export function normalizePhase(raw: string): string {
-  return PHASE_MAP[raw] ?? raw;
-}
-
-export function normalizeStatus(raw: string): string {
-  return STATUS_MAP[raw] ?? raw;
-}
+import { normalizePhase, normalizeStatus } from './clinical-trials-enums';
+export { PHASE_MAP, STATUS_MAP, normalizePhase, normalizeStatus } from './clinical-trials-enums';
 
 
 export const trialsApi = {

--- a/web/src/lib/clinical-trials-enums.ts
+++ b/web/src/lib/clinical-trials-enums.ts
@@ -1,0 +1,30 @@
+/** ClinicalTrials.gov API v2 phase enum → human-readable label */
+export const PHASE_MAP: Record<string, string> = {
+  'EARLY_PHASE1': 'Early Phase 1',
+  'PHASE1':       'Phase 1',
+  'PHASE2':       'Phase 2',
+  'PHASE3':       'Phase 3',
+  'PHASE4':       'Phase 4',
+  'NA':           'Not applicable',
+};
+
+/** ClinicalTrials.gov API v2 status enum → human-readable label */
+export const STATUS_MAP: Record<string, string> = {
+  'RECRUITING':              'Recruiting',
+  'NOT_YET_RECRUITING':      'Not yet recruiting',
+  'ACTIVE_NOT_RECRUITING':   'Active, not recruiting',
+  'COMPLETED':               'Completed',
+  'TERMINATED':              'Terminated',
+  'SUSPENDED':               'Suspended',
+  'WITHDRAWN':               'Withdrawn',
+  'ENROLLING_BY_INVITATION': 'Enrolling by invitation',
+  'UNKNOWN':                 'Unknown',
+};
+
+export function normalizePhase(raw: string): string {
+  return PHASE_MAP[raw] ?? raw;
+}
+
+export function normalizeStatus(raw: string): string {
+  return STATUS_MAP[raw] ?? raw;
+}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -11,6 +11,7 @@ export const ROUTES = {
   RESET_PASSWORD: '/reset-password',
   DASHBOARD: '/dashboard',
   ANALYTICS: '/analytics',
+  AGENT: '/agent',
 } as const;
 
 export const PUBLIC_ROUTES = [

--- a/web/src/lib/env.ts
+++ b/web/src/lib/env.ts
@@ -48,3 +48,23 @@ export const isDevelopment = env.nodeEnv === 'development';
  */
 export const isProduction = env.nodeEnv === 'production';
 
+/**
+ * Server-only environment variables.
+ *
+ * Lazy access — only call from server code (route handlers, server components, server actions).
+ * Throws at call time if the var is missing, so importing this module in a client bundle is safe.
+ */
+function requireServerEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`Missing required server env var: ${key}`);
+  return value;
+}
+
+export function getServerEnv() {
+  return {
+    supabaseSecretKey: requireServerEnv('SUPABASE_SECRET_KEY'),
+    anthropicApiKey: requireServerEnv('ANTHROPIC_API_KEY'),
+    pubmedApiKey: process.env.PUBMED_API_KEY,
+  };
+}
+

--- a/web/src/lib/supabase/service.ts
+++ b/web/src/lib/supabase/service.ts
@@ -1,0 +1,17 @@
+import { createClient } from '@supabase/supabase-js';
+import { env, getServerEnv } from '@/lib/env';
+
+/**
+ * Server-only Supabase client using the secret key. Bypasses RLS.
+ *
+ * NEVER import from a client component or any file that ships to the browser.
+ * Use only inside route handlers, server actions, or server components that
+ * need privileged writes (e.g. inserting rate-limit rows, persisting agent
+ * findings on behalf of a user).
+ */
+export function createServiceClient() {
+  const { supabaseSecretKey } = getServerEnv();
+  return createClient(env.supabase.url, supabaseSecretKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}

--- a/web/supabase/migrations/20260426114757_agent.sql
+++ b/web/supabase/migrations/20260426114757_agent.sql
@@ -1,0 +1,72 @@
+-- Agent findings: things the assistant saved on behalf of a user.
+CREATE TABLE agent_findings (
+  id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id     UUID REFERENCES auth.users(id) NOT NULL,
+  finding_type TEXT NOT NULL,
+  title       TEXT NOT NULL,
+  summary     TEXT NOT NULL,
+  source_tool TEXT NOT NULL,
+  citations   JSONB DEFAULT '[]',
+  metadata    JSONB DEFAULT '{}',
+  created_at  TIMESTAMPTZ DEFAULT now()
+);
+
+-- Persisted chat history.
+CREATE TABLE chat_sessions (
+  id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id     UUID REFERENCES auth.users(id) NOT NULL,
+  title       TEXT,
+  messages    JSONB NOT NULL DEFAULT '[]',
+  token_usage JSONB,
+  created_at  TIMESTAMPTZ DEFAULT now(),
+  updated_at  TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_chat_sessions_user_updated   ON chat_sessions(user_id, updated_at DESC);
+CREATE INDEX idx_agent_findings_user_created  ON agent_findings(user_id, created_at DESC);
+
+ALTER TABLE agent_findings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE chat_sessions  ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "own_findings" ON agent_findings FOR ALL USING (auth.uid() = user_id);
+CREATE POLICY "own_sessions" ON chat_sessions  FOR ALL USING (auth.uid() = user_id);
+
+-- Per-user sliding-window rate limiter. Accessed only via the SECURITY DEFINER
+-- RPC below (which bypasses RLS) using the secret key. RLS is enabled with no
+-- policies as defense-in-depth so anon/authenticated keys can't reach it via
+-- PostgREST even if the table is accidentally exposed.
+CREATE TABLE agent_rate_limit (
+  user_id UUID NOT NULL,
+  ts      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, ts)
+);
+
+CREATE INDEX idx_agent_rate_limit_user_ts ON agent_rate_limit(user_id, ts DESC);
+
+ALTER TABLE agent_rate_limit ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION check_agent_rate_limit(
+  p_user_id        UUID,
+  p_max            INT DEFAULT 20,
+  p_window_seconds INT DEFAULT 60
+) RETURNS BOOLEAN AS $$
+DECLARE
+  current_count INT;
+BEGIN
+  DELETE FROM agent_rate_limit
+    WHERE user_id = p_user_id
+      AND ts < now() - (p_window_seconds || ' seconds')::interval;
+
+  SELECT COUNT(*) INTO current_count
+    FROM agent_rate_limit
+    WHERE user_id = p_user_id
+      AND ts > now() - (p_window_seconds || ' seconds')::interval;
+
+  IF current_count >= p_max THEN
+    RETURN FALSE;
+  END IF;
+
+  INSERT INTO agent_rate_limit(user_id) VALUES (p_user_id);
+  RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
Streaming Claude Sonnet 4.6 chat with server-side tools for PubMed, ClinicalTrials.gov, ChEMBL, Open Targets, Supabase proprietary data, and domain-restricted Anthropic web search (OncLive, BioSpace, Targeted Oncology, Cancer Network). Postgres-backed sliding-window rate limit (20 req/min/user) via SECURITY DEFINER RPC, ephemeral prompt caching on system + tool defs, and chat history persisted to chat_sessions with RLS.