### PR TITLE
feat(melanoma): live news feed pipeline — scrapers, Gemini extraction, Supabase uploa

### DIFF
--- a/.github/workflows/scrape-news.yml
+++ b/.github/workflows/scrape-news.yml
@@ -1,0 +1,63 @@
+name: Scrape Oncology News
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # 03:00 UTC daily (~04:00 CET / 05:00 CEST)
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'Backfill from date (YYYY-MM-DD), e.g. 2026-02-06'
+        required: false
+        default: ''
+      source:
+        description: 'Single source to run (onclive|cancernetwork|targetedonc|biospace)'
+        required: false
+        default: ''
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Cache venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: melanoma/.venv
+          key: venv-news-${{ runner.os }}-py3.11-${{ hashFiles('melanoma/poetry.lock') }}
+
+      - name: Install dependencies (main only)
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        working-directory: ./melanoma
+        run: poetry install --no-interaction --no-root --only main
+
+      - name: Run news scraper
+        working-directory: ./melanoma
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          ARGS="--days 2"
+          if [ -n "${{ github.event.inputs.since }}" ]; then
+            ARGS="--since ${{ github.event.inputs.since }}"
+          fi
+          if [ -n "${{ github.event.inputs.source }}" ]; then
+            ARGS="$ARGS --source ${{ github.event.inputs.source }}"
+          fi
+          poetry run python3 scripts/scrape_news_supabase.py $ARGS

--- a/.github/workflows/scrape-news.yml
+++ b/.github/workflows/scrape-news.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           ARGS="--days 2"
           if [ -n "${{ github.event.inputs.since }}" ]; then

--- a/melanoma/poetry.lock
+++ b/melanoma/poetry.lock
@@ -354,18 +354,18 @@ typecheck = ["mypy"]
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.13.5"
+version = "4.14.3"
 description = "Screen-scraping library"
 optional = false
 python-versions = ">=3.7.0"
-groups = ["processing"]
+groups = ["main", "processing"]
 files = [
-    {file = "beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a"},
-    {file = "beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695"},
+    {file = "beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb"},
+    {file = "beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86"},
 ]
 
 [package.dependencies]
-soupsieve = ">1.2"
+soupsieve = ">=1.6.1"
 typing-extensions = ">=4.0.0"
 
 [package.extras]
@@ -1019,6 +1019,21 @@ typing-extensions = ">=4.8.0"
 all = ["email-validator (>=2.0.0)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.5)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "feedparser"
+version = "6.0.12"
+description = "Universal feed parser, handles RSS 0.9x, RSS 1.0, RSS 2.0, CDF, Atom 0.3, and Atom 1.0 feeds"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324"},
+    {file = "feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228"},
+]
+
+[package.dependencies]
+sgmllib3k = "*"
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 description = "A platform independent file lock."
@@ -1286,7 +1301,7 @@ google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.63.2,<2.0.0"
 grpcio = [
     {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
-    {version = ">=1.33.2,<2.0.0", optional = true, markers = "extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0.0", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
 ]
 grpcio-status = [
     {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
@@ -2298,6 +2313,156 @@ openai-agents = ["openai-agents (>=0.0.3)"]
 otel = ["opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http (>=1.30.0)", "opentelemetry-sdk (>=1.30.0)"]
 pytest = ["pytest (>=7.0.0)", "rich (>=13.9.4)", "vcrpy (>=7.0.0)"]
 vcr = ["vcrpy (>=7.0.0)"]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "lxml-6.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:41dcc4c7b10484257cbd6c37b83ddb26df2b0e5aff5ac00d095689015af868ec"},
+    {file = "lxml-6.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a31286dbb5e74c8e9a5344465b77ab4c5bd511a253b355b5ca2fae7e579fafec"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1bc4cc83fb7f66ffb16f74d6dd0162e144333fc36ebcce32246f80c8735b2551"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:20cf4d0651987c906a2f5cba4e3a8d6ba4bfdf973cfe2a96c0d6053888ea2ecd"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffb34ea45a82dd637c2c97ae1bbb920850c1e59bcae79ce1c15af531d83e7215"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1d9b99e5b2597e4f5aed2484fef835256fa1b68a19e4265c97628ef4bf8bcf4"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:d43aa26dcda363f21e79afa0668f5029ed7394b3bb8c92a6927a3d34e8b610ea"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:6262b87f9e5c1e5fe501d6c153247289af42eb44ad7660b9b3de17baaf92d6f6"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d1392c569c032f78a11a25d1de1c43fff13294c793b39e19d84fade3045cbbc3"},
+    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:045e387d1f4f42a418380930fa3f45c73c9b392faf67e495e58902e68e8f44a7"},
+    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:9f93d5b8b07f73e8c77e3c6556a3db269918390c804b5e5fcdd4858232cc8f16"},
+    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:de550d129f18d8ab819651ffe4f38b1b713c7e116707de3c0c6400d0ef34fbc1"},
+    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c08da09dc003c9e8c70e06b53a11db6fb3b250c21c4236b03c7d7b443c318e7a"},
+    {file = "lxml-6.1.0-cp310-cp310-win32.whl", hash = "sha256:37448bf9c7d7adfc5254763901e2bbd6bb876228dfc1fc7f66e58c06368a7544"},
+    {file = "lxml-6.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:2593a0a6621545b9095b71ad74ed4226eba438a7d9fc3712a99bdb15508cf93a"},
+    {file = "lxml-6.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:e80807d72f96b96ad5588cb85c75616e4f2795a7737d4630784c51497beb7776"},
+    {file = "lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9"},
+    {file = "lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a"},
+    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3"},
+    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9"},
+    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11"},
+    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4"},
+    {file = "lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3"},
+    {file = "lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7"},
+    {file = "lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39"},
+    {file = "lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d"},
+    {file = "lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d"},
+    {file = "lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f"},
+    {file = "lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366"},
+    {file = "lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819"},
+    {file = "lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45"},
+    {file = "lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33"},
+    {file = "lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62"},
+    {file = "lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16"},
+    {file = "lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d"},
+    {file = "lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8"},
+    {file = "lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585"},
+    {file = "lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f"},
+    {file = "lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120"},
+    {file = "lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946"},
+    {file = "lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c"},
+    {file = "lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180"},
+    {file = "lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2"},
+    {file = "lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5"},
+    {file = "lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac"},
+    {file = "lxml-6.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b6c2f225662bc5ad416bdd06f72ca301b31b39ce4261f0e0097017fc2891b940"},
+    {file = "lxml-6.1.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a86f06f059e22a0d574990ee2df24ede03f7f3c68c1336293eee9536c4c776cd"},
+    {file = "lxml-6.1.0-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:468479e52ecf3ec23799c863336d02c05fc2f7ffd1a1424eeeb9a28d4eb69d13"},
+    {file = "lxml-6.1.0-cp38-cp38-manylinux_2_28_i686.whl", hash = "sha256:a02ca8fe48815bddcfca3248efe54451abb9dbf2f7d1c5744c8aa4142d476919"},
+    {file = "lxml-6.1.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bb40648d96157f9081886defe13eac99253e663be969ff938a9289eff6e47b72"},
+    {file = "lxml-6.1.0-cp38-cp38-win32.whl", hash = "sha256:1dd6a1c3ad4cb674f44525d9957f3e9c209bb6dd9213245195167a281fcc2bdc"},
+    {file = "lxml-6.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:4e2c54d6b47361d0f1d3bc8d4e082ad87201e56ccdcca4d3b9ee3644ff595ec8"},
+    {file = "lxml-6.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:920354904d1cb86577d4b3cfe2830c2dbe81d6f4449e57ada428f1609b5985f7"},
+    {file = "lxml-6.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c871299c595ee004d186f61840f0bfc4941aa3f17c8ba4a565ead7e4f4f820ee"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d0d799ff958655781296ec870d5e2448e75150da2b3d07f13ff5b0c2c35beefd"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ba11752e346bd804ea312ec2eea2532dfa8b8d3261d81a32ef9e6ab16256280"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26c5272c6a4bf4cf32d3f5a7890c942b0e04438691157d341616d02cca74d4bd"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c53fa3a5a52122d590e847a57ccf955557b9634a7f99ff5a35131321b0a85317"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_28_i686.whl", hash = "sha256:76b958b4ea3104483c20f74866d55aa056546e15ebe83dd7aecd63698f43b755"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:8c11b984b5ce6add4dccc7144c7be5d364d298f15b0c6a57da1991baedc750ce"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d3829a6e6fd550a219564912d4002c537f65da4c6ae4e093cc34462f4fa027ad"},
+    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:52b0ac6903cf74ebf997eb8c682d2fbac7d1ab7e4c552413eec55868a9b73f39"},
+    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:29f5c00cb7d752bce2c70ebd2d31b0a42f9499ffdd3ecb2f31a5b73ee43031ad"},
+    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:c748ebcb6877de89f48ab90ca96642ac458fff5dec291a2b9337cd4d0934e383"},
+    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:08950a23f296b3f83521577274e3d3b0f3d739bf2e68d01a752e4288bc50d286"},
+    {file = "lxml-6.1.0-cp39-cp39-win32.whl", hash = "sha256:11a873c77a181b4fef9c2e357d08ed399542c2af1390101da66720a19c7c9618"},
+    {file = "lxml-6.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:81ff55c70b67d19d52b6fd118a114c0a4c97d799cd3089ff9bd9e2ff4b414ee2"},
+    {file = "lxml-6.1.0-cp39-cp39-win_arm64.whl", hash = "sha256:481d6e2104285d9add34f41b42b247b76b61c5b5c26c303c2e9707bbf8bd9a64"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace"},
+    {file = "lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13"},
+]
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html-clean = ["lxml_html_clean"]
+html5 = ["html5lib"]
+htmlsoup = ["BeautifulSoup4"]
 
 [[package]]
 name = "mako"
@@ -3379,8 +3544,8 @@ files = [
 numpy = [
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.5", markers = "python_version == \"3.11\""},
-    {version = ">=1.21.4", markers = "python_version == \"3.10\" and platform_system == \"Darwin\""},
-    {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version == \"3.10\""},
+    {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\""},
+    {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version >= \"3.10\""},
 ]
 
 [[package]]
@@ -5743,6 +5908,17 @@ test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=
 type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
 
 [[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+description = "Py3k port of sgmllib."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9"},
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
@@ -5784,7 +5960,7 @@ version = "2.7"
 description = "A modern CSS selector implementation for Beautiful Soup."
 optional = false
 python-versions = ">=3.8"
-groups = ["processing"]
+groups = ["main", "processing"]
 files = [
     {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
     {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
@@ -7117,4 +7293,4 @@ cffi = ["cffi (>=1.17) ; python_version >= \"3.13\" and platform_python_implemen
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "3574bfb98f99f818df2c7d3e62008f9e69cb7c805612f1591231ac3362a8abfd"
+content-hash = "18a52ac97bdf3a15b8d6cff9826931b38d08d2369a3bf57bcbaace8c33f83b9f"

--- a/melanoma/poetry.lock
+++ b/melanoma/poetry.lock
@@ -1406,6 +1406,23 @@ protobuf = ">=3.20.2,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4
 grpc = ["grpcio (>=1.44.0,<2.0.0)"]
 
 [[package]]
+name = "googlenewsdecoder"
+version = "0.1.7"
+description = "A Python package to decode Google News URLs to their original sources."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "googlenewsdecoder-0.1.7-py3-none-any.whl", hash = "sha256:a8be897bb41864a82d81da6e05777d8c795989cf65f14b41e8e772b3f5a8354d"},
+    {file = "googlenewsdecoder-0.1.7.tar.gz", hash = "sha256:0fcd8fa2aa6a145f84798921aeef0ec45d40bcf5ceebb467742f0efd068d3902"},
+]
+
+[package.dependencies]
+pysocks = ">=1.7.1"
+requests = ">=2.32.3"
+selectolax = ">=0.3.27"
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 description = "Lightweight in-process concurrent programming"
@@ -5011,6 +5028,19 @@ files = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+groups = ["main"]
+files = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
+]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
@@ -5859,6 +5889,162 @@ numpy = ">=1.23.5,<2.5"
 dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy (==1.10.0)", "pycodestyle", "pydevtool", "rich-click", "ruff (>=0.0.292)", "types-psutil", "typing_extensions"]
 doc = ["intersphinx_registry", "jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.19.1)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0,<8.0.0)", "sphinx-copybutton", "sphinx-design (>=0.4.0)"]
 test = ["Cython", "array-api-strict (>=2.0,<2.1.1)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja ; sys_platform != \"emscripten\"", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+
+[[package]]
+name = "selectolax"
+version = "0.4.1"
+description = "Fast HTML5 parser with CSS selectors."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version >= \"3.14\""
+files = [
+    {file = "selectolax-0.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e2c39bffad15247afe4cef9fcc752879ad68e7c872be750448aca3b1fa5e5ece"},
+    {file = "selectolax-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed4e2144b0d4c518480bdbf7dc1f595219c4f91cfcfb48b716a083575d439806"},
+    {file = "selectolax-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1436837403871249ec6bb7c1b7fc571996e3e49fe9042a0631f15c8255664e07"},
+    {file = "selectolax-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d856ddff667ac9fde529228719e142cd4a4cf033d41b7e5da20e216fdcc3f974"},
+    {file = "selectolax-0.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:21ca0ddaf259abc7adea24bb8e48852aab8937e12d7343a401a08a5be185f984"},
+    {file = "selectolax-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9c5c7a11d5e688ba30eb0df18829eebe77d527324dfd6273a8ea5f32367b439b"},
+    {file = "selectolax-0.4.1-cp310-cp310-win32.whl", hash = "sha256:c366e0618c215029f6dd37717acc092387107fdbaf5c9d1595356e943824778c"},
+    {file = "selectolax-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:5387c4673c460516a7e42cd9d3d7a68a7f4738d11f35e1e6e4c5d0c80a7446ea"},
+    {file = "selectolax-0.4.1-cp310-cp310-win_arm64.whl", hash = "sha256:b47474ecd10c6142f5543c6d2cb7449c073dd4930a4761808cf40c173eeca273"},
+    {file = "selectolax-0.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7fdb85ee8019ae6507ead4ed6763cf42b0ef9732fa4c1db80756ab6e330b99a9"},
+    {file = "selectolax-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0d4d9324ba9b3fd814f670fa00721dd1e034f83cce9ae5669abf1d20e6506845"},
+    {file = "selectolax-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b09c36be9aff672686b180a0c684426a8fa9881fc798bdf428dfd93509c5dce8"},
+    {file = "selectolax-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74f3ea7678c79f31c36d1a674ab9c3046aa9a98fadb2c80637b608edbfd1908a"},
+    {file = "selectolax-0.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2237dbf51a3d596e2e2a887da74ed25c80a6058fb1e3d17f91f7ed45653a92bf"},
+    {file = "selectolax-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80e43bd84a5af2c6bb34c489eb172d9f3f7bf757c935f099bcd7b2ce920e66da"},
+    {file = "selectolax-0.4.1-cp311-cp311-win32.whl", hash = "sha256:bca7c37dd8bca2cfb41ba2e63f3bf04823c2d986ee7831ca2e81dbb4d7278f78"},
+    {file = "selectolax-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:73f46fc397b309ec472134c8d59b02c90d5bd171acb2c1368b4d75c8a139bb4d"},
+    {file = "selectolax-0.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:13c17c0a4be4cc877ae670096aa7152b1c23a700d44231fc5db4657cc4c3add7"},
+    {file = "selectolax-0.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a1dae8dacc0915d23fb81063dd937393f769aff3a9d24e6b499c02a008766f37"},
+    {file = "selectolax-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dd800f6ef54da4086934db1b4b569acfbbe69d5f4f9959dddbbfaff67b890c23"},
+    {file = "selectolax-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a0ededa5361287a6a8bde2b94d2ac920529079fd643e3e9e27cc927004dd65e"},
+    {file = "selectolax-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ac9491a1b29f712695cd3c32f75722775cb7ee70236023df696f462299b590fe"},
+    {file = "selectolax-0.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:677bfed36aeea126e28a601aeba5f8dff7a42c808e0a55a2deac7c4599177aba"},
+    {file = "selectolax-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ff58c34e76010f9ef17b94a7481404ad143d7560142e077c38ea291e982b1ef7"},
+    {file = "selectolax-0.4.1-cp312-cp312-win32.whl", hash = "sha256:1d6786f77eb9fd27cd6acd4009aefa6a6924553b40bc3be7e24201de55a8fc3f"},
+    {file = "selectolax-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:b14d8259f819c72ce11454fd6b1466da1a03c9b7bbe0170d577cb0acc1258ea6"},
+    {file = "selectolax-0.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:6a8acdcd6452b66e094d0aa0db1d0aa1a752ddf98a4907fd87253c7ab1314768"},
+    {file = "selectolax-0.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:97964efa178891820c4ac4921260d47be3a0cfb3d7c6f8090ad7bacd3a546176"},
+    {file = "selectolax-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:67c0c28c50e79bd524dd0ad8050ac669d198608144d6b68b81b087221163caa5"},
+    {file = "selectolax-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:406fa1597ec6e1b0bd30051f114a9497aab28a37d1f1c6693372485df4fa8c03"},
+    {file = "selectolax-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:068b75e52dfea7f46a8f3ab86d8318e42e06f02274c55558877cbf3bdc93c00e"},
+    {file = "selectolax-0.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:57fa60ac22171d03877497d0fe02f3de6b750c99f11c9c1a6dbb8a234b2021ef"},
+    {file = "selectolax-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d3e04c450e510a22468aa063227d40a1eac155d78852f215ed3c1b718378eb26"},
+    {file = "selectolax-0.4.1-cp313-cp313-win32.whl", hash = "sha256:0b564904c3b1e4700f3046884a9d4abc3bbe1e05debb2d2871deeb664e9afe35"},
+    {file = "selectolax-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:44c4654d8519d1c016e8ef2db75f16b63c2635505da5ab6702043cbb340b484e"},
+    {file = "selectolax-0.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:79d7c150d70168aa817fe91b0e026574e14475122429e3fa4659e77efa28128b"},
+    {file = "selectolax-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:058fbf1fcbe7d91cb865917ee9f76b2ad86668e8ddd071495b1ad30c112a1869"},
+    {file = "selectolax-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e81cd405ccb59c96f89a2e3c9bf928072cd37024613b7e2f6a0c34fb933f5517"},
+    {file = "selectolax-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b356ba11a3666499a96ac4e20f1ce847d49501df15b1fdbb79d2387f6608f7d6"},
+    {file = "selectolax-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6447adabd584c7c60cf8ce5c6cd30b4b410061d838d94a69e18dab467325618"},
+    {file = "selectolax-0.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6104aea4b2e7407edbbc9a9545698e9f3df3c6a4c47f204a83568b0728366905"},
+    {file = "selectolax-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bce67e316c6ab957bd0a46c8df2f14c2a7bcc7752ece3b570724092ec84245ca"},
+    {file = "selectolax-0.4.1-cp314-cp314-win32.whl", hash = "sha256:a6a93d5964a0f9b580d37e8aebf13ca2a37804e9d75d6481b016f9a4770d4a39"},
+    {file = "selectolax-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:d702743f9e69d101305d9cf3b2d92aebc0acae806bb0c113dd9ba2c78e80b9cd"},
+    {file = "selectolax-0.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:6edbe6ecee7da69211828425116521b3e62111351c4c3e344e4da257275004f7"},
+    {file = "selectolax-0.4.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:93320c0f1f81ad686f804ebec1024bb22a3ac696b77aa5087809faccfc65f901"},
+    {file = "selectolax-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2efcc875cc9b7d80ea0becce5a4cdf2f7f552a38de51dc0f80fd59048045d48b"},
+    {file = "selectolax-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f4374159c4816767bb5a0c47a2fc3dc65d3f1c53b614876e6e66f8ad5009577"},
+    {file = "selectolax-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:140db53496eb6d15fca187ca85e770bb889d5eb0994c0173f9a56513f31d5a46"},
+    {file = "selectolax-0.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e52a3eccb0d9da471ea09b4000e4d0a32e5094cfad76d17d2311b48e9b49046a"},
+    {file = "selectolax-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:aad323017fc75dd0543b9617ce2c99db49efba787a74904d45e7e036d545c0a1"},
+    {file = "selectolax-0.4.1-cp314-cp314t-win32.whl", hash = "sha256:434b18ae66566c7b376513585c89c05dd77f67feaf5eb0687e96786398da403b"},
+    {file = "selectolax-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:7ee47eccd9f9705f784b872cbaa8328b27878b7fe3e060ca5a27125a9b47034f"},
+    {file = "selectolax-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2d2e2944b28ccbbaa7cb403fe86702fef616a35421bc5cbd6a618ad3dce3dac2"},
+    {file = "selectolax-0.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:717cd99ce6337cc623b2bd8cfbea3f3ecce6a40ee80f1104b1bead7056d6408f"},
+    {file = "selectolax-0.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cd7e5fa804cec79b5b30dd8b6c55538da288b26d4ed896c4c37a21844fa95431"},
+    {file = "selectolax-0.4.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:590332c4f782685969886ffec03ea8cd4aaf1aa17975986e36a50deb02a8b223"},
+    {file = "selectolax-0.4.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d95256ea7a687b23b3ba459d7581f3e86508c5778fea8ae2e1812d6a0a7d7dc"},
+    {file = "selectolax-0.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:59fe4c39bedd0b14521910ccc0199478f3b079b5abf0a8531d9269bb52b89bff"},
+    {file = "selectolax-0.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:e221a1bdd8326a52cfb7be484eb1317ccd11ccd1ccf24f6709128ac50086b327"},
+    {file = "selectolax-0.4.1-cp39-cp39-win32.whl", hash = "sha256:2b749be78bbc62c829183cb1b3779ee9c12b7e69f91ccbe5c768dc95b13f06fb"},
+    {file = "selectolax-0.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:ed13255505fbd1f10737dfa8164375b57e568fb1225042d9588c5b1f0000bc8e"},
+    {file = "selectolax-0.4.1-cp39-cp39-win_arm64.whl", hash = "sha256:1cc5eb09c3366d7a4110ac18f765ce046ed423240be7b0fd691ea6284e06a114"},
+    {file = "selectolax-0.4.1.tar.gz", hash = "sha256:f0cca2d4cc2e69d8ef9864071efcf4fc97f5afc042f9becee045dff63c09be43"},
+]
+
+[package.extras]
+cython = ["Cython"]
+
+[[package]]
+name = "selectolax"
+version = "0.4.8"
+description = "A fast HTML5 parser with CSS selectors, written in Cython, using Modest and Lexbor engines."
+optional = false
+python-versions = "<3.15,>=3.9"
+groups = ["main"]
+markers = "python_version <= \"3.13\""
+files = [
+    {file = "selectolax-0.4.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2166f893420119151bb644f79c145f6d75f1f0435f98b071d9e663f273890551"},
+    {file = "selectolax-0.4.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4542a35f5ea993ae8bdb5850346f65848794afabc83976e576dcab07a6699020"},
+    {file = "selectolax-0.4.8-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c65d50ab4654c55a3fa17db17cae39405a688693aad0681d8cd8bf8c1b01b588"},
+    {file = "selectolax-0.4.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:239fb539f67a43cbd543d48a09314eb955b5f3fe1b9ede4e1a31feb7ccfdd6b0"},
+    {file = "selectolax-0.4.8-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c6753fe6132c4dfbc984ce9b48777f7f7282c63b3943e558459a6b8847da962e"},
+    {file = "selectolax-0.4.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:059056df901766278018a1064dd4e49a6111a01fef02a7e668352fe716c80c84"},
+    {file = "selectolax-0.4.8-cp310-cp310-win32.whl", hash = "sha256:c7a10112c6f96f3db34e757d8e82e7441fd76c7361dc0d8f19a9c383bd4afd26"},
+    {file = "selectolax-0.4.8-cp310-cp310-win_amd64.whl", hash = "sha256:4be603bbe70f6c036b189bd2a7227ab2fd7d47d360c2282a3623712cf3e2f23d"},
+    {file = "selectolax-0.4.8-cp310-cp310-win_arm64.whl", hash = "sha256:903abf55ffcd2b5a8f8918925e9c532ffeae09b752c39371569a5350dc1c1157"},
+    {file = "selectolax-0.4.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e334eb5d1a8ed41c539d5fbc170bfbecbaa5312c6f3358cb36b606565f748a8c"},
+    {file = "selectolax-0.4.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:241b99d10ebf1df8b7b57fd90a3479abfd987ef04acb6253c4d3571b570346c9"},
+    {file = "selectolax-0.4.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1269dcb740b7a1eaefabce6b189324a5bd9c93a39b25b54a888b4ea0cf10290d"},
+    {file = "selectolax-0.4.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8414beca1e821cd260d94c8fe687f9a8ae4ef765e2b4710d8bd233ec32cde26"},
+    {file = "selectolax-0.4.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dbaac0b708e539358343305534be59cc47875f2b62b50b33af50f5a1ecf7bff2"},
+    {file = "selectolax-0.4.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dc2781ef2a6ac8aeed10f729aaafff056053e2430e0effa291a8cc74fdf2fdee"},
+    {file = "selectolax-0.4.8-cp311-cp311-win32.whl", hash = "sha256:ed66d2531b58ff7117c84f8d6d62d2d0d8a426f04d10ca45bd3744c7af71acd1"},
+    {file = "selectolax-0.4.8-cp311-cp311-win_amd64.whl", hash = "sha256:f96959cecb10e70fd93e89e2c4522cfa671f5443427f4ccc12285604b6239c85"},
+    {file = "selectolax-0.4.8-cp311-cp311-win_arm64.whl", hash = "sha256:787370345153cde7cd65f2271a00d7608b77993e1951f2f941a3c2ef92b942e0"},
+    {file = "selectolax-0.4.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bbcd4cb837dec4b16a3ab6a8b2ec4388ea20c050092b68536dc9a60ce8f19b56"},
+    {file = "selectolax-0.4.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f1cdcf946dd46e11640ca0a0361945c3ed65627ba4bd219ccf84a53fab28c072"},
+    {file = "selectolax-0.4.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:074254670a8a00b36202ab0cd99ce8fb2a25b3b2f10072891a35a6a85c53f679"},
+    {file = "selectolax-0.4.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bbd33d348a555b37d5f922c421338db690500e5b579353ffa24e3bd23a04704"},
+    {file = "selectolax-0.4.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c0cf863f652ed6de58c9f3599173be70064827807f46ddd38ad82b185fead322"},
+    {file = "selectolax-0.4.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ca2e1a9a06d1b1a7549d2828240f1888a172b60720baf8a2cb90936482d8b6b4"},
+    {file = "selectolax-0.4.8-cp312-cp312-win32.whl", hash = "sha256:b812691bbdf7c958b29956138917bd46cd78b96f2d4f51f56063f584f0d6c476"},
+    {file = "selectolax-0.4.8-cp312-cp312-win_amd64.whl", hash = "sha256:877df05c9fb306ed6b4d094cbd655ad8e89ea4744d3597eb1e5217c7f71d4ea4"},
+    {file = "selectolax-0.4.8-cp312-cp312-win_arm64.whl", hash = "sha256:52db6be936a0f0648d9d8acbfdf16d4c5a16600cfc31db1b557b0effd8b164ce"},
+    {file = "selectolax-0.4.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fb2c4bed19e0c3e34b877b6df607150725d84a38dda32bccb030d8744078eda6"},
+    {file = "selectolax-0.4.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a2d83e04bf0a9f0a8c9a6a7989df1844acc2242025f26293c1e12ce82b4a3f9"},
+    {file = "selectolax-0.4.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8513c179ec9758d9bbc43a9e7e58fecfcfc1ec88e9100ed592cce2703c316b63"},
+    {file = "selectolax-0.4.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b6225fd6b5bec6be59bc07aeee17f50448c9b4769531afaa079c74650ebd2c5"},
+    {file = "selectolax-0.4.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:899b62117147fd804b43822e7af0c422730c6743b27b20b233c4896363b1e655"},
+    {file = "selectolax-0.4.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:573b67610d2876b67707eaaad71d28da5a0d4ce72ab4880a68abeacdbdd825b1"},
+    {file = "selectolax-0.4.8-cp313-cp313-win32.whl", hash = "sha256:69cf8b1edbc2f6e401a1be0a2fc6eb1ea05679446053724a3ac399abea1e98d3"},
+    {file = "selectolax-0.4.8-cp313-cp313-win_amd64.whl", hash = "sha256:e57a2c314b339ffd6da899bf7d37a3d850aa03b8bcbcbb25d183fdae4525ad6d"},
+    {file = "selectolax-0.4.8-cp313-cp313-win_arm64.whl", hash = "sha256:9a593eaf1a6686b559e3f65f20d21c592933cf6c18a0a042a9f46d96a88f54d3"},
+    {file = "selectolax-0.4.8-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:412d8c3203d294a36bed5b01942d8f81724a6731458e257b0153f2f4425e3da9"},
+    {file = "selectolax-0.4.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:45e02ed68d9888828edae568c17ebd055f265221c2784329ed63078283c4e0ea"},
+    {file = "selectolax-0.4.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f7aa77dec4a04b8b63aeaa505c168ac2597df2be426783ede8d74d56e925b48"},
+    {file = "selectolax-0.4.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4fab78f7cab55c06a1a994f522adb5b4c5302aaacac60bdca7de1f8eaacaa9f9"},
+    {file = "selectolax-0.4.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7923f90a5d51325cde8b47e41aa71a0f81429afb85d26966369389c5eaf99c6e"},
+    {file = "selectolax-0.4.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7af017e28bcdcea1d7aaeab329f78515fab3becf30c4c9408e0c9b8303be1393"},
+    {file = "selectolax-0.4.8-cp314-cp314-win32.whl", hash = "sha256:40f6de3a820983c1f3feacb60351677b69d0c829b63aa11c7bd4811bcbcb8f42"},
+    {file = "selectolax-0.4.8-cp314-cp314-win_amd64.whl", hash = "sha256:ce6668c260ada8880106f6d37cd073b53ac3342f04b8a771dacb6ea68d953285"},
+    {file = "selectolax-0.4.8-cp314-cp314-win_arm64.whl", hash = "sha256:5125e171b16bbbdb76ea36140c165f183b1e99fe4170eb9b79a7141090bba51c"},
+    {file = "selectolax-0.4.8-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:bc041e2554c4cce221401bbde42177a99670fdba8a60448f0ae65731fc08a0b5"},
+    {file = "selectolax-0.4.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:957fd757b0491e29f96235cb5ce0a46b8cdc8cce41f5032805387311d2504677"},
+    {file = "selectolax-0.4.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d001ceff303937e0d05ecba4c1a8d39ea04840a653ccaecf59446667c16f65bc"},
+    {file = "selectolax-0.4.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f293e28183b329bed738918d18cd35966add6600bad2f3431470ffa18c0639e"},
+    {file = "selectolax-0.4.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3972b884caa78abf3710a0e7723dc705974dbdaef46d98a05e47c68493d86922"},
+    {file = "selectolax-0.4.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a6aacac9d106a2c992b817b5c1d4a1aa2e825403a5c1354386657968fa4b9b15"},
+    {file = "selectolax-0.4.8-cp314-cp314t-win32.whl", hash = "sha256:ccfb2d172db96401a8d4ebc2dc12f4f4f20208597f5e6510d3f6bdc5a49c46b5"},
+    {file = "selectolax-0.4.8-cp314-cp314t-win_amd64.whl", hash = "sha256:5c34fd9a29a430c1f8800d94e7a2c4fd0b1aef10485b0871fbae914cde232c41"},
+    {file = "selectolax-0.4.8-cp314-cp314t-win_arm64.whl", hash = "sha256:136dfad919728023fcd13fc773a1c488204fb0efd9c1f9baf7bd815fbb35eec3"},
+    {file = "selectolax-0.4.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e3284a479b85822f0c468450557c51c81526beafcc705545bd86e6455fe5fd78"},
+    {file = "selectolax-0.4.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:969abfbe4bff02b0ddff54542d19bf3806048d3139ec2b5e89214ced1f42a4a7"},
+    {file = "selectolax-0.4.8-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5c76b0b9fcec0446f6dd34ad164b5c0e452ca714843befdf164b7f3edfca48b"},
+    {file = "selectolax-0.4.8-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ea1c2bd2bae8d57d14109f059da718a4134841d6c37e830beeddb06c4e20400"},
+    {file = "selectolax-0.4.8-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1204a0517766d67e0f08b1e329283355ec797a2888100bb29125fe698811ed65"},
+    {file = "selectolax-0.4.8-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:44af7c7ecd4c6c55fe1d6a13a21f93aa8fe6b7d3c94d4ede75b620012f7a4686"},
+    {file = "selectolax-0.4.8-cp39-cp39-win32.whl", hash = "sha256:cc982706494736b455e7027c064c96048cda97a748fee4a51b5b064232096888"},
+    {file = "selectolax-0.4.8-cp39-cp39-win_amd64.whl", hash = "sha256:e860c5f3970f55d078d87430fb139dadbdd8e23c2ff272f93a999a44611460c6"},
+    {file = "selectolax-0.4.8-cp39-cp39-win_arm64.whl", hash = "sha256:b0e6a9dd04e2e4832e8de6ebd8902dae8584a56ae9b7a826f1b7c64ae3fcc35f"},
+    {file = "selectolax-0.4.8.tar.gz", hash = "sha256:cd703165b9a346be255e2ca5b4219e01009911977ac8a474d8ccb7e32e9a4fae"},
+]
+
+[package.extras]
+cython = ["Cython"]
 
 [[package]]
 name = "sentence-transformers"
@@ -7293,4 +7479,4 @@ cffi = ["cffi (>=1.17) ; python_version >= \"3.13\" and platform_python_implemen
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "18a52ac97bdf3a15b8d6cff9826931b38d08d2369a3bf57bcbaace8c33f83b9f"
+content-hash = "34b5a01423fb9a8f8c56772cc96a325160a6bd69e11ca30f12a7446fd544650e"

--- a/melanoma/pyproject.toml
+++ b/melanoma/pyproject.toml
@@ -29,6 +29,7 @@ langchain-google-genai = "<2.0"
 feedparser = "^6.0.12"
 beautifulsoup4 = "^4.14.3"
 lxml = "^6.1.0"
+googlenewsdecoder = ">=0.1.7"
 
 [tool.poetry.group.processing]
 optional = true

--- a/melanoma/pyproject.toml
+++ b/melanoma/pyproject.toml
@@ -25,6 +25,10 @@ langchain-openai = "^0.3.33"
 google-genai = ">=1.4.0"
 supabase = "^2.28.3"
 langchain-google-genai = "<2.0"
+# News scraper dependencies
+feedparser = "^6.0.12"
+beautifulsoup4 = "^4.14.3"
+lxml = "^6.1.0"
 
 [tool.poetry.group.processing]
 optional = true

--- a/melanoma/pyproject.toml
+++ b/melanoma/pyproject.toml
@@ -120,6 +120,7 @@ strict_equality = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/melanoma/scripts/replace_publications_supabase.py
+++ b/melanoma/scripts/replace_publications_supabase.py
@@ -1,0 +1,230 @@
+"""
+Delete all source_type='publication' rows from trial_outcomes, then insert
+fresh rows from a publications extraction JSON.
+
+Usage:
+    cd melanoma
+    poetry run python3 scripts/replace_publications_supabase.py [--dry-run] [--file PATH]
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+
+from dotenv import load_dotenv
+
+# Load env BEFORE importing upload_to_supabase — that module sys.exits if env missing
+load_dotenv()
+
+_here = pathlib.Path(__file__).parent
+_root = _here.parent
+sys.path.insert(0, str(_root))    # melanoma/ → enables `from src...`
+sys.path.insert(0, str(_here))    # scripts/  → enables `from upload_to_supabase import ...`
+
+from upload_to_supabase import ATTRIBUTE_MAPPING  # noqa: E402
+from src.infrastructure.clinical_trials.supabase_parser import normalize_cancer_type  # noqa: E402
+
+from supabase import Client, create_client  # noqa: E402
+
+url = os.environ.get("SUPABASE_URL")
+key = os.environ.get("SUPABASE_KEY")
+if not url or not key:
+    print("SUPABASE_URL and SUPABASE_KEY must be set in .env")
+    sys.exit(1)
+
+supabase: Client = create_client(url, key)
+
+DEFAULT_JSON = str(
+    _root / "data/output/Publication_May_2026/extraction_results_Publications_final_70.json"
+)
+
+EMPTY_VALUES = {None, "", "Not found", "N/A", "Not available", "Not reached"}
+
+
+def parse_numeric(val: str) -> float | None:
+    """Parse a numeric string, falling back to the value inside parentheses.
+
+    Handles dirty extraction outputs like '1 (<1%)' or '<1' by extracting
+    the parenthesized portion first, then stripping <, >, % characters.
+    """
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        pass
+    m = re.search(r'\(([^)]+)\)', val)
+    candidate = m.group(1) if m else val
+    stripped = re.sub(r'[<>%]', '', candidate).strip()
+    try:
+        return float(stripped)
+    except (ValueError, TypeError):
+        return None
+
+
+def build_rows(publications: list) -> list[dict]:
+    rows = []
+    for pub in publications:
+        pub_id = pub.get("pub_id", "unknown")
+        arm_results = pub.get("arm_results", {})
+        if not arm_results:
+            continue
+
+        first_arm_attrs = next(iter(arm_results.values()), {}).get("attributes", {})
+
+        # Normalize all attribute keys once for this pub
+        def _norm(attrs: dict) -> dict:
+            return {
+                k.lower().replace("attributetype.", "").replace("_", ""): v
+                for k, v in attrs.items()
+            }
+
+        first_norm = _norm(first_arm_attrs)
+
+        # publication_id = publication_name attribute of first arm
+        pub_name_obj = first_norm.get("publicationname", {})
+        pub_name = pub_name_obj.get("value")
+        publication_id = None if pub_name in EMPTY_VALUES else pub_name
+
+        # nct_id from attribute
+        nct_obj = first_norm.get("nctnumber", {}) or first_norm.get("nctid", {})
+        nct_raw = nct_obj.get("value")
+        nct_id = None if nct_raw in EMPTY_VALUES else nct_raw
+
+        for arm_key, arm_data in arm_results.items():
+            arm_id = arm_data.get("arm_id", arm_key)
+            attrs = arm_data.get("attributes", {})
+            norm_attrs = _norm(attrs)
+
+            pk = f"publication_{pub_id}_{arm_id}".replace("/", "_").replace(" ", "_")
+
+            record: dict = {
+                "id": pk,
+                "source_type": "publication",
+                "source_name": pub_id,
+                "abstract_id": None,
+                "publication_id": publication_id,
+                "source_url": None,
+                "nct_id": nct_id,
+                "arm_id": arm_id,
+                "arm_name": arm_data.get("arm_name"),
+                "confidence": pub.get("overall_confidence", 0.0),
+            }
+
+            known_strings = {
+                "id", "source_type", "source_name", "abstract_id", "publication_id",
+                "source_url", "nct_id", "arm_id", "arm_name", "cancer_type", "sponsors",
+                "line_of_treatment", "generic_name", "brand_name", "dosage",
+                "type_of_dosing", "mechanism_of_action", "target_protein",
+                "type_of_therapy", "sub_therapy", "is_nr", "all_attributes",
+                "created_at", "ci_hr_pfs", "ci_hr_os", "ci_hr_efs",
+                "ci_hr_rfs", "ci_hr_mfs", "ci_hr_ttp",
+            }
+
+            is_nr_list: list[str] = []
+            for attr_key, col_name in ATTRIBUTE_MAPPING.items():
+                is_num = col_name not in known_strings
+                clean_target = attr_key.lower().replace("_", "")
+                val_obj = norm_attrs.get(clean_target, {})
+                val = val_obj.get("value")
+
+                if str(val).upper() in {"NR", "NOT REACHED", "NOTREACHED"}:
+                    is_nr_list.append(col_name)
+                    val = None
+                elif val in EMPTY_VALUES:
+                    val = None
+
+                if is_num and val is not None:
+                    val = parse_numeric(val)
+                    if val is not None and col_name == "num_patients":
+                        val = int(val)
+
+                record[col_name] = val
+
+            # Fallback num_patients from arm-level field
+            if record.get("num_patients") is None:
+                arm_pc = arm_data.get("patient_count")
+                if isinstance(arm_pc, (int, float)) and arm_pc > 0:
+                    record["num_patients"] = int(arm_pc)
+
+            # Publications JSON stores these under different keys than ATTRIBUTE_MAPPING expects:
+            #   generic_name / dose / dosing_schedule → arm-level fields (not in attributes)
+            #   target        → target_protein
+            #   modality      → type_of_therapy
+            def _arm_str(field: str) -> str | None:
+                v = arm_data.get(field)
+                return v if v and v not in EMPTY_VALUES else None
+
+            def _attr_str(key: str) -> str | None:
+                v = norm_attrs.get(key, {}).get("value")
+                return v if v and v not in EMPTY_VALUES else None
+
+            if record.get("generic_name") is None:
+                record["generic_name"] = _arm_str("generic_name")
+            if record.get("dosage") is None:
+                record["dosage"] = _arm_str("dose")
+            if record.get("type_of_dosing") is None:
+                record["type_of_dosing"] = _arm_str("dosing_schedule")
+            if record.get("target_protein") is None:
+                record["target_protein"] = _attr_str("target")
+            record["modality"] = _attr_str("modality")
+
+            # cancer_type → TEXT[]
+            raw_ct = record.get("cancer_type")
+            if isinstance(raw_ct, str):
+                record["cancer_type"] = normalize_cancer_type(raw_ct)
+            elif not isinstance(raw_ct, list):
+                record["cancer_type"] = []
+
+            record["is_nr"] = is_nr_list if is_nr_list else None
+            rows.append(record)
+
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Replace publication rows in trial_outcomes")
+    parser.add_argument("--dry-run", action="store_true", help="Transform only, skip DB writes")
+    parser.add_argument("--file", default=DEFAULT_JSON, help="Path to publications JSON")
+    args = parser.parse_args()
+
+    json_path = pathlib.Path(args.file)
+    if not json_path.exists():
+        print(f"File not found: {json_path}")
+        sys.exit(1)
+
+    with open(json_path) as f:
+        data = json.load(f)
+
+    publications = data.get("publications", [])
+    print(f"Loaded {len(publications)} publications from {json_path.name}")
+
+    rows = build_rows(publications)
+    print(f"Transformed {len(rows)} arms")
+
+    if args.dry_run:
+        print("[dry-run] Skipping delete and upsert.")
+        return
+
+    # Step 1: delete existing publication rows
+    supabase.table("trial_outcomes").delete().eq("source_type", "publication").execute()
+    print("Deleted existing publication rows from trial_outcomes")
+
+    # Step 2: upsert in batches of 50
+    batch_size = 50
+    total_batches = (len(rows) + batch_size - 1) // batch_size
+    for i in range(0, len(rows), batch_size):
+        batch = rows[i : i + batch_size]
+        batch_num = i // batch_size + 1
+        try:
+            supabase.table("trial_outcomes").upsert(batch).execute()
+            print(f"  ✓ Batch {batch_num}/{total_batches}")
+        except Exception as e:
+            print(f"  ✗ Batch {batch_num}/{total_batches} failed: {e}")
+
+    print(f"Done. {len(rows)} rows inserted into trial_outcomes.")
+
+
+if __name__ == "__main__":
+    main()

--- a/melanoma/scripts/scrape_news_supabase.py
+++ b/melanoma/scripts/scrape_news_supabase.py
@@ -37,6 +37,7 @@ from src.infrastructure.news_scraper.gemini_extractor import (
 )
 from src.infrastructure.news_scraper.onclive import OncLiveScraper
 from src.infrastructure.news_scraper.targetedonc import TargetedOncScraper
+from src.infrastructure.cost_calculator import CostCalculator, ModelType
 
 logging.basicConfig(
     level=logging.INFO,
@@ -114,17 +115,15 @@ def main() -> int:
     if not args.dry_run and (not supabase_url or not supabase_key):
         logger.error("SUPABASE_URL and SUPABASE_KEY must be set (or use --dry-run)")
         return 2
-    if not args.dry_run and not gemini_key:
-        logger.error("GEMINI_API_KEY must be set (or use --dry-run)")
-        return 2
 
     supabase: Optional[Client] = (
         create_client(supabase_url, supabase_key)
         if (supabase_url and supabase_key and not args.dry_run)
         else None
     )
+    cost_calculator = CostCalculator(default_model=ModelType.GEMINI_25_FLASH_DIRECT)
     extractor: Optional[GeminiNewsExtractor] = (
-        GeminiNewsExtractor(api_key=gemini_key) if gemini_key else None
+        GeminiNewsExtractor(api_key=gemini_key, cost_calculator=cost_calculator) if gemini_key else None
     )
 
     since = compute_since(days=args.days, since_str=args.since_str)
@@ -164,13 +163,13 @@ def main() -> int:
     total = len(matched)
 
     for idx, (article, cancer_types) in enumerate(matched, start=1):
-        full_text = fetch_full_text(article.url, http_session)
+        full_text: Optional[str] = None
+        if extractor:
+            full_text = fetch_full_text(article.url, http_session)
 
         extraction: Optional[NewsExtractionResult] = None
         if extractor and full_text:
             extraction = extractor.extract(article.title, full_text, cancer_types)
-        elif full_text is None:
-            logger.warning("Skipping extraction for %s — full text unavailable", article.url)
 
         row = build_upsert_row(article, cancer_types, extraction)
 
@@ -194,6 +193,7 @@ def main() -> int:
             logger.info("Progress: %d/%d | %s", idx, total, counts)
 
     logger.info("Scrape complete: %s", counts)
+    cost_calculator.print_summary()
     return 0 if counts["error"] == 0 else 1
 
 

--- a/melanoma/scripts/scrape_news_supabase.py
+++ b/melanoma/scripts/scrape_news_supabase.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Daily sync of oncology news articles into Supabase news_feed table.
+
+Scrapes OncLive (RSS), CancerNetwork (RSS), TargetedOnc (Google News RSS),
+and BioSpace (HTML), filters to 8 skin cancer types, extracts NCT IDs and
+efficacy/safety data via Gemini, and upserts into `news_feed`.
+
+Usage:
+    poetry run python3 scripts/scrape_news_supabase.py [--since YYYY-MM-DD]
+                                                        [--days N]
+                                                        [--source SOURCE]
+                                                        [--dry-run]
+"""
+
+import argparse
+import logging
+import os
+import pathlib
+import sys
+from datetime import date, datetime, timedelta
+from typing import Any, Optional
+
+import requests
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
+from supabase import Client, create_client
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from src.infrastructure.news_scraper.base import NewsArticleRaw
+from src.infrastructure.news_scraper.biospace import BioSpaceScraper
+from src.infrastructure.news_scraper.cancer_filter import assign_cancer_types
+from src.infrastructure.news_scraper.cancernetwork import CancerNetworkScraper
+from src.infrastructure.news_scraper.gemini_extractor import (
+    GeminiNewsExtractor,
+    NewsExtractionResult,
+)
+from src.infrastructure.news_scraper.onclive import OncLiveScraper
+from src.infrastructure.news_scraper.targetedonc import TargetedOncScraper
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("scrape_news_supabase")
+
+_ALL_SOURCES = ["onclive", "cancernetwork", "targetedonc", "biospace"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--since", type=str, default=None, dest="since_str",
+                        help="Backfill from date YYYY-MM-DD (overrides --days)")
+    parser.add_argument("--days", type=int, default=2,
+                        help="Lookback window in days (default: 2)")
+    parser.add_argument("--source", type=str, choices=_ALL_SOURCES, default=None,
+                        help="Run a single source only")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Fetch and extract but do not write to Supabase")
+    return parser.parse_args()
+
+
+def compute_since(days: int, since_str: Optional[str]) -> date:
+    if since_str:
+        try:
+            return datetime.strptime(since_str, "%Y-%m-%d").date()
+        except ValueError:
+            logger.error("Invalid --since date %r, expected YYYY-MM-DD", since_str)
+            sys.exit(2)
+    return date.today() - timedelta(days=days)
+
+
+def fetch_full_text(url: str, session: requests.Session) -> Optional[str]:
+    try:
+        resp = session.get(url, timeout=30)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "lxml")
+        for tag in soup(["script", "style", "nav", "footer", "header", "aside"]):
+            tag.decompose()
+        return soup.get_text(separator=" ", strip=True)[:50000]
+    except Exception as exc:
+        logger.warning("Full-text fetch failed for %s: %s", url, exc)
+        return None
+
+
+def build_upsert_row(
+    article: NewsArticleRaw,
+    cancer_types: list[str],
+    extraction: Optional[NewsExtractionResult],
+) -> dict[str, Any]:
+    return {
+        "source": article.source,
+        "title": article.title,
+        "url": article.url,
+        "date": article.published_date.isoformat(),
+        "cancer_type": cancer_types,
+        "nct_ids": extraction.nct_ids if extraction else [],
+        "has_efficacy": extraction.has_efficacy if extraction else False,
+        "efficacy_data": extraction.efficacy_data if extraction else {},
+        "has_safety": extraction.has_safety if extraction else False,
+        "safety_data": extraction.safety_data if extraction else {},
+        "extracted_at": datetime.utcnow().isoformat() if extraction else None,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    load_dotenv()
+
+    supabase_url = os.environ.get("SUPABASE_URL")
+    supabase_key = os.environ.get("SUPABASE_KEY")
+    gemini_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY", "")
+
+    if not args.dry_run and (not supabase_url or not supabase_key):
+        logger.error("SUPABASE_URL and SUPABASE_KEY must be set (or use --dry-run)")
+        return 2
+    if not args.dry_run and not gemini_key:
+        logger.error("GEMINI_API_KEY must be set (or use --dry-run)")
+        return 2
+
+    supabase: Optional[Client] = (
+        create_client(supabase_url, supabase_key)
+        if (supabase_url and supabase_key and not args.dry_run)
+        else None
+    )
+    extractor: Optional[GeminiNewsExtractor] = (
+        GeminiNewsExtractor(api_key=gemini_key) if gemini_key else None
+    )
+
+    since = compute_since(days=args.days, since_str=args.since_str)
+    logger.info("Scrape starting: since=%s, source=%s, dry_run=%s",
+                since, args.source or "all", args.dry_run)
+
+    active_sources = [args.source] if args.source else _ALL_SOURCES
+    all_articles: list[NewsArticleRaw] = []
+
+    scrapers = {
+        "onclive": OncLiveScraper(),
+        "cancernetwork": CancerNetworkScraper(),
+        "targetedonc": TargetedOncScraper(),
+        "biospace": BioSpaceScraper(),
+    }
+    for source_name in active_sources:
+        try:
+            articles = scrapers[source_name].fetch_articles(since)
+            all_articles.extend(articles)
+        except Exception as exc:
+            logger.error("Scraper %s failed: %s", source_name, exc)
+
+    logger.info("Collected %d raw articles across all sources", len(all_articles))
+
+    matched: list[tuple[NewsArticleRaw, list[str]]] = []
+    for article in all_articles:
+        cancer_types = assign_cancer_types(article)
+        if cancer_types:
+            matched.append((article, cancer_types))
+
+    logger.info("%d articles matched skin cancer types", len(matched))
+
+    http_session = requests.Session()
+    http_session.headers["User-Agent"] = "Mozilla/5.0 (compatible; Bionocular/1.0)"
+
+    counts = {"upserted": 0, "skipped": 0, "error": 0}
+    total = len(matched)
+
+    for idx, (article, cancer_types) in enumerate(matched, start=1):
+        full_text = fetch_full_text(article.url, http_session)
+
+        extraction: Optional[NewsExtractionResult] = None
+        if extractor and full_text:
+            extraction = extractor.extract(article.title, full_text, cancer_types)
+        elif full_text is None:
+            logger.warning("Skipping extraction for %s — full text unavailable", article.url)
+
+        row = build_upsert_row(article, cancer_types, extraction)
+
+        if args.dry_run:
+            logger.info(
+                "[dry-run] %s | cancer_types=%s | nct_ids=%s | efficacy=%s | safety=%s",
+                row["url"], row["cancer_type"], row["nct_ids"],
+                row["has_efficacy"], row["has_safety"],
+            )
+            counts["upserted"] += 1
+        else:
+            assert supabase is not None
+            try:
+                supabase.table("news_feed").upsert(row, on_conflict="url").execute()
+                counts["upserted"] += 1
+            except Exception as exc:
+                logger.error("Upsert failed for %s: %s", article.url, exc)
+                counts["error"] += 1
+
+        if idx % 10 == 0 or idx == total:
+            logger.info("Progress: %d/%d | %s", idx, total, counts)
+
+    logger.info("Scrape complete: %s", counts)
+    return 0 if counts["error"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/melanoma/scripts/scrape_news_supabase.py
+++ b/melanoma/scripts/scrape_news_supabase.py
@@ -90,7 +90,6 @@ def build_upsert_row(
     extraction: Optional[NewsExtractionResult],
 ) -> dict[str, Any]:
     return {
-        "source": article.source,
         "title": article.title,
         "url": article.url,
         "date": article.published_date.isoformat(),

--- a/melanoma/scripts/scrape_news_supabase.py
+++ b/melanoma/scripts/scrape_news_supabase.py
@@ -110,7 +110,7 @@ def main() -> int:
 
     supabase_url = os.environ.get("SUPABASE_URL")
     supabase_key = os.environ.get("SUPABASE_KEY")
-    gemini_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY", "")
+    gemini_key = os.environ.get("GOOGLE_API_KEY", "")
 
     if not args.dry_run and (not supabase_url or not supabase_key):
         logger.error("SUPABASE_URL and SUPABASE_KEY must be set (or use --dry-run)")
@@ -175,8 +175,8 @@ def main() -> int:
 
         if args.dry_run:
             logger.info(
-                "[dry-run] %s | cancer_types=%s | nct_ids=%s | efficacy=%s | safety=%s",
-                row["url"], row["cancer_type"], row["nct_ids"],
+                "[dry-run] %s | title=%s | date=%s | cancer_types=%s | nct_ids=%s | efficacy=%s | safety=%s",
+                row["url"], row["title"], row["date"], row["cancer_type"], row["nct_ids"],
                 row["has_efficacy"], row["has_safety"],
             )
             counts["upserted"] += 1

--- a/melanoma/scripts/upload_legacy_news_feed.py
+++ b/melanoma/scripts/upload_legacy_news_feed.py
@@ -41,7 +41,7 @@ _CANCER_TYPE_MAP: dict[str, str] = {
 
 _LEGACY_EXTRACTED_AT = "2026-01-01T00:00:00+00:00"
 
-_SAFETY_KEYWORDS = {"safety", "adverse", "toxicity", "dlt", "trae", "grade"}
+_SAFETY_KEYWORDS = {"safety", "adverse", "toxicity", "dlt", "trae", "grade", "ae"}
 _EFFICACY_KEYWORDS = {"orr", "pfs", "dor", "dcr", "efficacy", "survival", "clearance",
                       "response", "progression", "overall"}
 

--- a/melanoma/scripts/upload_legacy_news_feed.py
+++ b/melanoma/scripts/upload_legacy_news_feed.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""One-off upload of legacy live_ticker.json data into Supabase news_feed table.
+
+Usage:
+    poetry run python3 scripts/upload_legacy_news_feed.py [--dry-run]
+"""
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+import sys
+from datetime import datetime
+from typing import Any
+
+from dotenv import load_dotenv
+from supabase import Client, create_client
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("upload_legacy_news_feed")
+
+_LEGACY_JSON = (
+    pathlib.Path(__file__).parent.parent
+    / "data" / "output" / "Legacy" / "live_ticker.json"
+)
+
+_CANCER_TYPE_MAP: dict[str, str] = {
+    "cutaneous-melanoma": "Cutaneous Melanoma",
+    "basal-cell-carcinoma": "Basal Cell Carcinoma",
+    "cutaneous-squamous-cell-carcinoma": "Cutaneous Squamous Cell Carcinoma",
+    "uveal-melanoma": "Uveal Melanoma",
+    "merkel-cell-carcinoma": "Merkel Cell Carcinoma",
+    "acral-melanoma": "Acral Melanoma",
+    "mucosal-melanoma": "Mucosal Melanoma",
+    "cutaneous-melanoma-with-brain-cns-metastasis": "Cutaneous Melanoma with Brain/CNS Metastasis",
+}
+
+_LEGACY_EXTRACTED_AT = "2026-01-01T00:00:00+00:00"
+
+_SAFETY_KEYWORDS = {"safety", "adverse", "toxicity", "dlt", "trae", "grade"}
+_EFFICACY_KEYWORDS = {"orr", "pfs", "dor", "dcr", "efficacy", "survival", "clearance",
+                      "response", "progression", "overall"}
+
+
+def _classify_efficacy_safety(metric: str) -> tuple[bool, bool]:
+    """Return (has_efficacy, has_safety) from metric keyword detection."""
+    lower = metric.lower()
+    has_safety = any(kw in lower for kw in _SAFETY_KEYWORDS)
+    has_efficacy = any(kw in lower for kw in _EFFICACY_KEYWORDS)
+    if not has_safety and not has_efficacy:
+        has_efficacy = True  # default: unrecognised metrics treated as efficacy
+    return has_efficacy, has_safety
+
+
+def parse_date(date_str: str) -> str:
+    """Convert 'February 2, 2026' → '2026-02-02'."""
+    return datetime.strptime(date_str, "%B %d, %Y").strftime("%Y-%m-%d")
+
+
+def parse_nct_ids(nct_id: str | None) -> list[str]:
+    """Convert 'NCT001, NCT002' → ['NCT001', 'NCT002']."""
+    if not nct_id:
+        return []
+    return [n.strip() for n in nct_id.split(",") if n.strip()]
+
+
+def _empty_row(url: str, title: str, date_str: str, nct_id: str | None) -> dict[str, Any]:  # values are heterogeneous (str | list | bool | dict | None)
+    return {
+        "url": url,
+        "title": title,
+        "date": parse_date(date_str),
+        "cancer_type": [],
+        "nct_ids": parse_nct_ids(nct_id),
+        "has_efficacy": False,
+        "efficacy_data": {},
+        "has_safety": False,
+        "safety_data": {},
+        "extracted_at": None,
+    }
+
+
+def build_rows(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Merge legacy JSON into one row per URL for news_feed upsert."""
+    rows: dict[str, dict[str, Any]] = {}
+
+    for slug, content in data.items():
+        cancer_type = _CANCER_TYPE_MAP.get(slug)
+        if cancer_type is None:
+            logger.warning("Unknown slug %r — skipping (update _CANCER_TYPE_MAP if needed)", slug)
+            continue
+
+        for article in content.get("articles", []):
+            url = article["url"]
+            if url not in rows:
+                rows[url] = _empty_row(url, article["title"], article["date"], article.get("nct_id"))
+            if cancer_type not in rows[url]["cancer_type"]:
+                rows[url]["cancer_type"].append(cancer_type)
+
+        for result in content.get("results", []):
+            url = result["url"]
+            if url not in rows:
+                rows[url] = _empty_row(url, result["title"], result["date"], result.get("nct_id"))
+            if cancer_type not in rows[url]["cancer_type"]:
+                rows[url]["cancer_type"].append(cancer_type)
+
+            # Classify combined legacy field into efficacy and/or safety by keyword detection.
+            eff = result.get("efficacy_or_safety_data")
+            if eff and "metric" in eff:
+                has_eff, has_saf = _classify_efficacy_safety(eff["metric"])
+                data = {"metric": eff["metric"], "value": eff["value"]}
+                if has_eff:
+                    rows[url]["has_efficacy"] = True
+                    rows[url]["efficacy_data"] = data
+                if has_saf:
+                    rows[url]["has_safety"] = True
+                    rows[url]["safety_data"] = data
+                rows[url]["extracted_at"] = _LEGACY_EXTRACTED_AT
+
+    return list(rows.values())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print rows without writing to Supabase")
+    args = parser.parse_args()
+
+    load_dotenv()
+
+    supabase_url = os.environ.get("SUPABASE_URL")
+    supabase_key = os.environ.get("SUPABASE_KEY")
+
+    if not args.dry_run and (not supabase_url or not supabase_key):
+        logger.error("SUPABASE_URL and SUPABASE_KEY must be set (or use --dry-run)")
+        return 2
+
+    with open(_LEGACY_JSON) as f:
+        data = json.load(f)
+
+    rows = build_rows(data)
+    logger.info("Built %d unique rows from legacy JSON", len(rows))
+
+    supabase: Client | None = (
+        create_client(supabase_url, supabase_key)  # type: ignore[arg-type]
+        if (supabase_url and supabase_key and not args.dry_run)
+        else None
+    )
+
+    counts: dict[str, int] = {"upserted": 0, "error": 0, "dry_run": 0}
+    for row in rows:
+        if args.dry_run:
+            logger.info("[dry-run] %s | cancer_type=%s | has_efficacy=%s",
+                        row["url"], row["cancer_type"], row["has_efficacy"])
+            counts["dry_run"] += 1
+        else:
+            assert supabase is not None
+            try:
+                supabase.table("news_feed").upsert(row, on_conflict="url").execute()
+                counts["upserted"] += 1
+            except Exception as exc:
+                logger.error("Upsert failed for %s: %s", row["url"], exc)
+                counts["error"] += 1
+
+    logger.info("Done: %s", counts)
+    return 0 if counts["error"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/melanoma/src/infrastructure/news_scraper/base.py
+++ b/melanoma/src/infrastructure/news_scraper/base.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass
+class NewsArticleRaw:
+    source: str
+    title: str
+    url: str
+    published_date: date
+    description: str
+    full_text: str | None
+
+
+class NewsSourceBase(ABC):
+    @abstractmethod
+    def fetch_articles(self, since: date) -> list[NewsArticleRaw]: ...

--- a/melanoma/src/infrastructure/news_scraper/base.py
+++ b/melanoma/src/infrastructure/news_scraper/base.py
@@ -15,4 +15,5 @@ class NewsArticleRaw:
 
 class NewsSourceBase(ABC):
     @abstractmethod
-    def fetch_articles(self, since: date) -> list[NewsArticleRaw]: ...
+    def fetch_articles(self, since: date) -> list[NewsArticleRaw]:
+        ...

--- a/melanoma/src/infrastructure/news_scraper/biospace.py
+++ b/melanoma/src/infrastructure/news_scraper/biospace.py
@@ -62,7 +62,9 @@ class BioSpaceScraper(NewsSourceBase):
             try:
                 xml = self._fetch_gnews_text(keyword)
             except Exception as exc:
-                logger.warning("BioSpace Google News fetch failed for %s: %s", keyword, exc)
+                logger.warning(
+                    "BioSpace Google News fetch failed for %s: %s", keyword, exc
+                )
                 continue
 
             feed = feedparser.parse(xml)

--- a/melanoma/src/infrastructure/news_scraper/biospace.py
+++ b/melanoma/src/infrastructure/news_scraper/biospace.py
@@ -1,0 +1,92 @@
+import logging
+import re
+from datetime import date, datetime
+
+import requests
+from bs4 import BeautifulSoup
+
+from .base import NewsArticleRaw, NewsSourceBase
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://www.biospace.com"
+_PAGE_URL = f"{_BASE_URL}/cancer"
+_DATE_FORMATS = ["%B %d, %Y", "%b %d, %Y"]
+
+_SKIN_CANCER_PRE_FILTER = re.compile(
+    r"\b(melanoma|squamous cell carcinoma|cscc|basal cell carcinoma|bcc|"
+    r"merkel cell|mcc)\b",
+    re.IGNORECASE,
+)
+
+
+def _parse_date(text: str) -> date | None:
+    text = text.strip()
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+class BioSpaceScraper(NewsSourceBase):
+    def __init__(self, timeout: int = 30) -> None:
+        self._timeout = timeout
+        self._session = requests.Session()
+        self._session.headers["User-Agent"] = "Mozilla/5.0 (compatible; Bionocular/1.0)"
+
+    def _fetch_page_html(self) -> str:
+        resp = self._session.get(_PAGE_URL, timeout=self._timeout)
+        resp.raise_for_status()
+        return resp.text
+
+    def fetch_articles(self, since: date) -> list[NewsArticleRaw]:
+        try:
+            html = self._fetch_page_html()
+        except Exception as exc:
+            logger.warning("BioSpace fetch failed: %s", exc)
+            return []
+
+        soup = BeautifulSoup(html, "lxml")
+        articles: list[NewsArticleRaw] = []
+
+        for card in soup.find_all("article"):
+            title_tag = card.find("a", href=True)
+            if title_tag is None:
+                continue
+            title = title_tag.get_text(strip=True)
+            href: str = title_tag["href"]
+
+            # Pre-filter: skip articles with no skin cancer keyword in title or summary
+            if not _SKIN_CANCER_PRE_FILTER.search(title):
+                summary_tag = card.find("p")
+                summary_text = summary_tag.get_text(strip=True) if summary_tag else ""
+                if not _SKIN_CANCER_PRE_FILTER.search(summary_text):
+                    continue
+
+            date_tag = card.find(["span", "time"])
+            if date_tag is None:
+                continue
+            pub_date = _parse_date(date_tag.get_text(strip=True))
+            if pub_date is None or pub_date < since:
+                continue
+
+            url = href if href.startswith("http") else f"{_BASE_URL}{href}"
+
+            summary_tag = card.find("p")
+            description = summary_tag.get_text(strip=True) if summary_tag else ""
+
+            articles.append(
+                NewsArticleRaw(
+                    source="biospace",
+                    title=title,
+                    url=url,
+                    published_date=pub_date,
+                    description=description,
+                    full_text=None,
+                )
+            )
+
+        logger.info("BioSpace: %d articles since %s", len(articles), since)
+        return articles

--- a/melanoma/src/infrastructure/news_scraper/biospace.py
+++ b/melanoma/src/infrastructure/news_scraper/biospace.py
@@ -1,92 +1,97 @@
 import logging
-import re
 from datetime import date, datetime
 
+import feedparser
 import requests
-from bs4 import BeautifulSoup
+from googlenewsdecoder import gnewsdecoder
 
 from .base import NewsArticleRaw, NewsSourceBase
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "https://www.biospace.com"
-_PAGE_URL = f"{_BASE_URL}/cancer"
-_DATE_FORMATS = ["%B %d, %Y", "%b %d, %Y"]
+_SEARCH_KEYWORDS: list[str] = [
+    "cutaneous+melanoma",
+    "uveal+melanoma",
+    "acral+melanoma",
+    "mucosal+melanoma",
+    "merkel+cell+carcinoma",
+    "basal+cell+carcinoma",
+    "cutaneous+squamous+cell+carcinoma",
+]
 
-_SKIN_CANCER_PRE_FILTER = re.compile(
-    r"\b(melanoma|squamous cell carcinoma|cscc|basal cell carcinoma|bcc|"
-    r"merkel cell|mcc)\b",
-    re.IGNORECASE,
+_GNEWS_URL = (
+    "https://news.google.com/rss/search"
+    "?q=site:biospace.com+{keyword}&hl=en-US&gl=US&ceid=US:en"
 )
 
 
-def _parse_date(text: str) -> date | None:
-    text = text.strip()
-    for fmt in _DATE_FORMATS:
-        try:
-            return datetime.strptime(text, fmt).date()
-        except ValueError:
-            continue
-    return None
+def _parse_feed_date(entry: object) -> date | None:
+    parsed = getattr(entry, "published_parsed", None)
+    if parsed is None:
+        return None
+    try:
+        return datetime(*parsed[:6]).date()
+    except Exception:
+        return None
 
 
 class BioSpaceScraper(NewsSourceBase):
-    def __init__(self, timeout: int = 30) -> None:
+    def __init__(self, timeout: int = 15) -> None:
         self._timeout = timeout
         self._session = requests.Session()
         self._session.headers["User-Agent"] = "Mozilla/5.0 (compatible; Bionocular/1.0)"
 
-    def _fetch_page_html(self) -> str:
-        resp = self._session.get(_PAGE_URL, timeout=self._timeout)
+    def _fetch_gnews_text(self, keyword: str) -> str:
+        url = _GNEWS_URL.format(keyword=keyword)
+        resp = self._session.get(url, timeout=self._timeout)
         resp.raise_for_status()
         return resp.text
 
-    def fetch_articles(self, since: date) -> list[NewsArticleRaw]:
-        try:
-            html = self._fetch_page_html()
-        except Exception as exc:
-            logger.warning("BioSpace fetch failed: %s", exc)
-            return []
+    def _resolve_url(self, google_url: str) -> str:
+        result = gnewsdecoder(google_url, interval=1)
+        if result.get("status"):
+            return result["decoded_url"]
+        logger.warning("gnewsdecoder returned no URL for %s: %s", google_url, result)
+        return google_url
 
-        soup = BeautifulSoup(html, "lxml")
+    def fetch_articles(self, since: date) -> list[NewsArticleRaw]:
+        seen_urls: set[str] = set()
         articles: list[NewsArticleRaw] = []
 
-        for card in soup.find_all("article"):
-            title_tag = card.find("a", href=True)
-            if title_tag is None:
+        for keyword in _SEARCH_KEYWORDS:
+            try:
+                xml = self._fetch_gnews_text(keyword)
+            except Exception as exc:
+                logger.warning("BioSpace Google News fetch failed for %s: %s", keyword, exc)
                 continue
-            title = title_tag.get_text(strip=True)
-            href: str = title_tag["href"]
 
-            # Pre-filter: skip articles with no skin cancer keyword in title or summary
-            if not _SKIN_CANCER_PRE_FILTER.search(title):
-                summary_tag = card.find("p")
-                summary_text = summary_tag.get_text(strip=True) if summary_tag else ""
-                if not _SKIN_CANCER_PRE_FILTER.search(summary_text):
+            feed = feedparser.parse(xml)
+            for entry in feed.entries:
+                pub_date = _parse_feed_date(entry)
+                if pub_date is None or pub_date < since:
                     continue
 
-            date_tag = card.find(["span", "time"])
-            if date_tag is None:
-                continue
-            pub_date = _parse_date(date_tag.get_text(strip=True))
-            if pub_date is None or pub_date < since:
-                continue
+                google_url: str = entry.get("link", "")
+                try:
+                    resolved_url = self._resolve_url(google_url)
+                except Exception as exc:
+                    logger.warning("URL decode failed for %s: %s", google_url, exc)
+                    resolved_url = google_url
 
-            url = href if href.startswith("http") else f"{_BASE_URL}{href}"
+                if resolved_url in seen_urls:
+                    continue
+                seen_urls.add(resolved_url)
 
-            summary_tag = card.find("p")
-            description = summary_tag.get_text(strip=True) if summary_tag else ""
-
-            articles.append(
-                NewsArticleRaw(
-                    source="biospace",
-                    title=title,
-                    url=url,
-                    published_date=pub_date,
-                    description=description,
-                    full_text=None,
+                articles.append(
+                    NewsArticleRaw(
+                        source="biospace",
+                        title=entry.get("title", ""),
+                        url=resolved_url,
+                        published_date=pub_date,
+                        description=entry.get("summary", ""),
+                        full_text=None,
+                    )
                 )
-            )
 
         logger.info("BioSpace: %d articles since %s", len(articles), since)
         return articles

--- a/melanoma/src/infrastructure/news_scraper/cancer_filter.py
+++ b/melanoma/src/infrastructure/news_scraper/cancer_filter.py
@@ -1,0 +1,50 @@
+from .base import NewsArticleRaw
+
+# Canonical type names match getDbCancerType() output in web/src/lib/api.ts
+# so that .contains('cancer_type', [getDbCancerType(slug)]) queries match.
+# Order matters: more specific subtypes checked before generic "Cutaneous Melanoma".
+_BRAIN_CNS_KEYWORDS = [
+    "melanoma brain metastasis",
+    "melanoma cns metastasis",
+    "melanoma brain met",
+    "intracranial melanoma",
+    "leptomeningeal melanoma",
+]
+_UVEAL_KEYWORDS = ["uveal melanoma", "ocular melanoma", "choroidal melanoma"]
+_ACRAL_KEYWORDS = ["acral melanoma", "acral lentiginous melanoma"]
+_MUCOSAL_KEYWORDS = ["mucosal melanoma"]
+_CSCC_KEYWORDS = ["cutaneous squamous cell carcinoma", "cscc"]
+_BCC_KEYWORDS = ["basal cell carcinoma", "bcc"]
+_MCC_KEYWORDS = ["merkel cell carcinoma", "merkel cell cancer", "merkel cell"]
+
+
+def assign_cancer_types(article: NewsArticleRaw) -> list[str]:
+    text = (article.title + " " + article.description).lower()
+    matched: list[str] = []
+
+    if any(kw in text for kw in _UVEAL_KEYWORDS):
+        matched.append("Uveal Melanoma")
+    if any(kw in text for kw in _ACRAL_KEYWORDS):
+        matched.append("Acral Melanoma")
+    if any(kw in text for kw in _MUCOSAL_KEYWORDS):
+        matched.append("Mucosal Melanoma")
+
+    has_melanoma = "melanoma" in text
+    has_brain_cns = any(kw in text for kw in _BRAIN_CNS_KEYWORDS) or (
+        has_melanoma
+        and any(kw in text for kw in ["brain metastasis", "cns metastasis", "brain met", "intracranial"])
+    )
+    if has_brain_cns:
+        matched.append("Cutaneous Melanoma with Brain/CNS Metastasis")
+
+    if has_melanoma:
+        matched.append("Cutaneous Melanoma")
+
+    if any(kw in text for kw in _CSCC_KEYWORDS):
+        matched.append("Cutaneous Squamous Cell Carcinoma")
+    if any(kw in text for kw in _BCC_KEYWORDS):
+        matched.append("Basal Cell Carcinoma")
+    if any(kw in text for kw in _MCC_KEYWORDS):
+        matched.append("Merkel Cell Carcinoma")
+
+    return list(dict.fromkeys(matched))

--- a/melanoma/src/infrastructure/news_scraper/cancer_filter.py
+++ b/melanoma/src/infrastructure/news_scraper/cancer_filter.py
@@ -32,7 +32,15 @@ def assign_cancer_types(article: NewsArticleRaw) -> list[str]:
     has_melanoma = "melanoma" in text
     has_brain_cns = any(kw in text for kw in _BRAIN_CNS_KEYWORDS) or (
         has_melanoma
-        and any(kw in text for kw in ["brain metastasis", "cns metastasis", "brain met", "intracranial"])
+        and any(
+            kw in text
+            for kw in [
+                "brain metastasis",
+                "cns metastasis",
+                "brain met",
+                "intracranial",
+            ]
+        )
     )
     if has_brain_cns:
         matched.append("Cutaneous Melanoma with Brain/CNS Metastasis")

--- a/melanoma/src/infrastructure/news_scraper/cancernetwork.py
+++ b/melanoma/src/infrastructure/news_scraper/cancernetwork.py
@@ -1,0 +1,58 @@
+import logging
+from datetime import date, datetime
+
+import feedparser
+import requests
+
+from .base import NewsArticleRaw, NewsSourceBase
+
+logger = logging.getLogger(__name__)
+
+_RSS_URL = "https://www.cancernetwork.com/rss"
+
+
+def _parse_feed_date(entry: object) -> date | None:
+    parsed = getattr(entry, "published_parsed", None)
+    if parsed is None:
+        return None
+    try:
+        return datetime(*parsed[:6]).date()
+    except Exception:
+        return None
+
+
+class CancerNetworkScraper(NewsSourceBase):
+    def __init__(self, timeout: int = 30) -> None:
+        self._timeout = timeout
+
+    def _fetch_feed_text(self) -> str:
+        resp = requests.get(_RSS_URL, timeout=self._timeout)
+        resp.raise_for_status()
+        return resp.text
+
+    def fetch_articles(self, since: date) -> list[NewsArticleRaw]:
+        try:
+            xml = self._fetch_feed_text()
+        except Exception as exc:
+            logger.warning("CancerNetwork RSS fetch failed: %s", exc)
+            return []
+
+        feed = feedparser.parse(xml)
+        articles: list[NewsArticleRaw] = []
+        for entry in feed.entries:
+            pub_date = _parse_feed_date(entry)
+            if pub_date is None or pub_date < since:
+                continue
+            articles.append(
+                NewsArticleRaw(
+                    source="cancernetwork",
+                    title=entry.get("title", ""),
+                    url=entry.get("link", ""),
+                    published_date=pub_date,
+                    description=entry.get("summary", ""),
+                    full_text=None,
+                )
+            )
+
+        logger.info("CancerNetwork: %d articles since %s", len(articles), since)
+        return articles

--- a/melanoma/src/infrastructure/news_scraper/cancernetwork.py
+++ b/melanoma/src/infrastructure/news_scraper/cancernetwork.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import date, datetime
 
 import feedparser
@@ -9,6 +10,12 @@ from .base import NewsArticleRaw, NewsSourceBase
 logger = logging.getLogger(__name__)
 
 _RSS_URL = "https://www.cancernetwork.com/rss"
+_CDATA_RE = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.DOTALL)
+
+
+def _strip_cdata(text: str) -> str:
+    m = _CDATA_RE.match(text)
+    return m.group(1).strip() if m else text
 
 
 def _parse_feed_date(entry: object) -> date | None:
@@ -46,7 +53,7 @@ class CancerNetworkScraper(NewsSourceBase):
             articles.append(
                 NewsArticleRaw(
                     source="cancernetwork",
-                    title=entry.get("title", ""),
+                    title=_strip_cdata(entry.get("title", "")),
                     url=entry.get("link", ""),
                     published_date=pub_date,
                     description=entry.get("summary", ""),

--- a/melanoma/src/infrastructure/news_scraper/gemini_extractor.py
+++ b/melanoma/src/infrastructure/news_scraper/gemini_extractor.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+
+from pydantic import BaseModel, Field
+
+from ..gemini_service import GeminiLLMService
+
+logger = logging.getLogger(__name__)
+
+_EXTRACTION_PROMPT = """You are a clinical data extractor for oncology news articles.
+
+Article Title: {title}
+Cancer types covered by this article: {cancer_types}
+
+Article Text:
+{full_text}
+
+Extract:
+1. NCT IDs: Any clinical trial registration numbers (format: NCTxxxxxxxx, e.g. NCT12345678).
+2. For each cancer type listed above, extract any reported data:
+   - Efficacy metrics: ORR, PFS, OS, DOR, hazard ratios, p-values, response rates, survival rates
+   - Safety metrics: AE rates, Grade 3+ adverse events, serious AEs, TRAEs, discontinuation rates
+
+Return a JSON object with:
+- nct_ids: array of NCT ID strings (empty array if none found)
+- efficacy_data: object keyed by cancer type name, each value is an object of metric name to string value.
+  Example: {{"Cutaneous Melanoma": {{"orr": "68%", "median_pfs": "12.3 months"}}, "Basal Cell Carcinoma": {{"orr": "45%"}}}}
+  Only include cancer types that have efficacy data in this article. Omit types with no data.
+- safety_data: same structure as efficacy_data but for safety metrics.
+  Example: {{"Cutaneous Melanoma": {{"grade_3_plus_ae_pct": "23%", "serious_ae": "12%"}}}}
+"""
+
+
+class NewsExtractionResult(BaseModel):
+    nct_ids: list[str] = Field(default_factory=list)
+    has_efficacy: bool = False
+    efficacy_data: dict[str, dict[str, str]] = Field(default_factory=dict)
+    has_safety: bool = False
+    safety_data: dict[str, dict[str, str]] = Field(default_factory=dict)
+
+
+class GeminiNewsExtractor:
+    def __init__(self, api_key: str, model: str = "gemini-2.5-flash") -> None:
+        self._service = GeminiLLMService(api_key=api_key, model=model)
+
+    def extract(
+        self, title: str, full_text: str, cancer_types: list[str]
+    ) -> NewsExtractionResult:
+        capped = full_text[:40000] if len(full_text) > 40000 else full_text
+        cancer_types_str = ", ".join(cancer_types) if cancer_types else "unknown"
+        prompt = _EXTRACTION_PROMPT.format(
+            title=title,
+            cancer_types=cancer_types_str,
+            full_text=capped,
+        )
+        try:
+            result = asyncio.run(
+                self._service.generate_structured(
+                    prompt=prompt,
+                    response_schema=NewsExtractionResult,
+                    operation="news_extraction",
+                    max_tokens=2048,
+                )
+            )
+            result.has_efficacy = any(bool(v) for v in result.efficacy_data.values())
+            result.has_safety = any(bool(v) for v in result.safety_data.values())
+            return result
+        except Exception as exc:
+            logger.warning("Gemini extraction failed for %r: %s", title[:60], exc)
+            return NewsExtractionResult()

--- a/melanoma/src/infrastructure/news_scraper/gemini_extractor.py
+++ b/melanoma/src/infrastructure/news_scraper/gemini_extractor.py
@@ -50,7 +50,9 @@ class GeminiNewsExtractor:
         model: str = "gemini-2.5-flash",
         cost_calculator: Optional[CostCalculator] = None,
     ) -> None:
-        self._service = GeminiLLMService(api_key=api_key, model=model, cost_calculator=cost_calculator)
+        self._service = GeminiLLMService(
+            api_key=api_key, model=model, cost_calculator=cost_calculator
+        )
         self.cost_calculator = cost_calculator
 
     def extract(

--- a/melanoma/src/infrastructure/news_scraper/gemini_extractor.py
+++ b/melanoma/src/infrastructure/news_scraper/gemini_extractor.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from ..cost_calculator import CostCalculator
 from ..gemini_service import GeminiLLMService
 
 logger = logging.getLogger(__name__)
@@ -21,13 +23,15 @@ Extract:
    - Efficacy metrics: ORR, PFS, OS, DOR, hazard ratios, p-values, response rates, survival rates
    - Safety metrics: AE rates, Grade 3+ adverse events, serious AEs, TRAEs, discontinuation rates
 
-Return a JSON object with:
+Return ONLY valid JSON, no prose, no markdown fences. JSON structure:
+{{
+  "nct_ids": ["NCT12345678"],
+  "efficacy_data": {{"Cutaneous Melanoma": {{"orr": "68%", "median_pfs": "12.3 months"}}}},
+  "safety_data": {{"Cutaneous Melanoma": {{"grade_3_plus_ae_pct": "23%"}}}}
+}}
 - nct_ids: array of NCT ID strings (empty array if none found)
-- efficacy_data: object keyed by cancer type name, each value is an object of metric name to string value.
-  Example: {{"Cutaneous Melanoma": {{"orr": "68%", "median_pfs": "12.3 months"}}, "Basal Cell Carcinoma": {{"orr": "45%"}}}}
-  Only include cancer types that have efficacy data in this article. Omit types with no data.
-- safety_data: same structure as efficacy_data but for safety metrics.
-  Example: {{"Cutaneous Melanoma": {{"grade_3_plus_ae_pct": "23%", "serious_ae": "12%"}}}}
+- efficacy_data: object keyed by cancer type name, each value is metric name to string value. Omit cancer types with no data.
+- safety_data: same structure as efficacy_data but for safety metrics. Omit cancer types with no data.
 """
 
 
@@ -40,8 +44,14 @@ class NewsExtractionResult(BaseModel):
 
 
 class GeminiNewsExtractor:
-    def __init__(self, api_key: str, model: str = "gemini-2.5-flash") -> None:
-        self._service = GeminiLLMService(api_key=api_key, model=model)
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gemini-2.5-flash",
+        cost_calculator: Optional[CostCalculator] = None,
+    ) -> None:
+        self._service = GeminiLLMService(api_key=api_key, model=model, cost_calculator=cost_calculator)
+        self.cost_calculator = cost_calculator
 
     def extract(
         self, title: str, full_text: str, cancer_types: list[str]
@@ -54,14 +64,13 @@ class GeminiNewsExtractor:
             full_text=capped,
         )
         try:
-            result = asyncio.run(
-                self._service.generate_structured(
+            raw = asyncio.run(
+                self._service.extract_json(
                     prompt=prompt,
-                    response_schema=NewsExtractionResult,
                     operation="news_extraction",
-                    max_tokens=2048,
                 )
             )
+            result = NewsExtractionResult.model_validate(raw)
             result.has_efficacy = any(bool(v) for v in result.efficacy_data.values())
             result.has_safety = any(bool(v) for v in result.safety_data.values())
             return result

--- a/melanoma/src/infrastructure/news_scraper/onclive.py
+++ b/melanoma/src/infrastructure/news_scraper/onclive.py
@@ -1,0 +1,58 @@
+import logging
+from datetime import date, datetime
+
+import feedparser
+import requests
+
+from .base import NewsArticleRaw, NewsSourceBase
+
+logger = logging.getLogger(__name__)
+
+_RSS_URL = "https://www.onclive.com/rss"
+
+
+def _parse_feed_date(entry: object) -> date | None:
+    parsed = getattr(entry, "published_parsed", None)
+    if parsed is None:
+        return None
+    try:
+        return datetime(*parsed[:6]).date()
+    except Exception:
+        return None
+
+
+class OncLiveScraper(NewsSourceBase):
+    def __init__(self, timeout: int = 30) -> None:
+        self._timeout = timeout
+
+    def _fetch_feed_text(self) -> str:
+        resp = requests.get(_RSS_URL, timeout=self._timeout)
+        resp.raise_for_status()
+        return resp.text
+
+    def fetch_articles(self, since: date) -> list[NewsArticleRaw]:
+        try:
+            xml = self._fetch_feed_text()
+        except Exception as exc:
+            logger.warning("OncLive RSS fetch failed: %s", exc)
+            return []
+
+        feed = feedparser.parse(xml)
+        articles: list[NewsArticleRaw] = []
+        for entry in feed.entries:
+            pub_date = _parse_feed_date(entry)
+            if pub_date is None or pub_date < since:
+                continue
+            articles.append(
+                NewsArticleRaw(
+                    source="onclive",
+                    title=entry.get("title", ""),
+                    url=entry.get("link", ""),
+                    published_date=pub_date,
+                    description=entry.get("summary", ""),
+                    full_text=None,
+                )
+            )
+
+        logger.info("OncLive: %d articles since %s", len(articles), since)
+        return articles

--- a/melanoma/src/infrastructure/news_scraper/onclive.py
+++ b/melanoma/src/infrastructure/news_scraper/onclive.py
@@ -16,9 +16,11 @@ _NEWS_NS = "http://www.google.com/schemas/sitemap-news/0.9"
 class OncLiveScraper(NewsSourceBase):
     def __init__(self, timeout: int = 30) -> None:
         self._timeout = timeout
+        self._session = requests.Session()
+        self._session.headers["User-Agent"] = "Mozilla/5.0 (compatible; Bionocular/1.0)"
 
     def _fetch_sitemap_text(self) -> str:
-        resp = requests.get(_SITEMAP_URL, timeout=self._timeout)
+        resp = self._session.get(_SITEMAP_URL, timeout=self._timeout)
         resp.raise_for_status()
         return resp.text
 

--- a/melanoma/src/infrastructure/news_scraper/onclive.py
+++ b/melanoma/src/infrastructure/news_scraper/onclive.py
@@ -1,55 +1,60 @@
 import logging
-from datetime import date, datetime
+import xml.etree.ElementTree as ET
+from datetime import date
 
-import feedparser
 import requests
 
 from .base import NewsArticleRaw, NewsSourceBase
 
 logger = logging.getLogger(__name__)
 
-_RSS_URL = "https://www.onclive.com/rss"
-
-
-def _parse_feed_date(entry: object) -> date | None:
-    parsed = getattr(entry, "published_parsed", None)
-    if parsed is None:
-        return None
-    try:
-        return datetime(*parsed[:6]).date()
-    except Exception:
-        return None
+_SITEMAP_URL = "https://www.onclive.com/sitemap-news.xml"
+_SM_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+_NEWS_NS = "http://www.google.com/schemas/sitemap-news/0.9"
 
 
 class OncLiveScraper(NewsSourceBase):
     def __init__(self, timeout: int = 30) -> None:
         self._timeout = timeout
 
-    def _fetch_feed_text(self) -> str:
-        resp = requests.get(_RSS_URL, timeout=self._timeout)
+    def _fetch_sitemap_text(self) -> str:
+        resp = requests.get(_SITEMAP_URL, timeout=self._timeout)
         resp.raise_for_status()
         return resp.text
 
     def fetch_articles(self, since: date) -> list[NewsArticleRaw]:
         try:
-            xml = self._fetch_feed_text()
+            xml_text = self._fetch_sitemap_text()
         except Exception as exc:
-            logger.warning("OncLive RSS fetch failed: %s", exc)
+            logger.warning("OncLive sitemap fetch failed: %s", exc)
             return []
 
-        feed = feedparser.parse(xml)
+        root = ET.fromstring(xml_text)
         articles: list[NewsArticleRaw] = []
-        for entry in feed.entries:
-            pub_date = _parse_feed_date(entry)
-            if pub_date is None or pub_date < since:
+
+        for url_el in root.findall(f"{{{_SM_NS}}}url"):
+            loc = url_el.findtext(f"{{{_SM_NS}}}loc") or ""
+            news_el = url_el.find(f"{{{_NEWS_NS}}}news")
+            if news_el is None:
                 continue
+            pub_str = news_el.findtext(f"{{{_NEWS_NS}}}publication_date") or ""
+            title = news_el.findtext(f"{{{_NEWS_NS}}}title") or ""
+
+            try:
+                pub_date = date.fromisoformat(pub_str[:10])
+            except ValueError:
+                continue
+
+            if pub_date < since:
+                continue
+
             articles.append(
                 NewsArticleRaw(
                     source="onclive",
-                    title=entry.get("title", ""),
-                    url=entry.get("link", ""),
+                    title=title,
+                    url=loc,
                     published_date=pub_date,
-                    description=entry.get("summary", ""),
+                    description="",
                     full_text=None,
                 )
             )

--- a/melanoma/src/infrastructure/news_scraper/targetedonc.py
+++ b/melanoma/src/infrastructure/news_scraper/targetedonc.py
@@ -1,0 +1,93 @@
+import logging
+from datetime import date, datetime
+
+import feedparser
+import requests
+
+from .base import NewsArticleRaw, NewsSourceBase
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_KEYWORDS: list[str] = [
+    "cutaneous+melanoma",
+    "uveal+melanoma",
+    "acral+melanoma",
+    "mucosal+melanoma",
+    "merkel+cell+carcinoma",
+    "basal+cell+carcinoma",
+    "cutaneous+squamous+cell+carcinoma",
+]
+
+_GNEWS_URL = (
+    "https://news.google.com/rss/search"
+    "?q=site:targetedonc.com+{keyword}&hl=en-US&gl=US&ceid=US:en"
+)
+
+
+def _parse_feed_date(entry: object) -> date | None:
+    parsed = getattr(entry, "published_parsed", None)
+    if parsed is None:
+        return None
+    try:
+        return datetime(*parsed[:6]).date()
+    except Exception:
+        return None
+
+
+class TargetedOncScraper(NewsSourceBase):
+    def __init__(self, timeout: int = 15) -> None:
+        self._timeout = timeout
+        self._session = requests.Session()
+        self._session.headers["User-Agent"] = "Mozilla/5.0 (compatible; Bionocular/1.0)"
+
+    def _fetch_gnews_text(self, keyword: str = "melanoma") -> str:
+        url = _GNEWS_URL.format(keyword=keyword)
+        resp = self._session.get(url, timeout=self._timeout)
+        resp.raise_for_status()
+        return resp.text
+
+    def _resolve_redirect(self, url: str) -> str:
+        resp = self._session.get(url, timeout=self._timeout, allow_redirects=True)
+        return resp.url
+
+    def fetch_articles(self, since: date) -> list[NewsArticleRaw]:
+        seen_urls: set[str] = set()
+        articles: list[NewsArticleRaw] = []
+
+        for keyword in _SEARCH_KEYWORDS:
+            try:
+                xml = self._fetch_gnews_text(keyword)
+            except Exception as exc:
+                logger.warning("TargetedOnc Google News fetch failed for %s: %s", keyword, exc)
+                continue
+
+            feed = feedparser.parse(xml)
+            for entry in feed.entries:
+                pub_date = _parse_feed_date(entry)
+                if pub_date is None or pub_date < since:
+                    continue
+
+                google_url: str = entry.get("link", "")
+                try:
+                    resolved_url = self._resolve_redirect(google_url)
+                except Exception as exc:
+                    logger.warning("Redirect resolution failed for %s: %s", google_url, exc)
+                    resolved_url = google_url
+
+                if resolved_url in seen_urls:
+                    continue
+                seen_urls.add(resolved_url)
+
+                articles.append(
+                    NewsArticleRaw(
+                        source="targetedonc",
+                        title=entry.get("title", ""),
+                        url=resolved_url,
+                        published_date=pub_date,
+                        description=entry.get("summary", ""),
+                        full_text=None,
+                    )
+                )
+
+        logger.info("TargetedOnc: %d articles since %s", len(articles), since)
+        return articles

--- a/melanoma/src/infrastructure/news_scraper/targetedonc.py
+++ b/melanoma/src/infrastructure/news_scraper/targetedonc.py
@@ -62,7 +62,9 @@ class TargetedOncScraper(NewsSourceBase):
             try:
                 xml = self._fetch_gnews_text(keyword)
             except Exception as exc:
-                logger.warning("TargetedOnc Google News fetch failed for %s: %s", keyword, exc)
+                logger.warning(
+                    "TargetedOnc Google News fetch failed for %s: %s", keyword, exc
+                )
                 continue
 
             feed = feedparser.parse(xml)

--- a/melanoma/src/infrastructure/news_scraper/targetedonc.py
+++ b/melanoma/src/infrastructure/news_scraper/targetedonc.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 
 import feedparser
 import requests
+from googlenewsdecoder import gnewsdecoder
 
 from .base import NewsArticleRaw, NewsSourceBase
 
@@ -46,9 +47,12 @@ class TargetedOncScraper(NewsSourceBase):
         resp.raise_for_status()
         return resp.text
 
-    def _resolve_redirect(self, url: str) -> str:
-        resp = self._session.get(url, timeout=self._timeout, allow_redirects=True)
-        return resp.url
+    def _resolve_url(self, google_url: str) -> str:
+        result = gnewsdecoder(google_url, interval=1)
+        if result.get("status"):
+            return result["decoded_url"]
+        logger.warning("gnewsdecoder returned no URL for %s: %s", google_url, result)
+        return google_url
 
     def fetch_articles(self, since: date) -> list[NewsArticleRaw]:
         seen_urls: set[str] = set()
@@ -69,9 +73,9 @@ class TargetedOncScraper(NewsSourceBase):
 
                 google_url: str = entry.get("link", "")
                 try:
-                    resolved_url = self._resolve_redirect(google_url)
+                    resolved_url = self._resolve_url(google_url)
                 except Exception as exc:
-                    logger.warning("Redirect resolution failed for %s: %s", google_url, exc)
+                    logger.warning("URL decode failed for %s: %s", google_url, exc)
                     resolved_url = google_url
 
                 if resolved_url in seen_urls:

--- a/melanoma/tests/fixtures/biospace_cancer.html
+++ b/melanoma/tests/fixtures/biospace_cancer.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head><title>Cancer News - BioSpace</title></head>
+<body>
+<main>
+  <div class="news-container">
+    <article class="news-card">
+      <h3 class="news-title">
+        <a href="/avelumab-merkel-cell-carcinoma-3year-os">
+          Avelumab Phase 2 Data in Merkel Cell Carcinoma Shows 3-Year OS Benefit
+        </a>
+      </h3>
+      <span class="news-date">May 8, 2026</span>
+      <p class="news-summary">Avelumab demonstrated durable OS benefit in Merkel cell carcinoma patients with 3-year follow-up data from the JAVELIN Merkel 200 trial.</p>
+    </article>
+    <article class="news-card">
+      <h3 class="news-title">
+        <a href="/cemiplimab-cscc-real-world-outcomes">
+          Real-World Outcomes of cemiplimab in cutaneous squamous cell carcinoma
+        </a>
+      </h3>
+      <span class="news-date">April 22, 2026</span>
+      <p class="news-summary">Real-world study confirms cemiplimab efficacy in advanced cSCC patients.</p>
+    </article>
+    <article class="news-card">
+      <h3 class="news-title">
+        <a href="/type2-diabetes-new-drug-fda">
+          FDA Approves New Type 2 Diabetes Drug
+        </a>
+      </h3>
+      <span class="news-date">May 10, 2026</span>
+      <p class="news-summary">The FDA has approved a novel GLP-1 receptor agonist for type 2 diabetes treatment.</p>
+    </article>
+    <article class="news-card">
+      <h3 class="news-title">
+        <a href="/old-melanoma-article">
+          Old Melanoma Study From January
+        </a>
+      </h3>
+      <span class="news-date">January 15, 2026</span>
+      <p class="news-summary">Old melanoma article that predates our cutoff.</p>
+    </article>
+  </div>
+</main>
+</body>
+</html>

--- a/melanoma/tests/fixtures/cancernetwork_rss.xml
+++ b/melanoma/tests/fixtures/cancernetwork_rss.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>CancerNetwork</title>
+    <link>https://www.cancernetwork.com</link>
+    <description>CancerNetwork News</description>
+    <item>
+      <title>What is the Future of TIL Therapy in Metastatic Melanoma?</title>
+      <link>https://www.cancernetwork.com/view/til-therapy-metastatic-melanoma</link>
+      <guid isPermaLink="true">https://www.cancernetwork.com/view/til-therapy-metastatic-melanoma</guid>
+      <description>Muhammad Umair Mushtaq, MD, discussed the evolution of TIL therapy in melanoma, focusing on first-line treatment potential.</description>
+      <pubDate>Mon, 11 May 2026 19:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>cemiplimab Data in Cutaneous Squamous Cell Carcinoma</title>
+      <link>https://www.cancernetwork.com/view/cemiplimab-cscc</link>
+      <guid isPermaLink="true">https://www.cancernetwork.com/view/cemiplimab-cscc</guid>
+      <description>cemiplimab shows durable responses in advanced cutaneous squamous cell carcinoma (cSCC) in phase 2 study.</description>
+      <pubDate>Tue, 28 Apr 2026 10:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/melanoma/tests/fixtures/onclive_rss.xml
+++ b/melanoma/tests/fixtures/onclive_rss.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>OncLive articles</title>
+    <link>https://www.onclive.com</link>
+    <description>OncLive News</description>
+    <item>
+      <title>Phase 3 Pembrolizumab Shows PFS Benefit in Cutaneous Melanoma</title>
+      <link>https://www.onclive.com/view/phase-3-pembro-melanoma</link>
+      <guid isPermaLink="true">https://www.onclive.com/view/phase-3-pembro-melanoma</guid>
+      <description>Pembrolizumab demonstrated 12.3-month median PFS in cutaneous melanoma. NCT12345678 met its primary endpoint with ORR of 68%.</description>
+      <pubDate>Mon, 11 May 2026 21:02:31 GMT</pubDate>
+    </item>
+    <item>
+      <title>Avelumab Approved for Merkel Cell Carcinoma</title>
+      <link>https://www.onclive.com/view/avelumab-mcc</link>
+      <guid isPermaLink="true">https://www.onclive.com/view/avelumab-mcc</guid>
+      <description>FDA approval for avelumab in Merkel cell carcinoma based on JAVELIN trial.</description>
+      <pubDate>Wed, 08 Apr 2026 14:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Lung Cancer Immunotherapy Shows OS Benefit</title>
+      <link>https://www.onclive.com/view/lung-cancer-io</link>
+      <guid isPermaLink="true">https://www.onclive.com/view/lung-cancer-io</guid>
+      <description>Atezolizumab in NSCLC extends overall survival in phase 3 trial.</description>
+      <pubDate>Fri, 01 Jan 2026 10:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/melanoma/tests/fixtures/onclive_sitemap.xml
+++ b/melanoma/tests/fixtures/onclive_sitemap.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+  <url>
+    <loc>https://www.onclive.com/view/nivolumab-ipilimumab-melanoma-os-update</loc>
+    <news:news>
+      <news:publication>
+        <news:name>OncLive</news:name>
+        <news:language>en</news:language>
+      </news:publication>
+      <news:publication_date>2026-05-07</news:publication_date>
+      <news:title>Nivolumab Plus Ipilimumab Demonstrates Durable OS in Advanced Melanoma</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://www.onclive.com/view/pembrolizumab-cscc-phase3</loc>
+    <news:news>
+      <news:publication>
+        <news:name>OncLive</news:name>
+        <news:language>en</news:language>
+      </news:publication>
+      <news:publication_date>2026-04-10</news:publication_date>
+      <news:title>Pembrolizumab Meets Primary End Point in Phase 3 CSCC Trial</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://www.onclive.com/view/old-lung-cancer-article</loc>
+    <news:news>
+      <news:publication>
+        <news:name>OncLive</news:name>
+        <news:language>en</news:language>
+      </news:publication>
+      <news:publication_date>2026-01-01</news:publication_date>
+      <news:title>Some Old Lung Cancer Article</news:title>
+    </news:news>
+  </url>
+</urlset>

--- a/melanoma/tests/fixtures/targetedonc_gnews.xml
+++ b/melanoma/tests/fixtures/targetedonc_gnews.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Targeted Oncology - melanoma - Google News</title>
+    <link>https://news.google.com/rss/search?q=site:targetedonc.com+melanoma</link>
+    <description>Google News</description>
+    <item>
+      <title>FDA Grants Fast Track Designation to DOC1021 for Cutaneous Melanoma</title>
+      <link>https://news.google.com/rss/articles/CBMiogFBVV95cUxQ</link>
+      <guid>https://news.google.com/rss/articles/CBMiogFBVV95cUxQ</guid>
+      <source url="https://www.targetedonc.com">Targeted Oncology</source>
+      <pubDate>Wed, 07 May 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Tebentafusp-tebn Doubles 5-Year Survival in Metastatic Uveal Melanoma</title>
+      <link>https://news.google.com/rss/articles/CBMiogFBVV95cUxR</link>
+      <guid>https://news.google.com/rss/articles/CBMiogFBVV95cUxR</guid>
+      <source url="https://www.targetedonc.com">Targeted Oncology</source>
+      <pubDate>Fri, 24 Apr 2026 10:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/melanoma/tests/test_news_gemini_extractor.py
+++ b/melanoma/tests/test_news_gemini_extractor.py
@@ -19,10 +19,14 @@ class TestGeminiNewsExtractor:
         extractor = _make_extractor()
         mock_result = NewsExtractionResult(
             nct_ids=["NCT12345678"],
-            efficacy_data={"Cutaneous Melanoma": {"orr": "68%", "median_pfs": "12.3 months"}},
+            efficacy_data={
+                "Cutaneous Melanoma": {"orr": "68%", "median_pfs": "12.3 months"}
+            },
             safety_data={},
         )
-        with patch.object(extractor._service, "generate_structured", new=_mock_response(mock_result)):
+        with patch.object(
+            extractor._service, "generate_structured", new=_mock_response(mock_result)
+        ):
             result = extractor.extract(
                 title="Phase 3 Pembrolizumab in Melanoma",
                 full_text="NCT12345678 met primary endpoint. ORR 68%. Median PFS 12.3 months.",
@@ -58,9 +62,16 @@ class TestGeminiNewsExtractor:
         mock_result = NewsExtractionResult(
             nct_ids=[],
             efficacy_data={},
-            safety_data={"Cutaneous Melanoma": {"grade_3_plus_ae_pct": "23%", "serious_ae": "12%"}},
+            safety_data={
+                "Cutaneous Melanoma": {
+                    "grade_3_plus_ae_pct": "23%",
+                    "serious_ae": "12%",
+                }
+            },
         )
-        with patch.object(extractor._service, "generate_structured", new=_mock_response(mock_result)):
+        with patch.object(
+            extractor._service, "generate_structured", new=_mock_response(mock_result)
+        ):
             result = extractor.extract(
                 title="Safety Profile of Pembrolizumab in Melanoma",
                 full_text="Grade 3+ AEs occurred in 23% of patients.",
@@ -81,11 +92,16 @@ class TestGeminiNewsExtractor:
             },
             safety_data={},
         )
-        with patch.object(extractor._service, "generate_structured", new=_mock_response(mock_result)):
+        with patch.object(
+            extractor._service, "generate_structured", new=_mock_response(mock_result)
+        ):
             result = extractor.extract(
                 title="BCC and cSCC Treatment Advances",
                 full_text="ORR 45% in BCC. ORR 68% in cSCC.",
-                cancer_types=["Basal Cell Carcinoma", "Cutaneous Squamous Cell Carcinoma"],
+                cancer_types=[
+                    "Basal Cell Carcinoma",
+                    "Cutaneous Squamous Cell Carcinoma",
+                ],
             )
 
         assert result.has_efficacy is True

--- a/melanoma/tests/test_news_gemini_extractor.py
+++ b/melanoma/tests/test_news_gemini_extractor.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, patch
+
+from src.infrastructure.news_scraper.gemini_extractor import (
+    GeminiNewsExtractor,
+    NewsExtractionResult,
+)
+
+
+def _make_extractor() -> GeminiNewsExtractor:
+    return GeminiNewsExtractor(api_key="test-api-key")
+
+
+def _mock_response(result: NewsExtractionResult) -> AsyncMock:
+    return AsyncMock(return_value=result)
+
+
+class TestGeminiNewsExtractor:
+    def test_returns_nct_ids_and_per_type_efficacy(self):
+        extractor = _make_extractor()
+        mock_result = NewsExtractionResult(
+            nct_ids=["NCT12345678"],
+            efficacy_data={"Cutaneous Melanoma": {"orr": "68%", "median_pfs": "12.3 months"}},
+            safety_data={},
+        )
+        with patch.object(extractor._service, "generate_structured", new=_mock_response(mock_result)):
+            result = extractor.extract(
+                title="Phase 3 Pembrolizumab in Melanoma",
+                full_text="NCT12345678 met primary endpoint. ORR 68%. Median PFS 12.3 months.",
+                cancer_types=["Cutaneous Melanoma"],
+            )
+
+        assert result.nct_ids == ["NCT12345678"]
+        assert result.has_efficacy is True
+        assert result.efficacy_data["Cutaneous Melanoma"]["orr"] == "68%"
+        assert result.has_safety is False
+
+    def test_returns_empty_result_on_gemini_failure(self):
+        extractor = _make_extractor()
+        with patch.object(
+            extractor._service,
+            "generate_structured",
+            side_effect=Exception("API error"),
+        ):
+            result = extractor.extract(
+                title="Melanoma Trial Update",
+                full_text="Some article text.",
+                cancer_types=["Cutaneous Melanoma"],
+            )
+
+        assert result.nct_ids == []
+        assert result.has_efficacy is False
+        assert result.has_safety is False
+        assert result.efficacy_data == {}
+        assert result.safety_data == {}
+
+    def test_extracts_per_type_safety_data(self):
+        extractor = _make_extractor()
+        mock_result = NewsExtractionResult(
+            nct_ids=[],
+            efficacy_data={},
+            safety_data={"Cutaneous Melanoma": {"grade_3_plus_ae_pct": "23%", "serious_ae": "12%"}},
+        )
+        with patch.object(extractor._service, "generate_structured", new=_mock_response(mock_result)):
+            result = extractor.extract(
+                title="Safety Profile of Pembrolizumab in Melanoma",
+                full_text="Grade 3+ AEs occurred in 23% of patients.",
+                cancer_types=["Cutaneous Melanoma"],
+            )
+
+        assert result.has_safety is True
+        assert result.safety_data["Cutaneous Melanoma"]["grade_3_plus_ae_pct"] == "23%"
+        assert result.has_efficacy is False
+
+    def test_multi_cancer_type_extraction(self):
+        extractor = _make_extractor()
+        mock_result = NewsExtractionResult(
+            nct_ids=[],
+            efficacy_data={
+                "Basal Cell Carcinoma": {"orr": "45%"},
+                "Cutaneous Squamous Cell Carcinoma": {"orr": "68%"},
+            },
+            safety_data={},
+        )
+        with patch.object(extractor._service, "generate_structured", new=_mock_response(mock_result)):
+            result = extractor.extract(
+                title="BCC and cSCC Treatment Advances",
+                full_text="ORR 45% in BCC. ORR 68% in cSCC.",
+                cancer_types=["Basal Cell Carcinoma", "Cutaneous Squamous Cell Carcinoma"],
+            )
+
+        assert result.has_efficacy is True
+        assert "Basal Cell Carcinoma" in result.efficacy_data
+        assert "Cutaneous Squamous Cell Carcinoma" in result.efficacy_data
+
+    def test_prompt_contains_title_and_cancer_types(self):
+        extractor = _make_extractor()
+        captured: list[str] = []
+
+        async def capture(prompt: str, **kwargs: object) -> NewsExtractionResult:
+            captured.append(prompt)
+            return NewsExtractionResult()
+
+        with patch.object(extractor._service, "generate_structured", new=capture):
+            extractor.extract(
+                title="Unique Title For Testing",
+                full_text="Article body.",
+                cancer_types=["Uveal Melanoma", "Acral Melanoma"],
+            )
+
+        assert len(captured) == 1
+        assert "Unique Title For Testing" in captured[0]
+        assert "Uveal Melanoma" in captured[0]
+        assert "Acral Melanoma" in captured[0]

--- a/melanoma/tests/test_news_gemini_extractor.py
+++ b/melanoma/tests/test_news_gemini_extractor.py
@@ -11,7 +11,7 @@ def _make_extractor() -> GeminiNewsExtractor:
 
 
 def _mock_response(result: NewsExtractionResult) -> AsyncMock:
-    return AsyncMock(return_value=result)
+    return AsyncMock(return_value=result.model_dump())
 
 
 class TestGeminiNewsExtractor:
@@ -25,7 +25,7 @@ class TestGeminiNewsExtractor:
             safety_data={},
         )
         with patch.object(
-            extractor._service, "generate_structured", new=_mock_response(mock_result)
+            extractor._service, "extract_json", new=_mock_response(mock_result)
         ):
             result = extractor.extract(
                 title="Phase 3 Pembrolizumab in Melanoma",
@@ -42,7 +42,7 @@ class TestGeminiNewsExtractor:
         extractor = _make_extractor()
         with patch.object(
             extractor._service,
-            "generate_structured",
+            "extract_json",
             side_effect=Exception("API error"),
         ):
             result = extractor.extract(
@@ -70,7 +70,7 @@ class TestGeminiNewsExtractor:
             },
         )
         with patch.object(
-            extractor._service, "generate_structured", new=_mock_response(mock_result)
+            extractor._service, "extract_json", new=_mock_response(mock_result)
         ):
             result = extractor.extract(
                 title="Safety Profile of Pembrolizumab in Melanoma",
@@ -93,7 +93,7 @@ class TestGeminiNewsExtractor:
             safety_data={},
         )
         with patch.object(
-            extractor._service, "generate_structured", new=_mock_response(mock_result)
+            extractor._service, "extract_json", new=_mock_response(mock_result)
         ):
             result = extractor.extract(
                 title="BCC and cSCC Treatment Advances",
@@ -112,11 +112,11 @@ class TestGeminiNewsExtractor:
         extractor = _make_extractor()
         captured: list[str] = []
 
-        async def capture(prompt: str, **kwargs: object) -> NewsExtractionResult:
+        async def capture(prompt: str, **kwargs: object) -> dict:
             captured.append(prompt)
-            return NewsExtractionResult()
+            return NewsExtractionResult().model_dump()
 
-        with patch.object(extractor._service, "generate_structured", new=capture):
+        with patch.object(extractor._service, "extract_json", new=capture):
             extractor.extract(
                 title="Unique Title For Testing",
                 full_text="Article body.",

--- a/melanoma/tests/test_news_scraper_base.py
+++ b/melanoma/tests/test_news_scraper_base.py
@@ -1,7 +1,5 @@
 from datetime import date
 
-import pytest
-
 from src.infrastructure.news_scraper.base import NewsArticleRaw
 from src.infrastructure.news_scraper.cancer_filter import assign_cancer_types
 
@@ -79,9 +77,7 @@ def test_discards_unrelated():
 
 
 def test_multiple_types():
-    article = _article(
-        "Rare Skin Cancers: BCC and cSCC Treatment Advances"
-    )
+    article = _article("Rare Skin Cancers: BCC and cSCC Treatment Advances")
     types = assign_cancer_types(article)
     assert "Basal Cell Carcinoma" in types
     assert "Cutaneous Squamous Cell Carcinoma" in types

--- a/melanoma/tests/test_news_scraper_base.py
+++ b/melanoma/tests/test_news_scraper_base.py
@@ -1,0 +1,96 @@
+from datetime import date
+
+import pytest
+
+from src.infrastructure.news_scraper.base import NewsArticleRaw
+from src.infrastructure.news_scraper.cancer_filter import assign_cancer_types
+
+
+def _article(title: str, description: str = "") -> NewsArticleRaw:
+    return NewsArticleRaw(
+        source="onclive",
+        title=title,
+        url="https://example.com/article",
+        published_date=date(2026, 3, 1),
+        description=description,
+        full_text=None,
+    )
+
+
+def test_assigns_cutaneous_melanoma():
+    article = _article("Phase 3 Pembrolizumab Results in Cutaneous Melanoma")
+    types = assign_cancer_types(article)
+    assert "Cutaneous Melanoma" in types
+
+
+def test_assigns_uveal_melanoma():
+    article = _article("Tebentafusp Doubles 5-Year Survival in Uveal Melanoma")
+    types = assign_cancer_types(article)
+    assert "Uveal Melanoma" in types
+
+
+def test_assigns_acral_melanoma():
+    article = _article("New Data for Acral Lentiginous Melanoma Treatment")
+    types = assign_cancer_types(article)
+    assert "Acral Melanoma" in types
+
+
+def test_assigns_mucosal_melanoma():
+    article = _article("Immunotherapy Results in Mucosal Melanoma Reported")
+    types = assign_cancer_types(article)
+    assert "Mucosal Melanoma" in types
+
+
+def test_assigns_brain_cns_metastasis():
+    article = _article("Melanoma Brain Metastasis Study Shows Improved Outcomes")
+    types = assign_cancer_types(article)
+    assert "Cutaneous Melanoma with Brain/CNS Metastasis" in types
+    assert "Cutaneous Melanoma" in types  # also tagged as cutaneous
+
+
+def test_assigns_cscc():
+    article = _article("Anti-PD-1 in Cutaneous Squamous Cell Carcinoma Phase 2 Trial")
+    types = assign_cancer_types(article)
+    assert "Cutaneous Squamous Cell Carcinoma" in types
+
+
+def test_assigns_cscc_by_acronym():
+    article = _article("cemiplimab for cSCC Receives FDA Approval")
+    types = assign_cancer_types(article)
+    assert "Cutaneous Squamous Cell Carcinoma" in types
+
+
+def test_assigns_bcc():
+    article = _article("Vismodegib Data in Basal Cell Carcinoma")
+    types = assign_cancer_types(article)
+    assert "Basal Cell Carcinoma" in types
+
+
+def test_assigns_mcc():
+    article = _article("Avelumab Maintains OS Benefit in Merkel Cell Carcinoma")
+    types = assign_cancer_types(article)
+    assert "Merkel Cell Carcinoma" in types
+
+
+def test_discards_unrelated():
+    article = _article("Atezolizumab in NSCLC Shows PFS Benefit")
+    types = assign_cancer_types(article)
+    assert types == []
+
+
+def test_multiple_types():
+    article = _article(
+        "Rare Skin Cancers: BCC and cSCC Treatment Advances"
+    )
+    types = assign_cancer_types(article)
+    assert "Basal Cell Carcinoma" in types
+    assert "Cutaneous Squamous Cell Carcinoma" in types
+
+
+def test_description_fallback():
+    article = _article(
+        title="New Oncology Data Released",
+        description="Phase 3 results in cutaneous melanoma patients show ORR of 68%.",
+    )
+    types = assign_cancer_types(article)
+    assert "Cutaneous Melanoma" in types

--- a/melanoma/tests/test_news_scraper_biospace.py
+++ b/melanoma/tests/test_news_scraper_biospace.py
@@ -1,0 +1,54 @@
+import pathlib
+from datetime import date
+from unittest.mock import patch
+
+from src.infrastructure.news_scraper.biospace import BioSpaceScraper
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+
+
+class TestBioSpaceScraper:
+    def test_parses_skin_cancer_articles(self):
+        html = (FIXTURES / "biospace_cancer.html").read_text()
+        scraper = BioSpaceScraper()
+        with patch.object(scraper, "_fetch_page_html", return_value=html):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+
+        titles = [a.title for a in articles]
+        assert any("Merkel Cell Carcinoma" in t for t in titles)
+        assert any("squamous cell carcinoma" in t.lower() for t in titles)
+
+    def test_excludes_non_skin_cancer(self):
+        html = (FIXTURES / "biospace_cancer.html").read_text()
+        scraper = BioSpaceScraper()
+        with patch.object(scraper, "_fetch_page_html", return_value=html):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+
+        titles = [a.title for a in articles]
+        assert not any("Diabetes" in t for t in titles)
+
+    def test_filters_by_date(self):
+        html = (FIXTURES / "biospace_cancer.html").read_text()
+        scraper = BioSpaceScraper()
+        with patch.object(scraper, "_fetch_page_html", return_value=html):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+
+        assert not any("Old Melanoma" in a.title for a in articles)
+
+    def test_article_fields(self):
+        html = (FIXTURES / "biospace_cancer.html").read_text()
+        scraper = BioSpaceScraper()
+        with patch.object(scraper, "_fetch_page_html", return_value=html):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+
+        mcc_article = next(a for a in articles if "Merkel" in a.title)
+        assert mcc_article.source == "biospace"
+        assert mcc_article.published_date == date(2026, 5, 8)
+        assert mcc_article.url == "https://www.biospace.com/avelumab-merkel-cell-carcinoma-3year-os"
+        assert "JAVELIN" in mcc_article.description
+
+    def test_returns_empty_on_fetch_failure(self):
+        scraper = BioSpaceScraper()
+        with patch.object(scraper, "_fetch_page_html", side_effect=Exception("timeout")):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+        assert articles == []

--- a/melanoma/tests/test_news_scraper_biospace.py
+++ b/melanoma/tests/test_news_scraper_biospace.py
@@ -15,7 +15,8 @@ class TestBioSpaceScraper:
         with (
             patch.object(scraper, "_fetch_gnews_text", return_value=xml),
             patch.object(
-                scraper, "_resolve_url",
+                scraper,
+                "_resolve_url",
                 return_value="https://www.biospace.com/some-article",
             ),
         ):
@@ -29,7 +30,9 @@ class TestBioSpaceScraper:
 
         with (
             patch.object(scraper, "_fetch_gnews_text", return_value=xml),
-            patch.object(scraper, "_resolve_url", side_effect=Exception("decode failed")),
+            patch.object(
+                scraper, "_resolve_url", side_effect=Exception("decode failed")
+            ),
         ):
             articles = scraper.fetch_articles(since=date(2026, 4, 1))
 
@@ -54,6 +57,8 @@ class TestBioSpaceScraper:
 
     def test_returns_empty_on_fetch_failure(self):
         scraper = BioSpaceScraper()
-        with patch.object(scraper, "_fetch_gnews_text", side_effect=Exception("timeout")):
+        with patch.object(
+            scraper, "_fetch_gnews_text", side_effect=Exception("timeout")
+        ):
             articles = scraper.fetch_articles(since=date(2026, 4, 1))
         assert articles == []

--- a/melanoma/tests/test_news_scraper_biospace.py
+++ b/melanoma/tests/test_news_scraper_biospace.py
@@ -8,47 +8,52 @@ FIXTURES = pathlib.Path(__file__).parent / "fixtures"
 
 
 class TestBioSpaceScraper:
-    def test_parses_skin_cancer_articles(self):
-        html = (FIXTURES / "biospace_cancer.html").read_text()
+    def test_resolves_google_url_to_real_url(self):
+        xml = (FIXTURES / "targetedonc_gnews.xml").read_text()  # reuse same RSS shape
         scraper = BioSpaceScraper()
-        with patch.object(scraper, "_fetch_page_html", return_value=html):
-            articles = scraper.fetch_articles(since=date(2026, 2, 7))
 
-        titles = [a.title for a in articles]
-        assert any("Merkel Cell Carcinoma" in t for t in titles)
-        assert any("squamous cell carcinoma" in t.lower() for t in titles)
+        with (
+            patch.object(scraper, "_fetch_gnews_text", return_value=xml),
+            patch.object(
+                scraper, "_resolve_url",
+                return_value="https://www.biospace.com/some-article",
+            ),
+        ):
+            articles = scraper.fetch_articles(since=date(2026, 4, 1))
 
-    def test_excludes_non_skin_cancer(self):
-        html = (FIXTURES / "biospace_cancer.html").read_text()
+        assert all(not a.url.startswith("https://news.google.com") for a in articles)
+
+    def test_falls_back_to_google_url_on_decode_failure(self):
+        xml = (FIXTURES / "targetedonc_gnews.xml").read_text()
         scraper = BioSpaceScraper()
-        with patch.object(scraper, "_fetch_page_html", return_value=html):
-            articles = scraper.fetch_articles(since=date(2026, 2, 7))
 
-        titles = [a.title for a in articles]
-        assert not any("Diabetes" in t for t in titles)
+        with (
+            patch.object(scraper, "_fetch_gnews_text", return_value=xml),
+            patch.object(scraper, "_resolve_url", side_effect=Exception("decode failed")),
+        ):
+            articles = scraper.fetch_articles(since=date(2026, 4, 1))
 
-    def test_filters_by_date(self):
-        html = (FIXTURES / "biospace_cancer.html").read_text()
+        # fallback: keeps original google URL rather than crashing
+        assert len(articles) > 0
+
+    def test_deduplicates_across_keywords(self):
+        xml = (FIXTURES / "targetedonc_gnews.xml").read_text()
         scraper = BioSpaceScraper()
-        with patch.object(scraper, "_fetch_page_html", return_value=html):
-            articles = scraper.fetch_articles(since=date(2026, 2, 7))
 
-        assert not any("Old Melanoma" in a.title for a in articles)
+        def fake_resolve(_url: str) -> str:
+            return "https://www.biospace.com/same-article"  # always same URL
 
-    def test_article_fields(self):
-        html = (FIXTURES / "biospace_cancer.html").read_text()
-        scraper = BioSpaceScraper()
-        with patch.object(scraper, "_fetch_page_html", return_value=html):
-            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+        with (
+            patch.object(scraper, "_fetch_gnews_text", return_value=xml),
+            patch.object(scraper, "_resolve_url", side_effect=fake_resolve),
+        ):
+            articles = scraper.fetch_articles(since=date(2026, 4, 1))
 
-        mcc_article = next(a for a in articles if "Merkel" in a.title)
-        assert mcc_article.source == "biospace"
-        assert mcc_article.published_date == date(2026, 5, 8)
-        assert mcc_article.url == "https://www.biospace.com/avelumab-merkel-cell-carcinoma-3year-os"
-        assert "JAVELIN" in mcc_article.description
+        urls = [a.url for a in articles]
+        assert len(urls) == len(set(urls))
 
     def test_returns_empty_on_fetch_failure(self):
         scraper = BioSpaceScraper()
-        with patch.object(scraper, "_fetch_page_html", side_effect=Exception("timeout")):
-            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+        with patch.object(scraper, "_fetch_gnews_text", side_effect=Exception("timeout")):
+            articles = scraper.fetch_articles(since=date(2026, 4, 1))
         assert articles == []

--- a/melanoma/tests/test_news_scraper_cli.py
+++ b/melanoma/tests/test_news_scraper_cli.py
@@ -103,12 +103,11 @@ class TestBuildUpsertRow:
         assert row["extracted_at"] is None
 
 
-class TestPipelineWithoutGeminiKey:
-    def test_pipeline_runs_without_gemini_key(self, monkeypatch):
-        """Pipeline should proceed without GEMINI_API_KEY — skips extraction."""
+class TestPipelineWithoutGoogleApiKey:
+    def test_pipeline_runs_without_google_api_key(self, monkeypatch):
+        """Pipeline should proceed without GOOGLE_API_KEY — skips extraction."""
         from unittest.mock import MagicMock, patch
 
-        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
         monkeypatch.setenv("SUPABASE_KEY", "fake-key")
@@ -129,4 +128,4 @@ class TestPipelineWithoutGeminiKey:
 
             result = main()
 
-        assert result != 2, "Should not fail with GEMINI_API_KEY error"
+        assert result != 2

--- a/melanoma/tests/test_news_scraper_cli.py
+++ b/melanoma/tests/test_news_scraper_cli.py
@@ -1,16 +1,13 @@
 import sys
-import pathlib
 from datetime import date
 from unittest.mock import MagicMock
 
 import pytest
 
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
-
 from scripts.scrape_news_supabase import (
-    fetch_full_text,
     build_upsert_row,
     compute_since,
+    fetch_full_text,
     main,
 )
 from src.infrastructure.news_scraper.base import NewsArticleRaw
@@ -20,6 +17,7 @@ from src.infrastructure.news_scraper.gemini_extractor import NewsExtractionResul
 class TestComputeSince:
     def test_days_flag(self):
         from datetime import timedelta
+
         result = compute_since(days=3, since_str=None)
         assert result == date.today() - timedelta(days=3)
 
@@ -113,7 +111,9 @@ class TestPipelineWithoutGoogleApiKey:
         monkeypatch.setattr(sys, "argv", ["scrape_news_supabase.py", "--days", "1"])
 
         with (
-            patch("scripts.scrape_news_supabase.load_dotenv"),  # prevent .env from overwriting delenv
+            patch(
+                "scripts.scrape_news_supabase.load_dotenv"
+            ),  # prevent .env from overwriting delenv
             patch("scripts.scrape_news_supabase.OncLiveScraper") as mock_onclive,
             patch("scripts.scrape_news_supabase.CancerNetworkScraper") as mock_cn,
             patch("scripts.scrape_news_supabase.TargetedOncScraper") as mock_to,

--- a/melanoma/tests/test_news_scraper_cli.py
+++ b/melanoma/tests/test_news_scraper_cli.py
@@ -1,0 +1,102 @@
+import sys
+import pathlib
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from scripts.scrape_news_supabase import (
+    fetch_full_text,
+    build_upsert_row,
+    compute_since,
+)
+from src.infrastructure.news_scraper.base import NewsArticleRaw
+from src.infrastructure.news_scraper.gemini_extractor import NewsExtractionResult
+
+
+class TestComputeSince:
+    def test_days_flag(self):
+        from datetime import timedelta
+        result = compute_since(days=3, since_str=None)
+        assert result == date.today() - timedelta(days=3)
+
+    def test_since_str_overrides_days(self):
+        result = compute_since(days=7, since_str="2026-02-06")
+        assert result == date(2026, 2, 6)
+
+    def test_invalid_since_str_raises(self):
+        with pytest.raises(SystemExit):
+            compute_since(days=2, since_str="not-a-date")
+
+
+class TestFetchFullText:
+    def test_returns_text_on_success(self):
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "<html><body><p>Article content here.</p></body></html>"
+        mock_response.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_response
+
+        text = fetch_full_text("https://example.com/article", mock_session)
+        assert text is not None
+        assert "Article content here." in text
+
+    def test_returns_none_on_failure(self):
+        mock_session = MagicMock()
+        mock_session.get.side_effect = Exception("timeout")
+
+        text = fetch_full_text("https://example.com/article", mock_session)
+        assert text is None
+
+
+class TestBuildUpsertRow:
+    def test_builds_complete_row(self):
+        article = NewsArticleRaw(
+            source="onclive",
+            title="Phase 3 Pembrolizumab in Melanoma",
+            url="https://www.onclive.com/view/pembro-melanoma",
+            published_date=date(2026, 5, 11),
+            description="ORR 68% in cutaneous melanoma.",
+            full_text="Full article text here.",
+        )
+        cancer_types = ["Cutaneous Melanoma"]
+        extraction = NewsExtractionResult(
+            nct_ids=["NCT12345678"],
+            has_efficacy=True,
+            efficacy_data={"Cutaneous Melanoma": {"orr": "68%"}},
+            has_safety=False,
+            safety_data={},
+        )
+
+        row = build_upsert_row(article, cancer_types, extraction)
+
+        assert row["source"] == "onclive"
+        assert row["title"] == "Phase 3 Pembrolizumab in Melanoma"
+        assert row["url"] == "https://www.onclive.com/view/pembro-melanoma"
+        assert row["date"] == "2026-05-11"
+        assert row["cancer_type"] == ["Cutaneous Melanoma"]
+        assert row["nct_ids"] == ["NCT12345678"]
+        assert row["has_efficacy"] is True
+        assert row["efficacy_data"] == {"Cutaneous Melanoma": {"orr": "68%"}}
+        assert row["has_safety"] is False
+        assert row["safety_data"] == {}
+        assert row["extracted_at"] is not None
+
+    def test_builds_row_without_extraction(self):
+        article = NewsArticleRaw(
+            source="biospace",
+            title="Melanoma Trial Update",
+            url="https://www.biospace.com/melanoma-trial",
+            published_date=date(2026, 4, 1),
+            description="Trial update.",
+            full_text=None,
+        )
+        cancer_types = ["Cutaneous Melanoma"]
+
+        row = build_upsert_row(article, cancer_types, extraction=None)
+
+        assert row["nct_ids"] == []
+        assert row["has_efficacy"] is False
+        assert row["extracted_at"] is None

--- a/melanoma/tests/test_news_scraper_cli.py
+++ b/melanoma/tests/test_news_scraper_cli.py
@@ -11,6 +11,7 @@ from scripts.scrape_news_supabase import (
     fetch_full_text,
     build_upsert_row,
     compute_since,
+    main,
 )
 from src.infrastructure.news_scraper.base import NewsArticleRaw
 from src.infrastructure.news_scraper.gemini_extractor import NewsExtractionResult
@@ -100,3 +101,32 @@ class TestBuildUpsertRow:
         assert row["nct_ids"] == []
         assert row["has_efficacy"] is False
         assert row["extracted_at"] is None
+
+
+class TestPipelineWithoutGeminiKey:
+    def test_pipeline_runs_without_gemini_key(self, monkeypatch):
+        """Pipeline should proceed without GEMINI_API_KEY — skips extraction."""
+        from unittest.mock import MagicMock, patch
+
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
+        monkeypatch.setenv("SUPABASE_KEY", "fake-key")
+        monkeypatch.setattr(sys, "argv", ["scrape_news_supabase.py", "--days", "1"])
+
+        with (
+            patch("scripts.scrape_news_supabase.load_dotenv"),  # prevent .env from overwriting delenv
+            patch("scripts.scrape_news_supabase.OncLiveScraper") as mock_onclive,
+            patch("scripts.scrape_news_supabase.CancerNetworkScraper") as mock_cn,
+            patch("scripts.scrape_news_supabase.TargetedOncScraper") as mock_to,
+            patch("scripts.scrape_news_supabase.BioSpaceScraper") as mock_bs,
+            patch("scripts.scrape_news_supabase.create_client") as mock_create_client,
+            patch("scripts.scrape_news_supabase.CostCalculator"),
+        ):
+            for m in [mock_onclive, mock_cn, mock_to, mock_bs]:
+                m.return_value.fetch_articles.return_value = []
+            mock_create_client.return_value = MagicMock()
+
+            result = main()
+
+        assert result != 2, "Should not fail with GEMINI_API_KEY error"

--- a/melanoma/tests/test_news_scraper_cli.py
+++ b/melanoma/tests/test_news_scraper_cli.py
@@ -73,7 +73,6 @@ class TestBuildUpsertRow:
 
         row = build_upsert_row(article, cancer_types, extraction)
 
-        assert row["source"] == "onclive"
         assert row["title"] == "Phase 3 Pembrolizumab in Melanoma"
         assert row["url"] == "https://www.onclive.com/view/pembro-melanoma"
         assert row["date"] == "2026-05-11"

--- a/melanoma/tests/test_news_scraper_rss.py
+++ b/melanoma/tests/test_news_scraper_rss.py
@@ -2,10 +2,8 @@ import pathlib
 from datetime import date
 from unittest.mock import patch
 
-import pytest
-
-from src.infrastructure.news_scraper.onclive import OncLiveScraper
 from src.infrastructure.news_scraper.cancernetwork import CancerNetworkScraper
+from src.infrastructure.news_scraper.onclive import OncLiveScraper
 
 FIXTURES = pathlib.Path(__file__).parent / "fixtures"
 
@@ -14,37 +12,45 @@ def _read(name: str) -> str:
     return (FIXTURES / name).read_text()
 
 
-class TestOncLiveScraper:
-    def test_parses_articles_since_cutoff(self):
-        xml = _read("onclive_rss.xml")
+class TestOncLiveSitemapScraper:
+    def test_parses_articles_from_sitemap(self):
+        xml = _read("onclive_sitemap.xml")
         scraper = OncLiveScraper()
-        with patch.object(scraper, "_fetch_feed_text", return_value=xml):
-            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+        with patch.object(scraper, "_fetch_sitemap_text", return_value=xml):
+            articles = scraper.fetch_articles(since=date(2026, 4, 1))
 
+        assert len(articles) == 2
         urls = [a.url for a in articles]
-        assert "https://www.onclive.com/view/phase-3-pembro-melanoma" in urls
-        assert "https://www.onclive.com/view/avelumab-mcc" in urls
-        assert "https://www.onclive.com/view/lung-cancer-io" not in urls
+        assert "https://www.onclive.com/view/nivolumab-ipilimumab-melanoma-os-update" in urls
+        nivo = next(a for a in articles if "nivolumab" in a.url)
+        assert nivo.title == "Nivolumab Plus Ipilimumab Demonstrates Durable OS in Advanced Melanoma"
+        assert nivo.published_date == date(2026, 5, 7)
+        assert nivo.source == "onclive"
 
-    def test_article_fields(self):
-        xml = _read("onclive_rss.xml")
+    def test_filters_by_since_date(self):
+        xml = _read("onclive_sitemap.xml")
         scraper = OncLiveScraper()
-        with patch.object(scraper, "_fetch_feed_text", return_value=xml):
-            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+        with patch.object(scraper, "_fetch_sitemap_text", return_value=xml):
+            articles = scraper.fetch_articles(since=date(2026, 4, 1))
 
-        art = next(a for a in articles if "pembro" in a.url)
-        assert art.source == "onclive"
-        assert "Pembrolizumab" in art.title
-        assert art.published_date == date(2026, 5, 11)
-        assert "NCT12345678" in art.description
-        assert art.full_text is None
+        dates = [a.published_date for a in articles]
+        assert all(d >= date(2026, 4, 1) for d in dates)
+        assert date(2026, 1, 1) not in dates
 
-    def test_empty_when_all_old(self):
-        xml = _read("onclive_rss.xml")
+    def test_returns_empty_on_fetch_failure(self):
         scraper = OncLiveScraper()
-        with patch.object(scraper, "_fetch_feed_text", return_value=xml):
-            articles = scraper.fetch_articles(since=date(2026, 6, 1))
+        with patch.object(scraper, "_fetch_sitemap_text", side_effect=Exception("403")):
+            articles = scraper.fetch_articles(since=date(2026, 4, 1))
         assert articles == []
+
+    def test_url_is_real_article_url(self):
+        xml = _read("onclive_sitemap.xml")
+        scraper = OncLiveScraper()
+        with patch.object(scraper, "_fetch_sitemap_text", return_value=xml):
+            articles = scraper.fetch_articles(since=date(2026, 4, 1))
+
+        assert all(a.url.startswith("https://www.onclive.com/") for a in articles)
+        assert all("news.google.com" not in a.url for a in articles)
 
 
 class TestCancerNetworkScraper:

--- a/melanoma/tests/test_news_scraper_rss.py
+++ b/melanoma/tests/test_news_scraper_rss.py
@@ -21,9 +21,15 @@ class TestOncLiveSitemapScraper:
 
         assert len(articles) == 2
         urls = [a.url for a in articles]
-        assert "https://www.onclive.com/view/nivolumab-ipilimumab-melanoma-os-update" in urls
+        assert (
+            "https://www.onclive.com/view/nivolumab-ipilimumab-melanoma-os-update"
+            in urls
+        )
         nivo = next(a for a in articles if "nivolumab" in a.url)
-        assert nivo.title == "Nivolumab Plus Ipilimumab Demonstrates Durable OS in Advanced Melanoma"
+        assert (
+            nivo.title
+            == "Nivolumab Plus Ipilimumab Demonstrates Durable OS in Advanced Melanoma"
+        )
         assert nivo.published_date == date(2026, 5, 7)
         assert nivo.source == "onclive"
 
@@ -63,4 +69,6 @@ class TestCancerNetworkScraper:
         assert len(articles) == 2
         assert articles[0].source == "cancernetwork"
         urls = [a.url for a in articles]
-        assert "https://www.cancernetwork.com/view/til-therapy-metastatic-melanoma" in urls
+        assert (
+            "https://www.cancernetwork.com/view/til-therapy-metastatic-melanoma" in urls
+        )

--- a/melanoma/tests/test_news_scraper_rss.py
+++ b/melanoma/tests/test_news_scraper_rss.py
@@ -1,0 +1,60 @@
+import pathlib
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+from src.infrastructure.news_scraper.onclive import OncLiveScraper
+from src.infrastructure.news_scraper.cancernetwork import CancerNetworkScraper
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+
+
+def _read(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+class TestOncLiveScraper:
+    def test_parses_articles_since_cutoff(self):
+        xml = _read("onclive_rss.xml")
+        scraper = OncLiveScraper()
+        with patch.object(scraper, "_fetch_feed_text", return_value=xml):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+
+        urls = [a.url for a in articles]
+        assert "https://www.onclive.com/view/phase-3-pembro-melanoma" in urls
+        assert "https://www.onclive.com/view/avelumab-mcc" in urls
+        assert "https://www.onclive.com/view/lung-cancer-io" not in urls
+
+    def test_article_fields(self):
+        xml = _read("onclive_rss.xml")
+        scraper = OncLiveScraper()
+        with patch.object(scraper, "_fetch_feed_text", return_value=xml):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+
+        art = next(a for a in articles if "pembro" in a.url)
+        assert art.source == "onclive"
+        assert "Pembrolizumab" in art.title
+        assert art.published_date == date(2026, 5, 11)
+        assert "NCT12345678" in art.description
+        assert art.full_text is None
+
+    def test_empty_when_all_old(self):
+        xml = _read("onclive_rss.xml")
+        scraper = OncLiveScraper()
+        with patch.object(scraper, "_fetch_feed_text", return_value=xml):
+            articles = scraper.fetch_articles(since=date(2026, 6, 1))
+        assert articles == []
+
+
+class TestCancerNetworkScraper:
+    def test_parses_articles(self):
+        xml = _read("cancernetwork_rss.xml")
+        scraper = CancerNetworkScraper()
+        with patch.object(scraper, "_fetch_feed_text", return_value=xml):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+
+        assert len(articles) == 2
+        assert articles[0].source == "cancernetwork"
+        urls = [a.url for a in articles]
+        assert "https://www.cancernetwork.com/view/til-therapy-metastatic-melanoma" in urls

--- a/melanoma/tests/test_news_scraper_targetedonc.py
+++ b/melanoma/tests/test_news_scraper_targetedonc.py
@@ -1,8 +1,6 @@
 import pathlib
 from datetime import date
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from src.infrastructure.news_scraper.targetedonc import TargetedOncScraper
 

--- a/melanoma/tests/test_news_scraper_targetedonc.py
+++ b/melanoma/tests/test_news_scraper_targetedonc.py
@@ -1,0 +1,81 @@
+import pathlib
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.infrastructure.news_scraper.targetedonc import TargetedOncScraper
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+
+
+class TestTargetedOncScraper:
+    def test_parses_articles_from_gnews(self):
+        xml = (FIXTURES / "targetedonc_gnews.xml").read_text()
+        scraper = TargetedOncScraper()
+
+        def mock_resolve(url: str) -> str:
+            mapping = {
+                "https://news.google.com/rss/articles/CBMiogFBVV95cUxQ": "https://www.targetedonc.com/view/doc1021-fast-track-melanoma",
+                "https://news.google.com/rss/articles/CBMiogFBVV95cUxR": "https://www.targetedonc.com/view/tebentafusp-uveal-melanoma",
+            }
+            return mapping.get(url, url)
+
+        with (
+            patch.object(scraper, "_fetch_gnews_text", return_value=xml),
+            patch.object(scraper, "_resolve_redirect", side_effect=mock_resolve),
+        ):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+
+        assert len(articles) == 2
+        urls = [a.url for a in articles]
+        assert "https://www.targetedonc.com/view/doc1021-fast-track-melanoma" in urls
+        assert "https://www.targetedonc.com/view/tebentafusp-uveal-melanoma" in urls
+
+    def test_article_source_is_targetedonc(self):
+        xml = (FIXTURES / "targetedonc_gnews.xml").read_text()
+        scraper = TargetedOncScraper()
+        with (
+            patch.object(scraper, "_fetch_gnews_text", return_value=xml),
+            patch.object(scraper, "_resolve_redirect", side_effect=lambda url: url),
+        ):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+        assert all(a.source == "targetedonc" for a in articles)
+
+    def test_filters_by_date(self):
+        xml = (FIXTURES / "targetedonc_gnews.xml").read_text()
+        scraper = TargetedOncScraper()
+        with (
+            patch.object(scraper, "_fetch_gnews_text", return_value=xml),
+            patch.object(scraper, "_resolve_redirect", side_effect=lambda url: url),
+        ):
+            articles = scraper.fetch_articles(since=date(2026, 5, 1))
+
+        assert len(articles) == 1
+        assert "DOC1021" in articles[0].title
+
+    def test_deduplicates_by_url(self):
+        xml = (FIXTURES / "targetedonc_gnews.xml").read_text()
+        scraper = TargetedOncScraper()
+        with (
+            patch.object(scraper, "_fetch_gnews_text", return_value=xml),
+            patch.object(scraper, "_resolve_redirect", side_effect=lambda url: url),
+        ):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+        urls = [a.url for a in articles]
+        assert len(urls) == len(set(urls))
+
+    def test_falls_back_to_google_url_on_redirect_failure(self):
+        xml = (FIXTURES / "targetedonc_gnews.xml").read_text()
+        scraper = TargetedOncScraper()
+
+        def raise_on_resolve(url: str) -> str:
+            raise Exception("timeout")
+
+        with (
+            patch.object(scraper, "_fetch_gnews_text", return_value=xml),
+            patch.object(scraper, "_resolve_redirect", side_effect=raise_on_resolve),
+        ):
+            articles = scraper.fetch_articles(since=date(2026, 2, 7))
+
+        assert any(a.url.startswith("https://news.google.com") for a in articles)

--- a/melanoma/tests/test_news_scraper_targetedonc.py
+++ b/melanoma/tests/test_news_scraper_targetedonc.py
@@ -23,7 +23,7 @@ class TestTargetedOncScraper:
 
         with (
             patch.object(scraper, "_fetch_gnews_text", return_value=xml),
-            patch.object(scraper, "_resolve_redirect", side_effect=mock_resolve),
+            patch.object(scraper, "_resolve_url", side_effect=mock_resolve),
         ):
             articles = scraper.fetch_articles(since=date(2026, 2, 7))
 
@@ -37,7 +37,7 @@ class TestTargetedOncScraper:
         scraper = TargetedOncScraper()
         with (
             patch.object(scraper, "_fetch_gnews_text", return_value=xml),
-            patch.object(scraper, "_resolve_redirect", side_effect=lambda url: url),
+            patch.object(scraper, "_resolve_url", side_effect=lambda url: url),
         ):
             articles = scraper.fetch_articles(since=date(2026, 2, 7))
         assert all(a.source == "targetedonc" for a in articles)
@@ -47,7 +47,7 @@ class TestTargetedOncScraper:
         scraper = TargetedOncScraper()
         with (
             patch.object(scraper, "_fetch_gnews_text", return_value=xml),
-            patch.object(scraper, "_resolve_redirect", side_effect=lambda url: url),
+            patch.object(scraper, "_resolve_url", side_effect=lambda url: url),
         ):
             articles = scraper.fetch_articles(since=date(2026, 5, 1))
 
@@ -59,7 +59,7 @@ class TestTargetedOncScraper:
         scraper = TargetedOncScraper()
         with (
             patch.object(scraper, "_fetch_gnews_text", return_value=xml),
-            patch.object(scraper, "_resolve_redirect", side_effect=lambda url: url),
+            patch.object(scraper, "_resolve_url", side_effect=lambda url: url),
         ):
             articles = scraper.fetch_articles(since=date(2026, 2, 7))
         urls = [a.url for a in articles]
@@ -74,7 +74,7 @@ class TestTargetedOncScraper:
 
         with (
             patch.object(scraper, "_fetch_gnews_text", return_value=xml),
-            patch.object(scraper, "_resolve_redirect", side_effect=raise_on_resolve),
+            patch.object(scraper, "_resolve_url", side_effect=raise_on_resolve),
         ):
             articles = scraper.fetch_articles(since=date(2026, 2, 7))
 

--- a/melanoma/tests/test_upload_legacy_news_feed.py
+++ b/melanoma/tests/test_upload_legacy_news_feed.py
@@ -1,10 +1,9 @@
-import sys
-import pathlib
-import pytest
-
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
-
-from scripts.upload_legacy_news_feed import parse_date, parse_nct_ids, build_rows, _classify_efficacy_safety
+from scripts.upload_legacy_news_feed import (
+    _classify_efficacy_safety,
+    build_rows,
+    parse_date,
+    parse_nct_ids,
+)
 
 
 class TestParseDate:
@@ -26,7 +25,10 @@ class TestParseNctIds:
         assert parse_nct_ids("NCT03655756") == ["NCT03655756"]
 
     def test_comma_separated(self):
-        assert parse_nct_ids("NCT04949113, NCT03698019") == ["NCT04949113", "NCT03698019"]
+        assert parse_nct_ids("NCT04949113, NCT03698019") == [
+            "NCT04949113",
+            "NCT03698019",
+        ]
 
     def test_strips_whitespace(self):
         assert parse_nct_ids("NCT001,  NCT002") == ["NCT001", "NCT002"]
@@ -49,7 +51,9 @@ class TestClassifyEfficacySafety:
         assert has_saf is True
 
     def test_ae_abbreviation_is_safety(self):
-        has_eff, has_saf = _classify_efficacy_safety("ORR; AE-related Permanent Discontinuation")
+        has_eff, has_saf = _classify_efficacy_safety(
+            "ORR; AE-related Permanent Discontinuation"
+        )
         assert has_eff is True
         assert has_saf is True
 
@@ -94,15 +98,23 @@ class TestBuildRows:
         data = {
             "cutaneous-melanoma": {
                 "articles": [
-                    {"title": "Article B", "date": "March 1, 2026",
-                     "url": "https://example.com/b", "nct_id": None}
+                    {
+                        "title": "Article B",
+                        "date": "March 1, 2026",
+                        "url": "https://example.com/b",
+                        "nct_id": None,
+                    }
                 ],
                 "results": [],
             },
             "uveal-melanoma": {
                 "articles": [
-                    {"title": "Article B", "date": "March 1, 2026",
-                     "url": "https://example.com/b", "nct_id": None}
+                    {
+                        "title": "Article B",
+                        "date": "March 1, 2026",
+                        "url": "https://example.com/b",
+                        "nct_id": None,
+                    }
                 ],
                 "results": [],
             },
@@ -115,13 +127,21 @@ class TestBuildRows:
         data = {
             "cutaneous-melanoma": {
                 "articles": [
-                    {"title": "Article C", "date": "April 1, 2026",
-                     "url": "https://example.com/c", "nct_id": None}
+                    {
+                        "title": "Article C",
+                        "date": "April 1, 2026",
+                        "url": "https://example.com/c",
+                        "nct_id": None,
+                    }
                 ],
                 "results": [
-                    {"title": "Article C", "date": "April 1, 2026",
-                     "url": "https://example.com/c", "nct_id": None,
-                     "efficacy_or_safety_data": {"metric": "ORR", "value": "68%"}}
+                    {
+                        "title": "Article C",
+                        "date": "April 1, 2026",
+                        "url": "https://example.com/c",
+                        "nct_id": None,
+                        "efficacy_or_safety_data": {"metric": "ORR", "value": "68%"},
+                    }
                 ],
             }
         }
@@ -136,9 +156,16 @@ class TestBuildRows:
             "cutaneous-melanoma": {
                 "articles": [],
                 "results": [
-                    {"title": "Result Only", "date": "May 1, 2026",
-                     "url": "https://example.com/result-only", "nct_id": "NCT999",
-                     "efficacy_or_safety_data": {"metric": "PFS", "value": "12.3 months"}}
+                    {
+                        "title": "Result Only",
+                        "date": "May 1, 2026",
+                        "url": "https://example.com/result-only",
+                        "nct_id": "NCT999",
+                        "efficacy_or_safety_data": {
+                            "metric": "PFS",
+                            "value": "12.3 months",
+                        },
+                    }
                 ],
             }
         }
@@ -155,9 +182,16 @@ class TestBuildRows:
             "cutaneous-melanoma": {
                 "articles": [],
                 "results": [
-                    {"title": "Safety Article", "date": "May 1, 2026",
-                     "url": "https://example.com/safety", "nct_id": None,
-                     "efficacy_or_safety_data": {"metric": "Adverse Events", "value": "Grade 1-2 only"}}
+                    {
+                        "title": "Safety Article",
+                        "date": "May 1, 2026",
+                        "url": "https://example.com/safety",
+                        "nct_id": None,
+                        "efficacy_or_safety_data": {
+                            "metric": "Adverse Events",
+                            "value": "Grade 1-2 only",
+                        },
+                    }
                 ],
             }
         }
@@ -165,6 +199,9 @@ class TestBuildRows:
         assert len(rows) == 1
         row = rows[0]
         assert row["has_safety"] is True
-        assert row["safety_data"] == {"metric": "Adverse Events", "value": "Grade 1-2 only"}
+        assert row["safety_data"] == {
+            "metric": "Adverse Events",
+            "value": "Grade 1-2 only",
+        }
         assert row["has_efficacy"] is False
         assert row["efficacy_data"] == {}

--- a/melanoma/tests/test_upload_legacy_news_feed.py
+++ b/melanoma/tests/test_upload_legacy_news_feed.py
@@ -48,6 +48,11 @@ class TestClassifyEfficacySafety:
         assert has_eff is True
         assert has_saf is True
 
+    def test_ae_abbreviation_is_safety(self):
+        has_eff, has_saf = _classify_efficacy_safety("ORR; AE-related Permanent Discontinuation")
+        assert has_eff is True
+        assert has_saf is True
+
     def test_unknown_defaults_to_efficacy(self):
         has_eff, has_saf = _classify_efficacy_safety("Some unrecognised metric")
         assert has_eff is True

--- a/melanoma/tests/test_upload_legacy_news_feed.py
+++ b/melanoma/tests/test_upload_legacy_news_feed.py
@@ -1,0 +1,165 @@
+import sys
+import pathlib
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from scripts.upload_legacy_news_feed import parse_date, parse_nct_ids, build_rows, _classify_efficacy_safety
+
+
+class TestParseDate:
+    def test_standard_format(self):
+        assert parse_date("February 2, 2026") == "2026-02-02"
+
+    def test_single_digit_day(self):
+        assert parse_date("January 9, 2026") == "2026-01-09"
+
+    def test_double_digit_day(self):
+        assert parse_date("November 12, 2025") == "2025-11-12"
+
+
+class TestParseNctIds:
+    def test_null_returns_empty(self):
+        assert parse_nct_ids(None) == []
+
+    def test_single_id(self):
+        assert parse_nct_ids("NCT03655756") == ["NCT03655756"]
+
+    def test_comma_separated(self):
+        assert parse_nct_ids("NCT04949113, NCT03698019") == ["NCT04949113", "NCT03698019"]
+
+    def test_strips_whitespace(self):
+        assert parse_nct_ids("NCT001,  NCT002") == ["NCT001", "NCT002"]
+
+
+class TestClassifyEfficacySafety:
+    def test_efficacy_only(self):
+        has_eff, has_saf = _classify_efficacy_safety("ORR; Median PFS; Median OS")
+        assert has_eff is True
+        assert has_saf is False
+
+    def test_safety_only(self):
+        has_eff, has_saf = _classify_efficacy_safety("Adverse Events")
+        assert has_eff is False
+        assert has_saf is True
+
+    def test_both(self):
+        has_eff, has_saf = _classify_efficacy_safety("Safety (DLTs); Efficacy (PFS2)")
+        assert has_eff is True
+        assert has_saf is True
+
+    def test_unknown_defaults_to_efficacy(self):
+        has_eff, has_saf = _classify_efficacy_safety("Some unrecognised metric")
+        assert has_eff is True
+        assert has_saf is False
+
+
+class TestBuildRows:
+    def _minimal_data(self):
+        return {
+            "cutaneous-melanoma": {
+                "articles": [
+                    {
+                        "title": "Article A",
+                        "date": "February 2, 2026",
+                        "url": "https://example.com/a",
+                        "nct_id": "NCT001",
+                    }
+                ],
+                "results": [],
+            }
+        }
+
+    def test_single_article_no_result(self):
+        rows = build_rows(self._minimal_data())
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["url"] == "https://example.com/a"
+        assert row["title"] == "Article A"
+        assert row["date"] == "2026-02-02"
+        assert row["cancer_type"] == ["Cutaneous Melanoma"]
+        assert row["nct_ids"] == ["NCT001"]
+        assert row["has_efficacy"] is False
+        assert row["efficacy_data"] == {}
+        assert row["has_safety"] is False
+        assert row["safety_data"] == {}
+        assert row["extracted_at"] is None
+
+    def test_same_url_across_two_cancer_types_merged(self):
+        data = {
+            "cutaneous-melanoma": {
+                "articles": [
+                    {"title": "Article B", "date": "March 1, 2026",
+                     "url": "https://example.com/b", "nct_id": None}
+                ],
+                "results": [],
+            },
+            "uveal-melanoma": {
+                "articles": [
+                    {"title": "Article B", "date": "March 1, 2026",
+                     "url": "https://example.com/b", "nct_id": None}
+                ],
+                "results": [],
+            },
+        }
+        rows = build_rows(data)
+        assert len(rows) == 1
+        assert set(rows[0]["cancer_type"]) == {"Cutaneous Melanoma", "Uveal Melanoma"}
+
+    def test_result_adds_efficacy_data(self):
+        data = {
+            "cutaneous-melanoma": {
+                "articles": [
+                    {"title": "Article C", "date": "April 1, 2026",
+                     "url": "https://example.com/c", "nct_id": None}
+                ],
+                "results": [
+                    {"title": "Article C", "date": "April 1, 2026",
+                     "url": "https://example.com/c", "nct_id": None,
+                     "efficacy_or_safety_data": {"metric": "ORR", "value": "68%"}}
+                ],
+            }
+        }
+        rows = build_rows(data)
+        assert len(rows) == 1
+        assert rows[0]["has_efficacy"] is True
+        assert rows[0]["efficacy_data"] == {"metric": "ORR", "value": "68%"}
+        assert rows[0]["extracted_at"] is not None
+
+    def test_result_only_url_not_in_articles(self):
+        data = {
+            "cutaneous-melanoma": {
+                "articles": [],
+                "results": [
+                    {"title": "Result Only", "date": "May 1, 2026",
+                     "url": "https://example.com/result-only", "nct_id": "NCT999",
+                     "efficacy_or_safety_data": {"metric": "PFS", "value": "12.3 months"}}
+                ],
+            }
+        }
+        rows = build_rows(data)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["url"] == "https://example.com/result-only"
+        assert row["cancer_type"] == ["Cutaneous Melanoma"]
+        assert row["nct_ids"] == ["NCT999"]
+        assert row["has_efficacy"] is True
+
+    def test_safety_only_result(self):
+        data = {
+            "cutaneous-melanoma": {
+                "articles": [],
+                "results": [
+                    {"title": "Safety Article", "date": "May 1, 2026",
+                     "url": "https://example.com/safety", "nct_id": None,
+                     "efficacy_or_safety_data": {"metric": "Adverse Events", "value": "Grade 1-2 only"}}
+                ],
+            }
+        }
+        rows = build_rows(data)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["has_safety"] is True
+        assert row["safety_data"] == {"metric": "Adverse Events", "value": "Grade 1-2 only"}
+        assert row["has_efficacy"] is False
+        assert row["efficacy_data"] == {}

--- a/web/src/app/dashboard/[category]/live-ticker/page.tsx
+++ b/web/src/app/dashboard/[category]/live-ticker/page.tsx
@@ -47,8 +47,8 @@ function ArticleCard({ article }: { article: LiveTickerArticle }) {
           </h3>
           <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
             <span className="text-sm text-slate-500">{article.date}</span>
-            {article.nct_id && (
-              <span className="text-xs text-slate-500 font-medium tabular-nums">{article.nct_id}</span>
+            {article.nct_ids?.[0] && (
+              <span className="text-xs text-slate-500 font-medium tabular-nums">{article.nct_ids[0]}</span>
             )}
           </div>
         </div>
@@ -113,8 +113,8 @@ function ResultCard({ result }: { result: LiveTickerResult }) {
         </div>
         <div className="flex flex-wrap items-center justify-between gap-2">
           <span className="text-sm text-slate-500">{result.date}</span>
-          {result.nct_id && (
-            <span className="text-xs text-slate-500 font-medium tabular-nums">{result.nct_id}</span>
+          {result.nct_ids?.[0] && (
+            <span className="text-xs text-slate-500 font-medium tabular-nums">{result.nct_ids[0]}</span>
           )}
         </div>
         {metricLabel && (

--- a/web/src/app/dashboard/[category]/page.tsx
+++ b/web/src/app/dashboard/[category]/page.tsx
@@ -555,7 +555,7 @@ export default function CancerDashboardSnapshot() {
                     </div>
                   )}
                   {!liveTickerLoading && latestNewsItems.map((item, i) => {
-                    const { title, date, url, nct_id } = item.value;
+                    const { title, date, url, nct_ids } = item.value;
                     const efficacySafetyLabel = item.type === 'result' ? getEfficacySafetyLabel(item.value) : null;
                     const dateLabel = (() => {
                       try {
@@ -586,10 +586,10 @@ export default function CancerDashboardSnapshot() {
                           <span className="text-[clamp(0.7rem,1.7cqw,1.125rem)] font-semibold text-slate-700 line-clamp-2 leading-snug group-hover:text-blue-700 transition-colors">{title}</span>
                           <div className="flex items-center gap-[clamp(0.25rem,0.8cqw,0.625rem)] flex-wrap">
                             <span className="text-[clamp(0.55rem,1.2cqw,0.9375rem)] text-slate-400 font-medium tabular-nums">{dateLabel}</span>
-                            {nct_id && (
+                            {nct_ids?.[0] && (
                               <>
                                 <span className="w-0.5 h-0.5 rounded-full bg-slate-300" />
-                                <span className="text-[clamp(0.55rem,1.2cqw,0.9375rem)] text-slate-500 font-mono">{nct_id}</span>
+                                <span className="text-[clamp(0.55rem,1.2cqw,0.9375rem)] text-slate-500 font-mono">{nct_ids[0]}</span>
                               </>
                             )}
                             {efficacySafetyLabel && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -589,19 +589,24 @@ export const trialsApi = {
     const supabase = createClient();
     const { data, error } = await supabase
       .from('news_feed')
-      .select('*')
-      .eq('cancer_type', getDbCancerType(category))
+      .select('title, date, url, nct_ids, has_efficacy, has_safety, efficacy_data, safety_data')
+      .contains('cancer_type', [getDbCancerType(category)])
+      .order('date', { ascending: false })
       .limit(100);
-      
+
     if (error) throw error;
-    
-    const articles = data.map(d => ({
-      title: d.title,
-      date: d.date,
-      url: d.url,
-      nct_id: d.nct_id
+
+    const articles = (data ?? []).map(d => ({
+      title: d.title as string,
+      date: d.date as string,
+      url: d.url as string,
+      nct_ids: d.nct_ids as string[] | null,
+      has_efficacy: d.has_efficacy as boolean | null,
+      has_safety: d.has_safety as boolean | null,
+      efficacy_data: d.efficacy_data as Record<string, Record<string, string>> | null,
+      safety_data: d.safety_data as Record<string, Record<string, string>> | null,
     }));
-    
+
     return { articles, results: [] };
   },
 
@@ -1014,7 +1019,11 @@ export interface LiveTickerArticle {
   title: string;
   date: string;
   url: string;
-  nct_id?: string | null;
+  nct_ids?: string[] | null;
+  has_efficacy?: boolean | null;
+  has_safety?: boolean | null;
+  efficacy_data?: Record<string, Record<string, string>> | null;
+  safety_data?: Record<string, Record<string, string>> | null;
 }
 
 export interface LiveTickerEfficacySafety {

--- a/web/supabase/migrations/20260512000000_news_feed_schema.sql
+++ b/web/supabase/migrations/20260512000000_news_feed_schema.sql
@@ -18,6 +18,5 @@ ALTER TABLE news_feed
   ADD COLUMN IF NOT EXISTS safety_data   jsonb,
   ADD COLUMN IF NOT EXISTS extracted_at  timestamptz;
 
--- Unique constraint for idempotent upsert on URL
-ALTER TABLE news_feed
-  ADD CONSTRAINT IF NOT EXISTS news_feed_url_key UNIQUE (url);
+-- Unique index for idempotent upsert on URL (ON CONFLICT url)
+CREATE UNIQUE INDEX IF NOT EXISTS news_feed_url_key ON news_feed (url);

--- a/web/supabase/migrations/20260512000000_news_feed_schema.sql
+++ b/web/supabase/migrations/20260512000000_news_feed_schema.sql
@@ -18,11 +18,11 @@ ALTER TABLE news_feed
   ADD COLUMN IF NOT EXISTS safety_data   jsonb,
   ADD COLUMN IF NOT EXISTS extracted_at  timestamptz;
 
--- Deduplicate existing rows by URL before adding unique index, keep latest id
-DELETE FROM news_feed
-WHERE id NOT IN (
-  SELECT MAX(id) FROM news_feed GROUP BY url
-);
+-- Deduplicate existing rows by URL before adding unique index, keep last-inserted per URL
+DELETE FROM news_feed a
+USING news_feed b
+WHERE a.url = b.url
+  AND a.ctid < b.ctid;
 
 -- Unique index for idempotent upsert on URL (ON CONFLICT url)
 CREATE UNIQUE INDEX IF NOT EXISTS news_feed_url_key ON news_feed (url);

--- a/web/supabase/migrations/20260512000000_news_feed_schema.sql
+++ b/web/supabase/migrations/20260512000000_news_feed_schema.sql
@@ -18,5 +18,11 @@ ALTER TABLE news_feed
   ADD COLUMN IF NOT EXISTS safety_data   jsonb,
   ADD COLUMN IF NOT EXISTS extracted_at  timestamptz;
 
+-- Deduplicate existing rows by URL before adding unique index, keep latest id
+DELETE FROM news_feed
+WHERE id NOT IN (
+  SELECT MAX(id) FROM news_feed GROUP BY url
+);
+
 -- Unique index for idempotent upsert on URL (ON CONFLICT url)
 CREATE UNIQUE INDEX IF NOT EXISTS news_feed_url_key ON news_feed (url);

--- a/web/supabase/migrations/20260512000000_news_feed_schema.sql
+++ b/web/supabase/migrations/20260512000000_news_feed_schema.sql
@@ -1,0 +1,23 @@
+-- Rename nct_id (text) → nct_ids (text[])
+ALTER TABLE news_feed RENAME COLUMN nct_id TO nct_ids;
+ALTER TABLE news_feed
+  ALTER COLUMN nct_ids TYPE text[]
+    USING CASE WHEN nct_ids IS NULL THEN NULL ELSE ARRAY[nct_ids] END;
+
+-- cancer_type (text) → cancer_type (text[]) — articles can match multiple types
+ALTER TABLE news_feed
+  ALTER COLUMN cancer_type TYPE text[]
+    USING CASE WHEN cancer_type IS NULL THEN NULL ELSE ARRAY[cancer_type] END;
+
+-- New columns
+ALTER TABLE news_feed
+  ADD COLUMN IF NOT EXISTS source        text,
+  ADD COLUMN IF NOT EXISTS has_efficacy  boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS efficacy_data jsonb,
+  ADD COLUMN IF NOT EXISTS has_safety    boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS safety_data   jsonb,
+  ADD COLUMN IF NOT EXISTS extracted_at  timestamptz;
+
+-- Unique constraint for idempotent upsert on URL
+ALTER TABLE news_feed
+  ADD CONSTRAINT IF NOT EXISTS news_feed_url_key UNIQUE (url);


### PR DESCRIPTION
## Summary

- Add news scraper pipeline covering OncLive, CancerNetwork, TargetedOnc, and BioSpace — each with URL resolution, full-text fetch, and cancer-type filtering
- Add GeminiNewsExtractor for structured per-cancer-type efficacy/safety extraction from article text (GOOGLE_API_KEY optional — pipeline skips extraction and continues without it)
- Add `scrape_news_supabase.py` CLI for daily scrape + upsert into `news_feed`, and `upload_legacy_news_feed.py` for one-shot backfill from existing JSON exports
- Add `replace_publications_supabase.py` for replacing `trial_outcomes` publication rows from extraction JSON
- Update `news_feed` schema: `nct_ids text[]`, `cancer_type text[]`, efficacy/safety JSONB columns, unique index on `url`
- Wire `getLiveTicker` in web to new schema (nct_ids array, per-type efficacy/safety)
- Add daily GitHub Actions workflow for automated scraping
- Fix linting: ruff, black, mypy all clean; pytest `pythonpath` config eliminates sys.path hacks in tests

## Test plan

- [ ] `cd melanoma && poetry run pytest` — all tests pass
- [ ] `poetry run python3 scripts/scrape_news_supabase.py --days 3` — confirm articles upserted to Supabase
- [ ] `poetry run python3 scripts/scrape_news_supabase.py --days 1` without `GOOGLE_API_KEY` — confirm pipeline completes, `extracted_at` is null
- [ ] Live ticker on `/dashboard/[category]/live-ticker` renders articles with correct cancer type and efficacy/safety flags
- [ ] `poetry run ruff check src/ tests/ && poetry run black --check src/ tests/ && poetry run mypy src/` — all clean
