### PR TITLE
feat(web): add Kaplan-Meier survival curves page

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -42,3 +42,9 @@ next-env.d.ts
 
 # Allow lib directory
 !src/lib/
+
+# Local data
+data/
+
+# Seed SQL (proprietary curve data + local fixtures)
+supabase/seed/

--- a/web/scripts/load-km-curves.mjs
+++ b/web/scripts/load-km-curves.mjs
@@ -1,0 +1,242 @@
+// Build km_curves rows from survival-twin data folders in web/data/survival-twin/.
+//
+// Per folder (e.g. "Batch-I_31_Overall"):
+//   source_name = ^Batch-[IVX]+_\d+   (e.g. Batch-I_31)   cohort = the rest (Overall)
+//   - twin curve  ← KM step computed in JS from outputs/ipd_<arm>.csv
+//   - twin median ← outputs/validation_report.md
+//   - published median/rate/follow-up + publication_id(citation)/cancer_type/nct_id
+//                 ← trial_outcomes (matched by source_name, then arm_name)
+//   - id = `<folder>_<arm_name>`  e.g. Batch-I_31_Overall_Relatlimab-Nivolumab
+//
+// Usage (from web/):
+//   node scripts/load-km-curves.mjs            # dry run → writes supabase/seed/km_curves_generated.sql
+//   node scripts/load-km-curves.mjs --apply    # also upserts directly via SUPABASE_SECRET_KEY
+
+import { readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WEB_ROOT = join(__dirname, '..');
+const DATA_DIR = join(WEB_ROOT, 'data', 'survival-twin');
+const OUT_SQL = join(WEB_ROOT, 'supabase', 'seed', 'km_curves_generated.sql');
+const APPLY = process.argv.includes('--apply');
+
+// ---- env (.env.local, hand-parsed; no dotenv dep) -------------------------
+function loadEnv() {
+  const env = {};
+  const text = readFileSync(join(WEB_ROOT, '.env.local'), 'utf8');
+  for (const line of text.split('\n')) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (m) env[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+  return env;
+}
+const env = loadEnv();
+const supabase = createClient(
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.SUPABASE_SECRET_KEY,
+  { auth: { persistSession: false } }
+);
+
+// ---- tiny parsers ----------------------------------------------------------
+function parseCsv(path) {
+  const [head, ...rows] = readFileSync(path, 'utf8').trim().split('\n');
+  const cols = head.split(',').map((c) => c.replace(/^"|"$/g, ''));
+  return rows.map((r) => {
+    const vals = r.split(',').map((v) => v.replace(/^"|"$/g, ''));
+    return Object.fromEntries(cols.map((c, i) => [c, vals[i]]));
+  });
+}
+
+// meta.yaml is a fixed, shallow shape — parse it directly rather than add a dep.
+function parseMeta(path) {
+  const text = readFileSync(path, 'utf8');
+  const meta = { arms: [] };
+  let arm = null;
+  for (const raw of text.split('\n')) {
+    if (!raw.trim()) continue;
+    const top = raw.match(/^(\w+):\s*(.*)$/);
+    if (top && !raw.startsWith(' ')) {
+      if (top[1] === 'arms') continue;
+      meta[top[1]] = top[2];
+      continue;
+    }
+    const item = raw.match(/^-\s*name:\s*(.*)$/);
+    if (item) {
+      arm = { name: item[1].trim() };
+      meta.arms.push(arm);
+      continue;
+    }
+    const kv = raw.match(/^\s+(\w+):\s*(.*)$/);
+    if (kv && arm) arm[kv[1]] = kv[2].trim();
+  }
+  return meta;
+}
+
+// Reconstructed-median + status per arm from the validation report table.
+function parseValidation(path) {
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (!line.startsWith('|')) continue;
+    const cells = line.split('|').map((c) => c.trim()).filter(Boolean);
+    // | arm | published | reconstructed | S(t_med)% | 95% CI | % diff | flag | pass |
+    if (cells.length < 6 || cells[0] === 'arm' || cells[1] === 'published') continue;
+    const reconstructed = parseFloat(cells[2]);
+    const diff = parseFloat((cells[5] || '').replace('%', ''));
+    if (!Number.isNaN(reconstructed)) {
+      out[cells[0]] = {
+        twin_median: reconstructed,
+        match_pct: Number.isNaN(diff) ? null : Math.round((100 - Math.abs(diff)) * 10) / 10,
+      };
+    }
+  }
+  return out;
+}
+
+// ---- Kaplan-Meier step from reconstructed IPD ------------------------------
+function kmSteps(ipdRows) {
+  const rows = ipdRows
+    .map((r) => ({ time: parseFloat(r.time), status: parseInt(r.status, 10) }))
+    .filter((r) => !Number.isNaN(r.time))
+    .sort((a, b) => a.time - b.time);
+  const n = rows.length;
+  const eventTimes = [...new Set(rows.filter((r) => r.status === 1).map((r) => r.time))].sort((a, b) => a - b);
+
+  const coords = [{ time: 0, surv: 100 }];
+  let surv = 1;
+  for (const t of eventTimes) {
+    const atRisk = rows.filter((r) => r.time >= t).length;
+    const events = rows.filter((r) => r.time === t && r.status === 1).length;
+    if (atRisk > 0) surv *= 1 - events / atRisk;
+    coords.push({ time: Math.round(t * 1000) / 1000, surv: Math.round(surv * 1000) / 10 });
+  }
+  // Hold the last survival value flat out to the maximum observed follow-up
+  // (last censored time) so the curve doesn't stop at the final event.
+  const maxTime = n ? rows[n - 1].time : 0;
+  const last = coords[coords.length - 1];
+  if (maxTime > last.time) coords.push({ time: Math.round(maxTime * 1000) / 1000, surv: last.surv });
+  return { coords, n };
+}
+
+function survAt(coords, t) {
+  let s = 100;
+  for (const p of coords) {
+    if (p.time <= t) s = p.surv;
+    else break;
+  }
+  return Math.round(s * 10) / 10;
+}
+
+// ---- arm-name matching (meta ↔ trial_outcomes) -----------------------------
+const norm = (s) => (s || '').toLowerCase().replace(/[\s/+_-]/g, '');
+
+// Endpoint → trial_outcomes column groups.
+const PUBLISHED = {
+  PFS: { median: 'median_pfs', followup: 'pfs_followup_months', rates: [['pfs_rate_24m', 24], ['pfs_rate_12m', 12], ['pfs_rate_6m', 6]] },
+  OS: { median: 'median_os', followup: 'os_followup_months', rates: [['os_rate_24m', 24], ['os_rate_12m', 12], ['os_rate_6m', 6]] },
+};
+
+const num = (v) => (v == null || v === '' ? null : Number(v));
+const sqlStr = (v) => (v == null ? 'NULL' : `'${String(v).replace(/'/g, "''")}'`);
+const sqlNum = (v) => (v == null || Number.isNaN(v) ? 'NULL' : String(v));
+
+async function buildFolder(folder) {
+  const m = folder.match(/^(Batch-[IVX]+_\d+)(?:_(.+))?$/);
+  if (!m) { console.warn(`skip ${folder}: name not Batch-*_N[_cohort]`); return []; }
+  const source_name = m[1];
+  const cohort = m[2] || null;
+
+  const inDir = join(DATA_DIR, folder, 'inputs');
+  const outDir = join(DATA_DIR, folder, 'outputs');
+  const meta = parseMeta(join(inDir, 'meta.yaml'));
+  const endpoint = (meta.endpoint || 'PFS').toUpperCase();
+  const pub = PUBLISHED[endpoint] || PUBLISHED.PFS;
+  const validation = parseValidation(join(outDir, 'validation_report.md'));
+
+  const { data: outcomes, error } = await supabase
+    .from('trial_outcomes')
+    .select('*')
+    .eq('source_name', source_name);
+  if (error) throw error;
+  const meta0 = outcomes?.[0] || {};
+  const publication_id = meta0.publication_id ?? null;        // citation string
+  const cancer_type = Array.isArray(meta0.cancer_type) ? meta0.cancer_type[0] : meta0.cancer_type ?? null;
+  const nct_id = meta0.nct_id ?? null;
+
+  if (!outcomes?.length) console.warn(`! ${folder}: no trial_outcomes row for source_name=${source_name}`);
+
+  const rows = [];
+  for (const arm of meta.arms) {
+    const safe = arm.name.replace(/\//g, '-');
+    const ipdPath = join(outDir, `ipd_${safe}.csv`);
+    if (!existsSync(ipdPath)) { console.warn(`  skip arm ${arm.name}: ${ipdPath} missing`); continue; }
+
+    const { coords, n } = kmSteps(parseCsv(ipdPath));
+    const oc = outcomes?.find((o) => norm(o.arm_name) === norm(arm.name)) || {};
+
+    const rate = pub.rates.map(([col, t]) => [num(oc[col]), t]).find(([v]) => v != null) || [null, null];
+    const v = validation[arm.name] || {};
+
+    rows.push({
+      id: `${folder}_${arm.name}`,
+      publication_id,
+      nct_id,
+      cancer_type,
+      comparison_label: cohort,
+      arm_name: arm.name,
+      endpoint,
+      twin_coords: coords,
+      published_median: num(oc[pub.median]) ?? num(arm.published_median),
+      twin_median: v.twin_median ?? null,
+      rate_timepoint: rate[1],
+      published_rate: rate[0],
+      twin_rate: rate[1] != null ? survAt(coords, rate[1]) : null,
+      median_follow_up: num(oc[pub.followup]),
+      match_pct: v.match_pct ?? null,
+      n_points: n,
+      reference: publication_id,
+    });
+  }
+  return rows;
+}
+
+function toSql(rows) {
+  const cols = ['id', 'publication_id', 'nct_id', 'cancer_type', 'comparison_label', 'arm_name', 'endpoint',
+    'twin_coords', 'published_median', 'twin_median', 'rate_timepoint', 'published_rate', 'twin_rate',
+    'median_follow_up', 'match_pct', 'n_points', 'reference'];
+  const values = rows.map((r) => `  (${[
+    sqlStr(r.id), sqlStr(r.publication_id), sqlStr(r.nct_id), sqlStr(r.cancer_type), sqlStr(r.comparison_label),
+    sqlStr(r.arm_name), sqlStr(r.endpoint), `${sqlStr(JSON.stringify(r.twin_coords))}::jsonb`,
+    sqlNum(r.published_median), sqlNum(r.twin_median), sqlNum(r.rate_timepoint), sqlNum(r.published_rate),
+    sqlNum(r.twin_rate), sqlNum(r.median_follow_up), sqlNum(r.match_pct), sqlNum(r.n_points), sqlStr(r.reference),
+  ].join(', ')})`).join(',\n');
+  const updates = cols.filter((c) => c !== 'id').map((c) => `${c} = EXCLUDED.${c}`).join(', ');
+  return `-- Generated by scripts/load-km-curves.mjs. Do not edit by hand.\n` +
+    `INSERT INTO km_curves (${cols.join(', ')})\nVALUES\n${values}\nON CONFLICT (id) DO UPDATE SET ${updates};\n`;
+}
+
+async function main() {
+  const folders = readdirSync(DATA_DIR, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name);
+  let all = [];
+  for (const f of folders) all = all.concat(await buildFolder(f));
+  console.log(`Built ${all.length} km_curves rows from ${folders.length} folders.`);
+
+  const sql = toSql(all);
+  writeFileSync(OUT_SQL, sql);
+  console.log(`Wrote SQL → ${OUT_SQL}`);
+
+  if (APPLY) {
+    const { error } = await supabase.from('km_curves').upsert(all.map((r) => ({
+      ...r, twin_coords: r.twin_coords,
+    })), { onConflict: 'id' });
+    if (error) throw error;
+    console.log(`Applied: upserted ${all.length} rows into km_curves.`);
+  } else {
+    console.log('Dry run. Re-run with --apply to upsert, or run the SQL in Supabase.');
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/web/src/app/dashboard/[category]/analytics/page.tsx
+++ b/web/src/app/dashboard/[category]/analytics/page.tsx
@@ -1158,6 +1158,13 @@ export default function CategoryAnalyticsPage() {
                   >
                     Head to Head Efficacy : Safety
                   </Link>
+                  <span className="w-px h-4 bg-white/30" aria-hidden />
+                  <Link
+                    href={`/dashboard/${categorySlug}/head-to-head-survival`}
+                    className="px-2 py-1 rounded text-sm font-medium text-white/80 hover:text-white hover:bg-white/15 transition-colors"
+                  >
+                    KM Curves
+                  </Link>
                 </nav>
                 <span className="hidden sm:inline-block w-px h-4 bg-white/30"></span>
                 <p className="text-[var(--brand-accent)] text-xs hidden sm:block">Comparative analysis</p>
@@ -1356,6 +1363,13 @@ export default function CategoryAnalyticsPage() {
                   >
                     Head to Head Efficacy : Safety
                   </Link>
+                  <span className="w-px h-4 bg-white/30" aria-hidden />
+                  <Link
+                    href={`/dashboard/${categorySlug}/head-to-head-survival`}
+                    className="px-2 py-1 rounded text-sm font-medium text-white/80 hover:text-white hover:bg-white/15 transition-colors"
+                  >
+                    KM Curves
+                  </Link>
                 </nav>
                 <span className="hidden sm:inline-block w-px h-4 bg-white/30"></span>
                 <p className="text-[var(--brand-accent)] text-xs hidden sm:block">
@@ -1499,6 +1513,13 @@ export default function CategoryAnalyticsPage() {
                     className="px-2 py-1 rounded text-sm font-medium text-white/80 hover:text-white hover:bg-white/15 transition-colors"
                   >
                     Head to Head Efficacy : Safety
+                  </Link>
+                  <span className="w-px h-4 bg-white/30" aria-hidden />
+                  <Link
+                    href={`/dashboard/${categorySlug}/head-to-head-survival`}
+                    className="px-2 py-1 rounded text-sm font-medium text-white/80 hover:text-white hover:bg-white/15 transition-colors"
+                  >
+                    KM Curves
                   </Link>
                 </nav>
                 <span className="hidden sm:inline-block w-px h-4 bg-white/30"></span>

--- a/web/src/app/dashboard/[category]/head-to-head-survival/page.tsx
+++ b/web/src/app/dashboard/[category]/head-to-head-survival/page.tsx
@@ -1,0 +1,344 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { Activity, Check, ChevronDown, ListFilter, Loader2 } from 'lucide-react';
+import { useSession } from '@/lib/supabase/hooks';
+import { UserMenu } from '@/components/user-menu';
+import { Logo } from '@/components/Logo';
+import { DashboardNavLink } from '@/components/nav/DashboardNavLink';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+import { kmCurvesApi, type KmCurveRow } from '@/lib/api';
+import KaplanMeierChart from '@/components/charts/KaplanMeierChart';
+
+function fmt(n: number | null | undefined, suffix = ''): string {
+  return n == null ? '—' : `${n}${suffix}`;
+}
+
+// A "comparison" = one publication + cohort (comparison_label). Arm names are
+// unique within a comparison but can collide across them, so arms are selected
+// by curve id (not name) to allow head-to-head across publications/cohorts.
+const comparisonKey = (c: KmCurveRow) => `${c.publication_id ?? ''}||${c.comparison_label ?? ''}`;
+const comparisonLabel = (c: KmCurveRow) =>
+  c.comparison_label ? `${c.comparison_label} · ${c.publication_id ?? ''}` : c.publication_id ?? comparisonKey(c);
+
+const ENDPOINT_LABELS: Record<string, string> = {
+  PFS: 'Progression-free survival',
+  OS: 'Overall survival',
+  DFS: 'Disease-free survival',
+  RFS: 'Recurrence-free survival',
+  EFS: 'Event-free survival',
+};
+const endpointLabel = (e: string) => ENDPOINT_LABELS[e] ?? e;
+
+// Stable empty reference so query-loading state doesn't churn memo/effect deps.
+const EMPTY_CURVES: KmCurveRow[] = [];
+
+export default function HeadToHeadEfficacyPage() {
+  const { data: session } = useSession();
+  const params = useParams();
+  const categorySlug = params?.category as string;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['km-curves', categorySlug],
+    queryFn: () => kmCurvesApi.getByCancerType(categorySlug),
+    staleTime: 5 * 60 * 1000,
+  });
+  const allCurves = data ?? EMPTY_CURVES;
+
+  // Distinct endpoints across all publications (PFS, OS, …).
+  const endpoints = React.useMemo(
+    () => [...new Set(allCurves.map((c) => c.endpoint))].sort(),
+    [allCurves]
+  );
+
+  const [endpoint, setEndpoint] = React.useState<string>('');
+  React.useEffect(() => {
+    if (endpoints.length && !endpoints.includes(endpoint)) setEndpoint(endpoints[0]);
+  }, [endpoints, endpoint]);
+
+  // All arms for the selected endpoint, across every publication/cohort.
+  const armsForEndpoint = React.useMemo(
+    () => allCurves.filter((c) => c.endpoint === endpoint),
+    [allCurves, endpoint]
+  );
+
+  // Arms grouped by comparison for the dropdown.
+  const armGroups = React.useMemo(() => {
+    const map = new Map<string, { key: string; label: string; arms: KmCurveRow[] }>();
+    for (const c of armsForEndpoint) {
+      const key = comparisonKey(c);
+      if (!map.has(key)) map.set(key, { key, label: comparisonLabel(c), arms: [] });
+      map.get(key)!.arms.push(c);
+    }
+    return [...map.values()];
+  }, [armsForEndpoint]);
+
+  // Selected curve ids (default: arms of the first comparison only).
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
+  React.useEffect(() => {
+    const first = armGroups[0];
+    setSelectedIds(new Set(first ? first.arms.map((c) => c.id) : []));
+  }, [armGroups]);
+
+  const visibleCurves: KmCurveRow[] = React.useMemo(
+    () => armsForEndpoint.filter((c) => selectedIds.has(c.id)),
+    [armsForEndpoint, selectedIds]
+  );
+
+  // Rate timepoint can differ per arm. When selected arms agree, name it in the
+  // column header; when they mix, keep the header generic and annotate each cell.
+  const { rateLabel, rateMixed } = React.useMemo(() => {
+    const tps = [...new Set(visibleCurves.map((c) => c.rate_timepoint).filter((t) => t != null))];
+    return tps.length === 1
+      ? { rateLabel: `Rate @ ${tps[0]}m`, rateMixed: false }
+      : { rateLabel: 'Rate', rateMixed: tps.length > 1 };
+  }, [visibleCurves]);
+
+  // Rate value with a per-arm timepoint suffix when the selection mixes timepoints.
+  const fmtRate = (value: number | null | undefined, tp: number | null | undefined) =>
+    value == null ? '—' : `${value}%${rateMixed && tp != null ? ` @ ${tp}m` : ''}`;
+
+  const toggleId = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+  const selectAllArms = () => setSelectedIds(new Set(armsForEndpoint.map((c) => c.id)));
+  const clearArms = () => setSelectedIds(new Set());
+
+  return (
+    <div className="flex flex-col h-screen w-full bg-slate-100 overflow-hidden">
+      <header className="bg-white border-b border-slate-200 sticky top-0 z-50 shadow-sm">
+        <div className="w-full px-8">
+          <div className="flex items-center justify-between h-14 gap-4">
+            <div className="flex items-center gap-4">
+              <Link href="/" className="brand shrink-0">
+                <Logo height={32} />
+                <span className="brand-text text-lg">bi<span className="brand-o">o</span>nocular</span>
+              </Link>
+            </div>
+            <div className="flex items-center gap-2">
+              <DashboardNavLink />
+              {session?.user && (
+                <UserMenu
+                  email={session.user.email || null}
+                  name={(session.user.user_metadata?.full_name as string) || null}
+                  image={undefined}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 flex flex-col items-center overflow-y-auto px-4 py-6 bg-slate-100">
+        <div className="w-full max-w-7xl">
+          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-5">
+            <div>
+              <h1 className="text-3xl sm:text-4xl font-extrabold text-slate-900">
+                Head-to-Head Survival
+              </h1>
+              <p className="mt-1 text-sm text-slate-500">
+                Reconstructed digitized-twin survival curves by treatment arm.
+              </p>
+            </div>
+
+            {/* Selectors */}
+            <div className="flex items-center gap-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={!endpoints.length}
+                    className="h-9 gap-2 bg-white pl-3 pr-2.5 shadow-sm hover:bg-slate-50"
+                  >
+                    <Activity className="h-4 w-4 text-slate-400" />
+                    <span className="text-xs font-medium text-slate-400">Endpoint</span>
+                    <span className="font-semibold text-slate-900">{endpoint || '—'}</span>
+                    <ChevronDown className="h-4 w-4 text-slate-400" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[200px]">
+                  <DropdownMenuLabel className="text-xs font-normal text-slate-500">
+                    Endpoint
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {endpoints.map((e) => (
+                    <DropdownMenuItem
+                      key={e}
+                      onClick={() => setEndpoint(e)}
+                      className="justify-between gap-4"
+                    >
+                      <span>{endpointLabel(e)}</span>
+                      {e === endpoint && <Check className="h-4 w-4 text-slate-900" />}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={!armsForEndpoint.length}
+                    className="h-9 gap-2 bg-white pl-3 pr-2.5 shadow-sm hover:bg-slate-50"
+                  >
+                    <ListFilter className="h-4 w-4 text-slate-400" />
+                    <span className="font-medium text-slate-700">Treatment arms</span>
+                    <Badge variant="secondary" className="px-1.5 py-0 tabular-nums">
+                      {selectedIds.size}
+                    </Badge>
+                    <ChevronDown className="h-4 w-4 text-slate-400" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-[300px] p-0">
+                  <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2">
+                    <span className="text-xs text-slate-500 tabular-nums">
+                      {selectedIds.size} of {armsForEndpoint.length} selected
+                    </span>
+                    <div className="flex items-center gap-0.5">
+                      <button
+                        type="button"
+                        onClick={selectAllArms}
+                        disabled={selectedIds.size === armsForEndpoint.length}
+                        className="rounded px-1.5 py-0.5 text-xs font-medium text-slate-600 hover:bg-slate-100 disabled:opacity-40 disabled:hover:bg-transparent"
+                      >
+                        All
+                      </button>
+                      <button
+                        type="button"
+                        onClick={clearArms}
+                        disabled={selectedIds.size === 0}
+                        className="rounded px-1.5 py-0.5 text-xs font-medium text-slate-600 hover:bg-slate-100 disabled:opacity-40 disabled:hover:bg-transparent"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                  </div>
+                  <div className="max-h-[360px] overflow-y-auto py-1">
+                    {armGroups.map((g, gi) => (
+                      <React.Fragment key={g.key}>
+                        {gi > 0 && <DropdownMenuSeparator />}
+                        <DropdownMenuLabel className="truncate text-xs font-normal text-slate-400">
+                          {g.label}
+                        </DropdownMenuLabel>
+                        {g.arms.map((c) => (
+                          <DropdownMenuCheckboxItem
+                            key={c.id}
+                            checked={selectedIds.has(c.id)}
+                            onCheckedChange={() => toggleId(c.id)}
+                            onSelect={(e) => e.preventDefault()}
+                          >
+                            {c.arm_name}
+                          </DropdownMenuCheckboxItem>
+                        ))}
+                      </React.Fragment>
+                    ))}
+                  </div>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+
+          {/* Chart */}
+          <Card className="bg-white">
+            <CardHeader className="pb-0">
+              <CardTitle className="text-base font-semibold text-slate-700 text-center">
+                {endpoint ? `${endpointLabel(endpoint)} — Digitized twin` : 'Survival curves'}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {isLoading ? (
+                <div className="flex items-center justify-center h-[400px] text-slate-400">
+                  <Loader2 className="h-5 w-5 animate-spin mr-2" /> Loading curves…
+                </div>
+              ) : (
+                <KaplanMeierChart curves={visibleCurves} endpoint={endpoint} />
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Table: published vs digitized-twin */}
+          <Card className="mt-4 bg-white">
+            <CardContent className="pt-6 overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-b-2 bg-slate-50 hover:bg-slate-50">
+                    <TableHead className="text-xs font-semibold uppercase tracking-wide text-slate-600">Treatment Arm</TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wide text-slate-600">Median (published)</TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wide text-slate-600">Median (twin)</TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wide text-slate-600">{rateLabel} (published)</TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wide text-slate-600">{rateLabel} (twin)</TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wide text-slate-600">Med. Follow-up</TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wide text-slate-600">Digitized Twin Status</TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wide text-slate-600">Reference</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {visibleCurves.map((c) => (
+                    <TableRow key={c.id}>
+                      <TableCell className="font-medium">{c.arm_name}</TableCell>
+                      <TableCell>{fmt(c.published_median, 'm')}</TableCell>
+                      <TableCell>{fmt(c.twin_median, 'm')}</TableCell>
+                      <TableCell>{fmtRate(c.published_rate, c.rate_timepoint)}</TableCell>
+                      <TableCell>{fmtRate(c.twin_rate, c.rate_timepoint)}</TableCell>
+                      <TableCell>{fmt(c.median_follow_up, 'm')}</TableCell>
+                      <TableCell>
+                        {c.match_pct == null
+                          ? '—'
+                          : `${c.match_pct}% Match${c.n_points != null ? ` (${c.n_points} pts)` : ''}`}
+                      </TableCell>
+                      <TableCell className="max-w-[220px] truncate">
+                        {c.reference
+                          ? /^https?:\/\//.test(c.reference)
+                            ? (
+                              <a
+                                href={c.reference}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-sky-600 hover:underline"
+                              >
+                                {c.reference}
+                              </a>
+                            )
+                            : c.reference
+                          : '—'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/web/src/components/charts/KaplanMeierChart.tsx
+++ b/web/src/components/charts/KaplanMeierChart.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Line,
+  LineChart,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import type { KmCurveRow } from '@/lib/api';
+
+// Series palette — mirrors the dashboard TREATMENT_COLORS ordering.
+const CURVE_COLORS = [
+  '#3b82f6', // blue
+  '#15803d', // green
+  '#f59e0b', // amber
+  '#dc2626', // red
+  '#7c3aed', // purple
+  '#ec4899', // pink
+  '#06b6d4', // cyan
+  '#84cc16', // lime
+];
+
+const AXIS = '#64748b';
+const GRID = '#e2e8f0';
+
+// Fixed time axis (months). Curves end at their own last coordinate; points
+// beyond X_MAX are dropped.
+const X_MAX = 30;
+const X_TICKS = [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30];
+const Y_TICKS = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
+interface KaplanMeierChartProps {
+  /** Reconstructed digitized-twin curves to plot — one line per arm. */
+  curves: KmCurveRow[];
+  /** Endpoint label for the Y-axis, e.g. "PFS". */
+  endpoint: string;
+  height?: number;
+}
+
+/** Series color for the arm at a given legend position. */
+export function armColor(index: number): string {
+  return CURVE_COLORS[index % CURVE_COLORS.length];
+}
+
+/**
+ * Reshape per-arm step points into a single wide series keyed by time.
+ * For each arm we carry forward the last known survival value so the line is a
+ * proper KM step function sampled at the union of all time points.
+ */
+function toWideSeries(curves: KmCurveRow[]): Array<Record<string, number | null>> {
+  const times = new Set<number>();
+  for (const c of curves) for (const p of c.twin_coords) if (p.time <= X_MAX) times.add(p.time);
+  const sortedTimes = [...times].sort((a, b) => a - b);
+
+  return sortedTimes.map((time) => {
+    const row: Record<string, number | null> = { time };
+    for (const c of curves) {
+      const sorted = [...c.twin_coords].sort((a, b) => a.time - b.time);
+      const lastTime = sorted.length ? sorted[sorted.length - 1].time : 0;
+      let value: number | null = null;
+      // Carry the step value forward, but stop at the arm's last coordinate so
+      // the line ends where its data ends rather than running to the axis edge.
+      for (const p of sorted) {
+        if (p.time <= time) value = p.surv;
+        else break;
+      }
+      row[c.id] = time <= lastTime ? value : null;
+    }
+    return row;
+  });
+}
+
+export default function KaplanMeierChart({ curves, endpoint, height = 460 }: KaplanMeierChartProps) {
+  const data = useMemo(() => toWideSeries(curves), [curves]);
+
+  if (curves.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-[400px] text-slate-400 text-sm">
+        No curves selected
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height }}>
+      {/* HTML legend overlay — kept out of Recharts so it doesn't reserve layout
+          space and shrink the plot. Sits inside the plot at the top-right. */}
+      <div
+        className="absolute top-3 right-7 z-10 rounded-md border bg-white/90 px-2.5 py-1.5 text-xs"
+        style={{ borderColor: GRID }}
+      >
+        {curves.map((c, i) => (
+          <div key={c.id} className="flex items-center gap-2 py-0.5">
+            <span className="inline-block h-0.5 w-4 rounded" style={{ background: armColor(i) }} />
+            <span className="text-slate-700">{c.arm_name}</span>
+          </div>
+        ))}
+      </div>
+      <ResponsiveContainer width="100%" height={height}>
+        <LineChart data={data} margin={{ top: 8, right: 24, bottom: 28, left: 8 }}>
+        <CartesianGrid stroke={GRID} strokeDasharray="3 3" />
+        <XAxis
+          dataKey="time"
+          type="number"
+          domain={[0, X_MAX]}
+          ticks={X_TICKS}
+          allowDataOverflow
+          tick={{ fontSize: 12, fill: AXIS }}
+          tickLine={{ stroke: GRID }}
+          axisLine={{ stroke: GRID }}
+          label={{ value: 'Time (months)', position: 'insideBottom', offset: -12, fill: AXIS, fontSize: 12 }}
+        />
+        <YAxis
+          domain={[0, 100]}
+          ticks={Y_TICKS}
+          tick={{ fontSize: 12, fill: AXIS }}
+          tickLine={{ stroke: GRID }}
+          axisLine={{ stroke: GRID }}
+          label={{
+            value: `${endpoint} (%)`,
+            angle: -90,
+            position: 'insideLeft',
+            style: { textAnchor: 'middle', fill: AXIS, fontSize: 12, fontWeight: 600 },
+          }}
+        />
+        <Tooltip
+          formatter={(value, name) => [
+            value == null ? '—' : `${Number(value).toFixed(1)}%`,
+            name,
+          ]}
+          labelFormatter={(t) => `${t} mo`}
+          contentStyle={{ fontSize: 12, borderRadius: 8, borderColor: GRID }}
+        />
+        {curves.map((c, i) => (
+          <Line
+            key={c.id}
+            type="stepAfter"
+            dataKey={c.id}
+            name={c.arm_name}
+            stroke={armColor(i)}
+            strokeWidth={2.5}
+            dot={false}
+            connectNulls
+            isAnimationActive={false}
+          />
+        ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1376,4 +1376,50 @@ export interface SnapshotResponse {
   totalAbstracts: number;
 }
 
+/** A single reconstructed KM step point (survival 0-100 at a time in months). */
+export interface KmPoint {
+  time: number;
+  surv: number;
+}
+
+/** One row from `km_curves`: a reconstructed digitized-twin curve for one arm/endpoint. */
+export interface KmCurveRow {
+  id: string;
+  publication_id: string;
+  nct_id: string | null;
+  cancer_type: string;
+  comparison_label: string | null;
+  arm_name: string;
+  endpoint: string;
+  twin_coords: KmPoint[];
+  published_median: number | null;
+  twin_median: number | null;
+  rate_timepoint: number | null;
+  published_rate: number | null;
+  twin_rate: number | null;
+  median_follow_up: number | null;
+  match_pct: number | null;
+  n_points: number | null;
+  reference: string | null;
+}
+
+export const kmCurvesApi = {
+  /** All reconstructed KM curves for a cancer type, optionally filtered by endpoint. */
+  getByCancerType: async (slug: string, endpoint?: string): Promise<KmCurveRow[]> => {
+    const supabase = createClient();
+    let query = supabase
+      .from('km_curves')
+      .select('*')
+      .eq('cancer_type', getDbCancerType(slug));
+    if (endpoint) query = query.eq('endpoint', endpoint);
+
+    const { data, error } = await query;
+    if (error) {
+      console.error('[kmCurvesApi.getByCancerType] query failed:', error.message);
+      return [];
+    }
+    return (data ?? []) as KmCurveRow[];
+  },
+};
+
 

--- a/web/supabase/migrations/20260608000000_km_curves.sql
+++ b/web/supabase/migrations/20260608000000_km_curves.sql
@@ -1,0 +1,30 @@
+-- Reconstructed "digitized twin" Kaplan-Meier curves per arm, per endpoint.
+-- One row = one treatment arm of one publication for one survival endpoint.
+-- Curves are produced offline by the survival-twin pipeline and exist for
+-- publications only (keyed by publication_id).
+CREATE TABLE km_curves (
+  id               TEXT PRIMARY KEY,            -- e.g. publication_Batch-III_3_arm_1
+  publication_id   TEXT NOT NULL,               -- e.g. publication_Batch-III_3
+  nct_id           TEXT REFERENCES clinical_trials(nct_id),
+  cancer_type      TEXT NOT NULL,               -- DB cancer-type string (see getDbCancerType)
+  comparison_label TEXT,                         -- groups arms shown together
+  arm_name         TEXT NOT NULL,
+  endpoint         TEXT NOT NULL,               -- PFS / OS / DFS / ...
+  twin_coords      JSONB NOT NULL DEFAULT '[]', -- [{ "time": number, "surv": number }] (surv 0-100)
+  published_median NUMERIC,                      -- months
+  twin_median      NUMERIC,                      -- reconstructed median (months)
+  rate_timepoint   NUMERIC,                      -- months, e.g. 24
+  published_rate   NUMERIC,                      -- published % at rate_timepoint
+  twin_rate        NUMERIC,                      -- reconstructed % at rate_timepoint
+  median_follow_up NUMERIC,                      -- months
+  match_pct        NUMERIC,                      -- digitized-twin fidelity %, e.g. 99.4
+  n_points         INTEGER,                      -- points used, e.g. 142
+  reference        TEXT                          -- publication citation / URL / PMID
+);
+
+CREATE INDEX idx_km_curves_cancer_endpoint ON km_curves(cancer_type, endpoint);
+CREATE INDEX idx_km_curves_publication      ON km_curves(publication_id);
+
+-- Public read (mirrors trial_outcomes); curves carry no user-private data.
+ALTER TABLE km_curves ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "km_curves_read" ON km_curves FOR SELECT USING (true);


### PR DESCRIPTION
Add Head-to-Head Survival (KM Curves) view fed by reconstructed digitized-twin curves:

- km_curves table + RLS migration (public read)
- kmCurvesApi.getByCancerType in src/lib/api.ts
- KaplanMeierChart component and head-to-head-survival page
- KM Curves nav link on the analytics page
- load-km-curves.mjs to build seed SQL from survival-twin data

Curve seed SQL (proprietary output + local fixtures) is gitignored; the table is provisioned by the committed migration.