### PR TITLE
feat(melanoma): LLM-as-a-Judge validation pipeline for extracted trial parameters

### DIFF
--- a/melanoma/run_trials_validation.py
+++ b/melanoma/run_trials_validation.py
@@ -226,7 +226,10 @@ def main() -> None:
     print("=" * 60)
     for decision in ("kept", "fixed", "dropped", "hitl", "error"):
         print(f"  {decision.capitalize():9}: {counts.get(decision, 0)}")
+    cost = cost_calculator.get_summary()
+    print(f"  Cost     : ${cost.total_cost:.4f} ({cost.total_tokens:,} tokens)")
     print(f"  Output   : {config.output_dir}")
+    print(f"  Cost report: {config.output_dir / 'cost_report.json'}")
     print("=" * 60)
 
 

--- a/melanoma/run_trials_validation.py
+++ b/melanoma/run_trials_validation.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""CLI runner for the LLM-as-a-Judge trial parameter validation pipeline.
+
+Validates an extraction run's results.json against the source snapshot and writes
+validation.json plus the routed cohort files (results.cleaned.json, its
+dropped-ncts companion, validation_hitl.json, corrections.json).
+
+Backend is Vertex AI / Gemini via ADC, same as run_trials_extraction.py.
+
+Usage
+-----
+# Advisory (detect-only) sample run
+poetry run python3 run_trials_validation.py --snapshot data/output/trials_extraction_nonindustry/<date>-clinical-trials.json --sample 30
+
+# Higher throughput
+poetry run python3 run_trials_validation.py --snapshot <snap> --concurrency 8
+
+# Enable gated auto-fix (only after gold-set calibration)
+poetry run python3 run_trials_validation.py --snapshot <snap> --apply-fixes --score-threshold 0.8
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_MELANOMA_ROOT = Path(__file__).resolve().parent
+load_dotenv(_MELANOMA_ROOT / ".env")
+
+from src.app.trials_validation_service import (  # noqa: E402
+    TrialValidationService,
+    ValidationConfig,
+)
+from src.infrastructure.cost_calculator import CostCalculator  # noqa: E402
+from src.infrastructure.gemini_service import GeminiLLMService  # noqa: E402
+
+_DEFAULT_MODEL = "gemini-3.1-pro-preview"
+_DEFAULT_RESULTS = (
+    _MELANOMA_ROOT
+    / "data"
+    / "output"
+    / "trials_extraction_nonindustry"
+    / "results.json"
+)
+_DEFAULT_OUTPUT_DIR = (
+    _MELANOMA_ROOT / "data" / "output" / "trials_extraction_nonindustry" / "validation"
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="run_trials_validation",
+        description="Validate extracted trial parameters with an LLM judge.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--snapshot",
+        type=Path,
+        required=True,
+        metavar="PATH",
+        help="Snapshot JSON the extraction run used (source of truth for grading).",
+    )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=_DEFAULT_RESULTS,
+        metavar="PATH",
+        help=f"Extraction results.json to validate (default: {_DEFAULT_RESULTS}).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=_DEFAULT_OUTPUT_DIR,
+        metavar="DIR",
+        help=f"Output directory (default: {_DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument("--model", default=_DEFAULT_MODEL, metavar="MODEL_ID")
+    parser.add_argument(
+        "--mode",
+        choices=["online", "batch"],
+        default="online",
+        help="online = bounded-concurrency interactive; batch = Vertex Batch "
+        "Prediction (not yet implemented).",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=5,
+        metavar="N",
+        help="Max in-flight judge calls in online mode (default: 5).",
+    )
+    parser.add_argument(
+        "--apply-fixes",
+        action="store_true",
+        help="Enable gated auto-fix + judge-driven drops (default: off / advisory).",
+    )
+    parser.add_argument(
+        "--score-threshold",
+        type=float,
+        default=0.75,
+        metavar="F",
+        help="Minimum validation_score for a correction to be auto-applied.",
+    )
+    parser.add_argument(
+        "--sample",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Validate only the first N trials (after sorting/allowlist).",
+    )
+    parser.add_argument(
+        "--nct",
+        metavar="NCT_NUMBER",
+        action="append",
+        dest="nct_numbers",
+        help="Validate only the given NCT number(s). Repeatable.",
+    )
+    parser.add_argument(
+        "--no-resume",
+        dest="resume",
+        action="store_false",
+        help="Re-validate all trials, ignoring the checkpoint.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and report what would run; no LLM calls.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser
+
+
+def _configure_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    for noisy in ("httpx", "httpcore", "google_genai"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+
+def _validate_env() -> tuple[str, str]:
+    project = os.getenv("GOOGLE_CLOUD_PROJECT")
+    location = os.getenv("GOOGLE_CLOUD_LOCATION")
+    missing = [
+        name
+        for name, value in (
+            ("GOOGLE_CLOUD_PROJECT", project),
+            ("GOOGLE_CLOUD_LOCATION", location),
+        )
+        if not value
+    ]
+    if missing:
+        print(
+            f"ERROR: {', '.join(missing)} is not set. Add it to melanoma/.env.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    assert project and location
+    return project, location
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    _configure_logging(args.verbose)
+    logger = logging.getLogger(__name__)
+
+    project, location = _validate_env()
+    for path in (args.results, args.snapshot):
+        if not path.exists():
+            print(f"ERROR: not found: {path}", file=sys.stderr)
+            sys.exit(1)
+
+    config = ValidationConfig(
+        results_path=args.results,
+        snapshot_path=args.snapshot,
+        output_dir=args.output_dir,
+        model=args.model,
+        mode=args.mode,
+        concurrency=args.concurrency,
+        apply_fixes=args.apply_fixes,
+        score_threshold=args.score_threshold,
+        sample=args.sample,
+        resume=args.resume,
+        dry_run=args.dry_run,
+        nct_allowlist=(
+            [n.upper() for n in args.nct_numbers] if args.nct_numbers else None
+        ),
+    )
+
+    logger.info("=" * 60)
+    logger.info("Trial Parameter Validation Pipeline")
+    logger.info("Model       : %s", config.model)
+    logger.info("Mode        : %s", config.mode)
+    logger.info("Apply fixes : %s", config.apply_fixes)
+    logger.info("Output dir  : %s", config.output_dir)
+    logger.info("=" * 60)
+
+    cost_calculator = CostCalculator()
+    llm = GeminiLLMService(
+        model=config.model,
+        cost_calculator=cost_calculator,
+        project=project,
+        location=location,
+    )
+    service = TrialValidationService.from_config(config, llm, cost_calculator)
+
+    try:
+        results = asyncio.run(service.run())
+    except KeyboardInterrupt:
+        logger.warning("Interrupted - partial results saved.")
+        sys.exit(130)
+
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.decision.value] = counts.get(r.decision.value, 0) + 1
+
+    print("\n" + "=" * 60)
+    print("VALIDATION COMPLETE")
+    print("=" * 60)
+    for decision in ("kept", "fixed", "dropped", "hitl", "error"):
+        print(f"  {decision.capitalize():9}: {counts.get(decision, 0)}")
+    print(f"  Output   : {config.output_dir}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/melanoma/scripts/build_industry_results_from_csv.py
+++ b/melanoma/scripts/build_industry_results_from_csv.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Rebuild a validation-ready results.json from the March industry extraction CSVs.
+
+The industry cohort was extracted in March in per-batch CSVs
+(`data/output/trials_extraction/*_trials.csv`); its consolidated results.json was
+overwritten down to the last 300-row batch, so it cannot feed the validation
+pipeline as-is. This script concatenates all batch CSVs and reshapes each row into
+the `TrialParameterResult.to_dict` layout the judge expects: the six multi-value
+fields become lists (split on '; '), treatment_name / nct_number stay strings, and
+extraction_status / error_message are preserved for the status-consistency rule.
+
+The output carries no `snapshot_sha256` (the original snapshot is gone); the
+validator only warns on that and proceeds, which is fine for an advisory audit.
+
+Usage:
+    cd melanoma
+    poetry run python3 scripts/build_industry_results_from_csv.py
+    poetry run python3 scripts/build_industry_results_from_csv.py --out /tmp/r.json
+"""
+
+import argparse
+import csv
+import glob
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+_MELANOMA_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_CSV_DIR = _MELANOMA_ROOT / "data" / "output" / "trials_extraction"
+_DEFAULT_OUT = (
+    _MELANOMA_ROOT / "data" / "output" / "trials_extraction_industry" / "results.json"
+)
+
+# Multi-value fields the CSV stores as '; '-joined text; the judge and the
+# deterministic validator (trial_deterministic_validator._LIST_FIELDS) require lists.
+_LIST_FIELDS = (
+    "cancer_type",
+    "modality",
+    "biomarker",
+    "stage",
+    "line_of_therapy",
+    "previous_treatment_criteria",
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def _split(value: str) -> list[str]:
+    """Split a '; '-joined CSV cell back into a list; empty cell -> empty list."""
+    return [part.strip() for part in value.split(";") if part.strip()]
+
+
+def reshape_row(row: dict) -> dict:
+    """Map one CSV row onto the TrialParameterResult.to_dict shape."""
+    record: dict = {
+        "nct_number": row["nct_number"],
+        "treatment_name": row["treatment_name"],
+        "extraction_status": row["extraction_status"],
+        "error_message": row["error_message"],
+    }
+    for field in _LIST_FIELDS:
+        record[field] = _split(row[field])
+    return record
+
+
+def load_rows(csv_dir: Path) -> list[dict]:
+    """Concatenate every *_trials.csv batch under csv_dir, sorted by NCT number."""
+    rows: list[dict] = []
+    for path in sorted(glob.glob(str(csv_dir / "*_trials.csv"))):
+        with open(path, newline="") as handle:
+            rows.extend(reshape_row(r) for r in csv.DictReader(handle))
+    rows.sort(key=lambda r: r["nct_number"])
+    return rows
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="build_industry_results_from_csv",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--csv-dir", type=Path, default=_DEFAULT_CSV_DIR, metavar="DIR")
+    parser.add_argument("--out", type=Path, default=_DEFAULT_OUT, metavar="PATH")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    rows = load_rows(args.csv_dir)
+    duplicates = len(rows) - len({r["nct_number"] for r in rows})
+    if duplicates:
+        logger.warning("Found %d duplicate NCT numbers across batches", duplicates)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "metadata": {
+            "source": "trials_extraction/*_trials.csv (March industry extraction)",
+            "rebuilt_at": datetime.now(timezone.utc).isoformat(),
+            "total_trials": len(rows),
+        },
+        "trials": rows,
+    }
+    args.out.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    logger.info("Wrote %d trials to %s", len(rows), args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/melanoma/scripts/download_clinical_trials_snapshot.py
+++ b/melanoma/scripts/download_clinical_trials_snapshot.py
@@ -14,10 +14,18 @@ via `--snapshot` instead of hitting Supabase per run, and outcome-measure
 filtering happens locally against this file afterwards. It is co-located with the
 run's results.json / checkpoint.json so everything for this cohort lives together.
 
+The INDUSTRY cohort (`--sponsor-class INDUSTRY`) inverts the sponsor filter to
+`lead_sponsor_class == 'INDUSTRY'` and defaults its output to
+`data/output/trials_extraction_industry/`. Pass `--exclude-interventions` when
+auditing an extraction that predates interventions grounding so the judge grades
+against the same source text the extractor saw.
+
 Usage:
     cd melanoma
     poetry run python3 scripts/download_clinical_trials_snapshot.py
     poetry run python3 scripts/download_clinical_trials_snapshot.py --out /tmp/snap.json
+    poetry run python3 scripts/download_clinical_trials_snapshot.py \
+        --sponsor-class INDUSTRY --exclude-interventions
 """
 
 import argparse
@@ -33,6 +41,9 @@ from supabase import create_client
 
 _MELANOMA_ROOT = Path(__file__).resolve().parent.parent
 _DEFAULT_OUT_DIR = _MELANOMA_ROOT / "data" / "output" / "trials_extraction_nonindustry"
+_DEFAULT_OUT_DIR_INDUSTRY = (
+    _MELANOMA_ROOT / "data" / "output" / "trials_extraction_industry"
+)
 _PAGE_SIZE = 1000
 
 # Columns saved: extractor inputs + deferred outcome filter + provenance.
@@ -75,22 +86,48 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="Output file (default: data/snapshots/<date>-clinical-trials.json).",
     )
+    parser.add_argument(
+        "--sponsor-class",
+        choices=["NON_INDUSTRY", "INDUSTRY"],
+        default="NON_INDUSTRY",
+        help="Which cohort to fetch: NON_INDUSTRY (lead_sponsor_class != INDUSTRY, "
+        "the default) or INDUSTRY (lead_sponsor_class == INDUSTRY).",
+    )
+    parser.add_argument(
+        "--exclude-interventions",
+        action="store_true",
+        help="Drop the interventions column from the snapshot. Use when auditing an "
+        "extraction run that predates interventions grounding, so the judge grades "
+        "against the same source text the extractor actually saw.",
+    )
+    parser.add_argument(
+        "--all-study-types",
+        action="store_true",
+        help="Skip the study_type filter and fetch every study type (including "
+        "OBSERVATIONAL). Use when auditing an extraction whose cohort was not "
+        "restricted to interventional/expanded-access trials.",
+    )
     return parser
 
 
-def _fetch_all(client: object) -> list[dict]:
+def _fetch_all(
+    client: object, columns: list[str], industry: bool, all_study_types: bool
+) -> list[dict]:
     """Paginate the filtered clinical_trials query into a single list."""
     rows: list[dict] = []
     start = 0
     while True:
-        resp = (
-            client.table("clinical_trials")  # type: ignore[attr-defined]
-            .select(",".join(_COLUMNS))
-            .neq("lead_sponsor_class", _EXCLUDED_SPONSOR_CLASS)
-            .in_("study_type", _INCLUDED_STUDY_TYPES)
-            .range(start, start + _PAGE_SIZE - 1)
-            .execute()
+        query = client.table("clinical_trials").select(  # type: ignore[attr-defined]
+            ",".join(columns)
         )
+        query = (
+            query.eq("lead_sponsor_class", _EXCLUDED_SPONSOR_CLASS)
+            if industry
+            else query.neq("lead_sponsor_class", _EXCLUDED_SPONSOR_CLASS)
+        )
+        if not all_study_types:
+            query = query.in_("study_type", _INCLUDED_STUDY_TYPES)
+        resp = query.range(start, start + _PAGE_SIZE - 1).execute()
         page = resp.data
         if not page:
             break
@@ -114,32 +151,45 @@ def main() -> None:
         )
         sys.exit(1)
 
+    industry = args.sponsor_class == "INDUSTRY"
+    drop_interventions = args.exclude_interventions
+    columns = [c for c in _COLUMNS if not (drop_interventions and c == "interventions")]
+
     client = create_client(url, key)
     logger.info(
-        "Fetching non-industry %s trials from clinical_trials...",
-        "/".join(_INCLUDED_STUDY_TYPES),
+        "Fetching %s %s trials from clinical_trials...",
+        args.sponsor_class.lower().replace("_", "-"),
+        "all-study-type" if args.all_study_types else "/".join(_INCLUDED_STUDY_TYPES),
     )
-    rows = _fetch_all(client)
+    rows = _fetch_all(client, columns, industry, args.all_study_types)
 
     null_title = sum(1 for r in rows if not r.get("official_title"))
     logger.info(
         "Fetched %d trials (%d with null official_title)", len(rows), null_title
     )
 
+    default_dir = _DEFAULT_OUT_DIR_INDUSTRY if industry else _DEFAULT_OUT_DIR
     out_path = args.out or (
-        _DEFAULT_OUT_DIR / f"{date.today().isoformat()}-clinical-trials.json"
+        default_dir / f"{date.today().isoformat()}-clinical-trials.json"
     )
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
+    sponsor_filter = (
+        {"lead_sponsor_class_eq": _EXCLUDED_SPONSOR_CLASS}
+        if industry
+        else {"lead_sponsor_class_ne": _EXCLUDED_SPONSOR_CLASS}
+    )
     snapshot = {
         "metadata": {
             "source_table": "clinical_trials",
             "fetched_at": date.today().isoformat(),
             "filters": {
-                "lead_sponsor_class_ne": _EXCLUDED_SPONSOR_CLASS,
-                "study_type_in": _INCLUDED_STUDY_TYPES,
+                **sponsor_filter,
+                "study_type_in": (
+                    "ALL" if args.all_study_types else _INCLUDED_STUDY_TYPES
+                ),
             },
-            "columns": _COLUMNS,
+            "columns": columns,
             "row_count": len(rows),
         },
         "trials": rows,

--- a/melanoma/scripts/download_clinical_trials_snapshot.py
+++ b/melanoma/scripts/download_clinical_trials_snapshot.py
@@ -36,12 +36,15 @@ _DEFAULT_OUT_DIR = _MELANOMA_ROOT / "data" / "output" / "trials_extraction_nonin
 _PAGE_SIZE = 1000
 
 # Columns saved: extractor inputs + deferred outcome filter + provenance.
+# `interventions` is the structured CT.gov arms/interventions list; it grounds
+# treatment_name / modality extraction (see snapshot_source.load_trial).
 _COLUMNS = [
     "nct_id",
     "cancer_type",
     "official_title",
     "brief_title",
     "brief_summary",
+    "interventions",
     "eligibility_criteria",
     "primary_outcomes",
     "secondary_outcomes",
@@ -119,9 +122,13 @@ def main() -> None:
     rows = _fetch_all(client)
 
     null_title = sum(1 for r in rows if not r.get("official_title"))
-    logger.info("Fetched %d trials (%d with null official_title)", len(rows), null_title)
+    logger.info(
+        "Fetched %d trials (%d with null official_title)", len(rows), null_title
+    )
 
-    out_path = args.out or (_DEFAULT_OUT_DIR / f"{date.today().isoformat()}-clinical-trials.json")
+    out_path = args.out or (
+        _DEFAULT_OUT_DIR / f"{date.today().isoformat()}-clinical-trials.json"
+    )
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     snapshot = {

--- a/melanoma/src/app/trials_parameter_extraction_service.py
+++ b/melanoma/src/app/trials_parameter_extraction_service.py
@@ -14,6 +14,7 @@ Architecture
   TrialParameterExtractionService — wires all of the above together
 """
 
+import hashlib
 import itertools
 import json
 import logging
@@ -592,6 +593,10 @@ class TrialParameterExtractionService:
             model=self._config.model,
             run_date=run_start,
         )
+        if self._config.snapshot_path is not None:
+            snapshot_bytes = self._config.snapshot_path.read_bytes()
+            summary.snapshot_path = str(self._config.snapshot_path)
+            summary.snapshot_sha256 = hashlib.sha256(snapshot_bytes).hexdigest()
 
         candidates = self._build_candidate_list()
         logger.info(

--- a/melanoma/src/app/trials_validation_service.py
+++ b/melanoma/src/app/trials_validation_service.py
@@ -1,0 +1,567 @@
+"""LLM-as-a-Judge validation pipeline for extracted trial parameters.
+
+Reads the extractor's ``results.json``, re-loads the exact source text the
+extractor saw (snapshot-pinned), runs a deterministic pre-pass followed by a
+Gemini judge pass, and routes each trial (keep / fix / drop / HITL). Mirrors the
+extraction service's shape (config -> ``from_config`` factory -> collaborator
+classes -> ``run()`` loop -> checkpoint -> merge-upsert writer) but adds bounded
+concurrency, so the per-trial disk writes are guarded by a lock.
+
+Authority is staged:
+* ``apply_fixes=False`` (default, "2b") - the judge is advisory: PASS keeps,
+  anything else routes to the HITL queue. Nothing is dropped/edited on its say-so.
+* ``apply_fixes=True`` ("2c", enabled only after gold-set calibration) - FAIL with
+  a gated correction is auto-fixed, FAIL without one is dropped.
+
+The pure decision logic lives in module functions (``quote_grounded``,
+``route_trial``) so it can be unit-tested without an LLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from ..domain.structured_llm_interfaces import StructuredLLMService
+from ..domain.trial_validation_models import (
+    FieldEvaluation,
+    TrialValidationResult,
+    TrialValidationVerdict,
+    ValidationDecision,
+    ValidationFieldStatus,
+    ValidationRunSummary,
+)
+from ..domain.trials_extraction_prompts import (
+    BIOMARKER_VALUES,
+    LINE_OF_THERAPY_VALUES,
+    MODALITY_VALUES,
+    PREVIOUS_TREATMENT_VALUES,
+    STAGE_VALUES,
+)
+from ..domain.trials_validation_prompts import build_validation_prompt
+from ..infrastructure.clinical_trials.snapshot_source import SnapshotTrialSource
+from ..infrastructure.cost_calculator import CostCalculator
+from ..infrastructure.trial_deterministic_validator import (
+    DeterministicViolation,
+    check_trial,
+    is_droppable,
+)
+
+logger = logging.getLogger(__name__)
+
+# Fields whose values are constrained to a controlled vocabulary.
+_ENUM_VOCAB: dict[str, set[str]] = {
+    "modality": set(MODALITY_VALUES),
+    "biomarker": set(BIOMARKER_VALUES),
+    "stage": set(STAGE_VALUES),
+    "line_of_therapy": set(LINE_OF_THERAPY_VALUES),
+    "previous_treatment_criteria": set(PREVIOUS_TREATMENT_VALUES),
+}
+# Fields serialised into the candidate JSON shown to the judge.
+_CANDIDATE_FIELDS = (
+    "nct_number",
+    "cancer_type",
+    "treatment_name",
+    "modality",
+    "biomarker",
+    "stage",
+    "line_of_therapy",
+    "previous_treatment_criteria",
+)
+_MULTI_VALUE_SEP = "; "
+_OPERATION = "validation"
+# Rendered representations of a legitimately-empty extracted field.
+_EMPTY_VALUE_TOKENS = {"", "[]", "null", "none"}
+
+
+# ---------------------------------------------------------------------------
+# Pure logic (no I/O) - unit-testable without an LLM
+# ---------------------------------------------------------------------------
+
+
+def _collapse_ws(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _has_value(rendered: str) -> bool:
+    """Whether a rendered extracted value is a real (non-empty) value."""
+    return rendered.strip().lower() not in _EMPTY_VALUE_TOKENS
+
+
+def quote_grounded(quote: str | None, source_text: str) -> bool:
+    """True if `quote` is a (whitespace-normalised) literal substring of source.
+
+    The hard anti-hallucination guard: a quote the judge did not actually copy
+    from the source cannot ground a PASS or a fix.
+    """
+    if not quote or not quote.strip():
+        return False
+    return _collapse_ws(quote) in _collapse_ws(source_text)
+
+
+def parse_corrected_value(field_name: str, corrected_text: str) -> list[str] | str:
+    """Parse a judge `corrected_value` string into the record's native shape.
+
+    Enum/list fields become a list filtered to in-vocabulary values; free-text
+    fields (treatment_name) stay a string.
+    """
+    if field_name in _ENUM_VOCAB:
+        vocab = _ENUM_VOCAB[field_name]
+        return [
+            v.strip()
+            for v in corrected_text.split(_MULTI_VALUE_SEP)
+            if v.strip() in vocab
+        ]
+    return corrected_text.strip()
+
+
+def _fix_is_gated(
+    ev: FieldEvaluation, source_text: str, score: float, threshold: float
+) -> bool:
+    """Whether a FAIL's proposed correction clears every safety gate."""
+    if ev.corrected_value is None or not ev.corrected_value.strip():
+        return False
+    if score < threshold:
+        return False
+    if not quote_grounded(ev.source_evidence_quote, source_text):
+        return False
+    parsed = parse_corrected_value(ev.field_name, ev.corrected_value)
+    # For enum fields the parse drops out-of-vocab values; an empty result means
+    # the correction was not a valid vocabulary value.
+    if ev.field_name in _ENUM_VOCAB and not parsed:
+        return False
+    if isinstance(parsed, str) and not parsed:
+        return False
+    return True
+
+
+@dataclass
+class RouteOutcome:
+    decision: ValidationDecision
+    applied_corrections: list[dict] = field(default_factory=list)
+
+
+def route_trial(
+    verdict: TrialValidationVerdict,
+    source_text: str,
+    apply_fixes: bool,
+    score_threshold: float,
+) -> RouteOutcome:
+    """Decide a trial's fate from the judge verdict (pure).
+
+    A PASS of a NON-EMPTY value must carry a grounded quote; an ungrounded "PASS"
+    is treated as UNCERTAIN. A PASS of a legitimately-empty field needs no quote
+    (there is nothing to cite). Detect-only (apply_fixes=False) never drops/fixes.
+    """
+    fails: list[FieldEvaluation] = []
+    uncertain = False
+    for ev in verdict.field_evaluations:
+        status = ev.status
+        if (
+            status == ValidationFieldStatus.PASS
+            and _has_value(ev.extracted_value)
+            and not quote_grounded(ev.source_evidence_quote, source_text)
+        ):
+            status = ValidationFieldStatus.UNCERTAIN
+        if status == ValidationFieldStatus.FAIL:
+            fails.append(ev)
+        elif status == ValidationFieldStatus.UNCERTAIN:
+            uncertain = True
+
+    if not fails and not uncertain:
+        return RouteOutcome(ValidationDecision.KEPT)
+
+    if not apply_fixes:
+        # Advisory mode: never act on the judge, queue everything it flagged.
+        return RouteOutcome(ValidationDecision.HITL)
+
+    # Mature mode. UNCERTAIN always needs a human.
+    if uncertain:
+        return RouteOutcome(ValidationDecision.HITL)
+    # Every FAIL must be gate-fixable, otherwise the row is dropped.
+    corrections: list[dict] = []
+    for ev in fails:
+        if not _fix_is_gated(
+            ev, source_text, verdict.validation_score, score_threshold
+        ):
+            return RouteOutcome(ValidationDecision.DROPPED)
+        corrections.append(
+            {
+                "field": ev.field_name,
+                "corrected": parse_corrected_value(
+                    ev.field_name, ev.corrected_value or ""
+                ),
+                "evidence_quote": ev.source_evidence_quote,
+                "score": verdict.validation_score,
+            }
+        )
+    return RouteOutcome(ValidationDecision.FIXED, corrections)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ValidationConfig:
+    """Runtime configuration for a validation run."""
+
+    results_path: Path
+    snapshot_path: Path
+    output_dir: Path
+    model: str
+    mode: str = "online"  # online | batch
+    concurrency: int = 5
+    apply_fixes: bool = False
+    score_threshold: float = 0.75
+    sample: int | None = None
+    resume: bool = True
+    dry_run: bool = False
+    nct_allowlist: list[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint (resume across runs)
+# ---------------------------------------------------------------------------
+
+
+class ValidationCheckpointManager:
+    """Persists which NCTs have been validated so a run can resume."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._done: dict[str, dict] = {}
+        if path.exists():
+            self._done = json.loads(path.read_text())
+
+    def is_done(self, nct: str) -> bool:
+        return nct in self._done
+
+    def record(self, nct: str, decision: str) -> None:
+        self._done[nct] = {
+            "decision": decision,
+            "recorded_at": datetime.utcnow().isoformat(),
+        }
+        self._path.write_text(json.dumps(self._done, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Result writer
+# ---------------------------------------------------------------------------
+
+
+class ValidationResultWriter:
+    """Writes validation.json (merge-upsert) plus the derived routing files."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self._output_dir = output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    def write_validation(
+        self,
+        results: list[TrialValidationResult],
+        summary: ValidationRunSummary,
+    ) -> Path:
+        path = self._output_dir / "validation.json"
+        merged: dict[str, dict] = {}
+        if path.exists():
+            existing = json.loads(path.read_text())
+            for row in existing.get("trials", []):
+                merged[row["nct_number"]] = row
+        for result in results:
+            merged[result.nct_number] = result.to_dict()
+        rows = list(merged.values())
+
+        metadata = summary.to_dict()
+        decisions = [r["decision"] for r in rows]
+        metadata["total_trials"] = len(rows)
+        metadata["kept"] = decisions.count(ValidationDecision.KEPT.value)
+        metadata["fixed"] = decisions.count(ValidationDecision.FIXED.value)
+        metadata["dropped"] = decisions.count(ValidationDecision.DROPPED.value)
+        metadata["hitl"] = decisions.count(ValidationDecision.HITL.value)
+        metadata["errored"] = decisions.count(ValidationDecision.ERROR.value)
+
+        path.write_text(
+            json.dumps(
+                {"metadata": metadata, "trials": rows}, indent=2, ensure_ascii=False
+            )
+        )
+        return path
+
+    def write_derived(
+        self,
+        cleaned: list[dict],
+        dropped: list[dict],
+        hitl: list[dict],
+        corrections: list[dict],
+    ) -> None:
+        """Write the cleaned cohort and the drop / HITL / corrections side files."""
+        (self._output_dir / "results.cleaned.json").write_text(
+            json.dumps({"trials": cleaned}, indent=2, ensure_ascii=False)
+        )
+        (self._output_dir / "results.cleaned.json.dropped-ncts.json").write_text(
+            json.dumps({"dropped": dropped}, indent=2, ensure_ascii=False)
+        )
+        (self._output_dir / "validation_hitl.json").write_text(
+            json.dumps({"trials": hitl}, indent=2, ensure_ascii=False)
+        )
+        (self._output_dir / "corrections.json").write_text(
+            json.dumps({"corrections": corrections}, indent=2, ensure_ascii=False)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class TrialValidationService:
+    """Orchestrates deterministic + LLM validation over an extraction run."""
+
+    def __init__(
+        self,
+        config: ValidationConfig,
+        llm: StructuredLLMService,
+        snapshot_source: SnapshotTrialSource,
+        checkpoint: ValidationCheckpointManager,
+        writer: ValidationResultWriter,
+        cost_calculator: CostCalculator,
+    ) -> None:
+        self._config = config
+        self._llm = llm
+        self._snapshot = snapshot_source
+        self._checkpoint = checkpoint
+        self._writer = writer
+        self._cost_calculator = cost_calculator
+        self._write_lock = asyncio.Lock()
+
+    @classmethod
+    def from_config(
+        cls,
+        config: ValidationConfig,
+        llm: StructuredLLMService,
+        cost_calculator: CostCalculator,
+    ) -> TrialValidationService:
+        results = json.loads(config.results_path.read_text(encoding="utf-8"))
+        _assert_snapshot_matches(results, config.snapshot_path)
+        snapshot = json.loads(config.snapshot_path.read_text(encoding="utf-8"))
+        return cls(
+            config=config,
+            llm=llm,
+            snapshot_source=SnapshotTrialSource(snapshot),
+            checkpoint=ValidationCheckpointManager(
+                config.output_dir / "validation_checkpoint.json"
+            ),
+            writer=ValidationResultWriter(config.output_dir),
+            cost_calculator=cost_calculator,
+        )
+
+    def _candidates(self) -> list[dict]:
+        results = json.loads(self._config.results_path.read_text(encoding="utf-8"))
+        trials = results.get("trials", [])
+        if self._config.nct_allowlist:
+            wanted = {n.upper() for n in self._config.nct_allowlist}
+            trials = [t for t in trials if t["nct_number"].upper() in wanted]
+        trials.sort(key=lambda t: t["nct_number"])
+        if self._config.sample is not None:
+            trials = trials[: self._config.sample]
+        return trials
+
+    async def _validate_one(self, record: dict) -> TrialValidationResult:
+        nct = record["nct_number"]
+        source_cancer_types = self._snapshot.get_cancer_types(nct)
+        violations = check_trial(record, source_cancer_types)
+
+        if is_droppable(violations):
+            return TrialValidationResult(
+                nct_number=nct,
+                decision=ValidationDecision.DROPPED,
+                is_valid=False,
+                validation_score=0.0,
+                deterministic_violations=[_violation_dict(v) for v in violations],
+            )
+
+        source_text = self._snapshot.load_trial(nct).full_text
+        candidate_json = json.dumps(
+            {k: record.get(k) for k in _CANDIDATE_FIELDS}, ensure_ascii=False, indent=2
+        )
+        prompt = build_validation_prompt(source_text, candidate_json)
+        verdict = await self._llm.generate_structured(
+            prompt,
+            response_schema=TrialValidationVerdict,
+            operation=_OPERATION,
+            attribute_type="trial_validation",
+        )
+        outcome = route_trial(
+            verdict,
+            source_text,
+            self._config.apply_fixes,
+            self._config.score_threshold,
+        )
+        return TrialValidationResult(
+            nct_number=nct,
+            decision=outcome.decision,
+            is_valid=verdict.is_valid,
+            validation_score=verdict.validation_score,
+            deterministic_violations=[_violation_dict(v) for v in violations],
+            verdict=verdict.model_dump(mode="json"),
+            applied_corrections=outcome.applied_corrections,
+        )
+
+    async def run(self) -> list[TrialValidationResult]:
+        if self._config.mode == "batch":
+            raise NotImplementedError(
+                "Batch mode (Vertex Batch Prediction) is a documented follow-up; "
+                "use --mode online for now."
+            )
+
+        run_start = datetime.utcnow()
+        summary = ValidationRunSummary(
+            model=self._config.model,
+            run_date=run_start,
+            mode=self._config.mode,
+            apply_fixes=self._config.apply_fixes,
+            source_snapshot_sha256=_sha256(self._config.snapshot_path),
+        )
+
+        candidates = self._candidates()
+        pending = [
+            c
+            for c in candidates
+            if not (self._config.resume and self._checkpoint.is_done(c["nct_number"]))
+        ]
+        logger.info(
+            "Validation starting | candidates=%d pending=%d mode=%s apply_fixes=%s",
+            len(candidates),
+            len(pending),
+            self._config.mode,
+            self._config.apply_fixes,
+        )
+
+        if self._config.dry_run:
+            logger.info("Dry run - %d trials would be validated.", len(pending))
+            return []
+
+        results: list[TrialValidationResult] = []
+        semaphore = asyncio.Semaphore(max(1, self._config.concurrency))
+
+        async def _worker(record: dict) -> None:
+            async with semaphore:
+                try:
+                    result = await self._validate_one(record)
+                except Exception as exc:  # noqa: BLE001 - recorded, not swallowed
+                    logger.error(
+                        "Validation failed for %s: %s", record["nct_number"], exc
+                    )
+                    result = TrialValidationResult(
+                        nct_number=record["nct_number"],
+                        decision=ValidationDecision.ERROR,
+                        error_message=str(exc),
+                    )
+                async with self._write_lock:
+                    results.append(result)
+                    self._checkpoint.record(result.nct_number, result.decision.value)
+                    cost = self._cost_calculator.get_summary()
+                    summary.total_cost_usd = cost.total_cost
+                    summary.total_tokens = cost.total_tokens
+                    self._writer.write_validation(results, summary)
+                    logger.info(
+                        "Validated %d/%d | %s | %s",
+                        len(results),
+                        len(pending),
+                        result.nct_number,
+                        result.decision.value,
+                    )
+
+        await asyncio.gather(*(_worker(record) for record in pending))
+
+        self._write_derived_outputs(candidates)
+        cost = self._cost_calculator.get_summary()
+        summary.total_cost_usd = cost.total_cost
+        summary.total_tokens = cost.total_tokens
+        self._writer.write_validation(results, summary)
+        logger.info("Validation complete | %d trials", len(results))
+        return results
+
+    def _write_derived_outputs(self, candidates: list[dict]) -> None:
+        """Recompute the cleaned cohort + side files from validation.json."""
+        validation = json.loads(
+            (self._config.output_dir / "validation.json").read_text()
+        )
+        verdicts = {r["nct_number"]: r for r in validation.get("trials", [])}
+        by_nct = {c["nct_number"]: c for c in candidates}
+
+        cleaned: list[dict] = []
+        dropped: list[dict] = []
+        hitl: list[dict] = []
+        corrections: list[dict] = []
+
+        for nct, vr in verdicts.items():
+            record = by_nct.get(nct)
+            if record is None:
+                continue
+            decision = vr["decision"]
+            if decision == ValidationDecision.KEPT.value:
+                cleaned.append(record)
+            elif decision == ValidationDecision.FIXED.value:
+                fixed = dict(record)
+                for corr in vr.get("applied_corrections", []):
+                    fixed[corr["field"]] = corr["corrected"]
+                    corrections.append({"nct_number": nct, **corr})
+                cleaned.append(fixed)
+            elif decision == ValidationDecision.DROPPED.value:
+                dropped.append(
+                    {
+                        "nct_number": nct,
+                        "validation_score": vr.get("validation_score"),
+                        "deterministic_violations": vr.get("deterministic_violations"),
+                        "verdict": vr.get("verdict"),
+                    }
+                )
+            else:  # HITL or ERROR both need a human
+                hitl.append(vr)
+
+        self._writer.write_derived(cleaned, dropped, hitl, corrections)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _violation_dict(v: DeterministicViolation) -> dict:
+    return {
+        "field": v.field,
+        "rule": v.rule,
+        "severity": v.severity,
+        "detail": v.detail,
+    }
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_snapshot_matches(results: dict, snapshot_path: Path) -> None:
+    """Guard: the validator must grade against the snapshot the extractor used."""
+    recorded = results.get("metadata", {}).get("snapshot_sha256")
+    if recorded is None:
+        logger.warning(
+            "results.json has no snapshot_sha256; cannot verify source pinning. "
+            "Re-run extraction so provenance is recorded."
+        )
+        return
+    actual = _sha256(snapshot_path)
+    if recorded != actual:
+        raise ValueError(
+            "Snapshot mismatch: results.json was produced from a different snapshot "
+            f"(recorded {recorded[:12]}..., got {actual[:12]}...). The judge would "
+            "grade against the wrong source. Pass the snapshot used for extraction."
+        )

--- a/melanoma/src/app/trials_validation_service.py
+++ b/melanoma/src/app/trials_validation_service.py
@@ -316,6 +316,16 @@ class ValidationResultWriter:
             json.dumps({"corrections": corrections}, indent=2, ensure_ascii=False)
         )
 
+    def write_cost_report(self, cost_calculator: CostCalculator) -> Path:
+        """Write cost_report.json from the CostCalculator (parity with extraction).
+
+        Written incrementally under the run's write-lock so a mid-run kill keeps
+        the spend recorded up to that point.
+        """
+        path = self._output_dir / "cost_report.json"
+        cost_calculator.save_detailed_report(str(path))
+        return path
+
 
 # ---------------------------------------------------------------------------
 # Service
@@ -472,6 +482,7 @@ class TrialValidationService:
                     summary.total_cost_usd = cost.total_cost
                     summary.total_tokens = cost.total_tokens
                     self._writer.write_validation(results, summary)
+                    self._writer.write_cost_report(self._cost_calculator)
                     logger.info(
                         "Validated %d/%d | %s | %s",
                         len(results),
@@ -487,6 +498,7 @@ class TrialValidationService:
         summary.total_cost_usd = cost.total_cost
         summary.total_tokens = cost.total_tokens
         self._writer.write_validation(results, summary)
+        self._writer.write_cost_report(self._cost_calculator)
         logger.info("Validation complete | %d trials", len(results))
         return results
 

--- a/melanoma/src/domain/structured_llm_interfaces.py
+++ b/melanoma/src/domain/structured_llm_interfaces.py
@@ -1,0 +1,39 @@
+"""Interface for LLM calls that return a typed, schema-constrained object.
+
+Segregated from the broader ``LLMService`` (text/dict extraction) so callers that
+only need structured output - notably the validation judge - depend on just this
+one method. ``GeminiLLMService`` implements it; the OpenRouter backend does not,
+and is not used for structured output.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class StructuredLLMService(ABC):
+    """Contract for generating a response constrained to a Pydantic schema."""
+
+    @abstractmethod
+    async def generate_structured(
+        self,
+        prompt: str,
+        response_schema: type[T],
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        model_name: str | None = None,
+        operation: str = "structured_extraction",
+        attribute_type: str | None = None,
+        max_retries: int = 3,
+    ) -> T:
+        """Return a parsed instance of ``response_schema``.
+
+        Implementations must record token usage against their cost calculator and
+        apply retry/backoff on rate-limit errors, raising on exhaustion.
+        """
+        raise NotImplementedError

--- a/melanoma/src/domain/trial_parameter_models.py
+++ b/melanoma/src/domain/trial_parameter_models.py
@@ -86,6 +86,10 @@ class ExtractionRunSummary:
     skipped: int = 0
     total_cost_usd: float = 0.0
     total_tokens: int = 0
+    # Provenance of the source snapshot (snapshot mode only). Lets the validation
+    # pipeline assert it grades against the exact source the extractor saw.
+    snapshot_path: Optional[str] = None
+    snapshot_sha256: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
@@ -98,4 +102,6 @@ class ExtractionRunSummary:
             "skipped": self.skipped,
             "total_cost_usd": round(self.total_cost_usd, 6),
             "total_tokens": self.total_tokens,
+            "snapshot_path": self.snapshot_path,
+            "snapshot_sha256": self.snapshot_sha256,
         }

--- a/melanoma/src/domain/trial_validation_models.py
+++ b/melanoma/src/domain/trial_validation_models.py
@@ -1,0 +1,166 @@
+"""Domain models for LLM-as-a-Judge validation of extracted trial parameters.
+
+Two kinds of model live here:
+
+* The Pydantic ``TrialValidationVerdict`` and its parts are the *LLM contract* -
+  the typed structured output the judge returns (see ``generate_structured``).
+  Values are represented as strings (multi-values ``"; "``-joined) to keep the
+  Gemini response schema simple; the service parses them back when applying fixes.
+* The dataclass ``TrialValidationResult`` / ``ValidationRunSummary`` are the
+  *pipeline records* written to disk, mirroring the extraction pipeline's models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class ValidationFieldStatus(str, Enum):
+    """Per-field judgement from the validator."""
+
+    PASS = "PASS"
+    FAIL = "FAIL"
+    UNCERTAIN = "UNCERTAIN"
+
+
+class ValidationDecision(str, Enum):
+    """Routing outcome for a whole trial after validation."""
+
+    KEPT = "kept"
+    FIXED = "fixed"
+    DROPPED = "dropped"
+    HITL = "hitl"
+    ERROR = "error"
+
+
+# ---------------------------------------------------------------------------
+# LLM contract (Pydantic) - the judge's structured output
+# ---------------------------------------------------------------------------
+
+
+class FieldEvaluation(BaseModel):
+    """The judge's verdict on a single extracted field."""
+
+    field_name: str = Field(description="The extracted field being judged.")
+    status: ValidationFieldStatus
+    extracted_value: str = Field(
+        description="The value under review, rendered as text; "
+        'multi-values joined with "; ".'
+    )
+    source_evidence_quote: str | None = Field(
+        default=None,
+        description="Verbatim phrase from source_text that justifies the value. "
+        "Required to PASS; must be a literal substring of the source.",
+    )
+    mapping_justification: str | None = Field(
+        default=None,
+        description="Why the quoted phrase maps to the value (values are inferred, "
+        "not copied).",
+    )
+    corrected_value: str | None = Field(
+        default=None,
+        description="On FAIL, the proposed replacement value(s), rendered as text "
+        'with "; " between multiple values. Null when no correction is offered.',
+    )
+    issue_description: str | None = Field(default=None)
+
+
+class MissedValue(BaseModel):
+    """A value the source supports but the extractor omitted."""
+
+    field_name: str
+    suggested_value: str = Field(
+        description="A single value to add; for enum fields it must be in vocabulary."
+    )
+    source_evidence_quote: str = Field(
+        description="Verbatim phrase from source_text supporting the addition."
+    )
+
+
+class TrialValidationVerdict(BaseModel):
+    """Full judge verdict for one trial (the structured-output response schema)."""
+
+    is_valid: bool = Field(description="True when no field evaluation is FAIL.")
+    validation_score: float = Field(
+        ge=0.0, le=1.0, description="Overall confidence, 0.0-1.0."
+    )
+    field_evaluations: list[FieldEvaluation] = Field(default_factory=list)
+    missed_values: list[MissedValue] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline records (dataclasses) - written to disk
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TrialValidationResult:
+    """Outcome of validating one extracted trial record."""
+
+    nct_number: str
+    decision: ValidationDecision
+    is_valid: bool = True
+    validation_score: float = 1.0
+    # Deterministic violations as plain dicts (app layer serialises the infra
+    # DeterministicViolation objects so the domain stays free of infra imports).
+    deterministic_violations: list[dict] = field(default_factory=list)
+    # The judge verdict, serialised; None when the judge did not run (e.g. a
+    # deterministic drop, or dry run).
+    verdict: dict | None = None
+    # Corrections actually applied to the cleaned record (2c only).
+    applied_corrections: list[dict] = field(default_factory=list)
+    error_message: str | None = None
+    validated_at: datetime = field(default_factory=datetime.utcnow)
+
+    def to_dict(self) -> dict:
+        return {
+            "nct_number": self.nct_number,
+            "decision": self.decision.value,
+            "is_valid": self.is_valid,
+            "validation_score": round(self.validation_score, 4),
+            "deterministic_violations": self.deterministic_violations,
+            "verdict": self.verdict,
+            "applied_corrections": self.applied_corrections,
+            "error_message": self.error_message,
+            "validated_at": self.validated_at.isoformat(),
+        }
+
+
+@dataclass
+class ValidationRunSummary:
+    """High-level summary written to the validation.json metadata block."""
+
+    model: str
+    run_date: datetime
+    mode: str = "online"
+    apply_fixes: bool = False
+    source_snapshot_sha256: str | None = None
+    total_trials: int = 0
+    kept: int = 0
+    fixed: int = 0
+    dropped: int = 0
+    hitl: int = 0
+    errored: int = 0
+    total_cost_usd: float = 0.0
+    total_tokens: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "run_date": self.run_date.isoformat(),
+            "mode": self.mode,
+            "apply_fixes": self.apply_fixes,
+            "source_snapshot_sha256": self.source_snapshot_sha256,
+            "total_trials": self.total_trials,
+            "kept": self.kept,
+            "fixed": self.fixed,
+            "dropped": self.dropped,
+            "hitl": self.hitl,
+            "errored": self.errored,
+            "total_cost_usd": round(self.total_cost_usd, 6),
+            "total_tokens": self.total_tokens,
+        }

--- a/melanoma/src/domain/trials_extraction_prompts.py
+++ b/melanoma/src/domain/trials_extraction_prompts.py
@@ -90,6 +90,21 @@ PREVIOUS_TREATMENT_VALUES = [
     "IO Naive",
 ]
 
+# The eight skin-cancer indications this pipeline covers. Single source of truth
+# for the extraction scoping rule and the validation judge's vocabulary. These
+# strings match the cancer_type tags emitted by CT.gov discovery / Supabase
+# verbatim, so the judge never flags a live tag as out-of-vocabulary.
+CANCER_TYPE_VALUES = [
+    "Cutaneous Melanoma",
+    "Cutaneous Melanoma with Brain/CNS Metastasis",
+    "Acral Melanoma",
+    "Uveal Melanoma",
+    "Mucosal Melanoma",
+    "Cutaneous Squamous Cell Carcinoma",
+    "Basal Cell Carcinoma",
+    "Merkel Cell Carcinoma",
+]
+
 # ---------------------------------------------------------------------------
 # System prompt
 # ---------------------------------------------------------------------------
@@ -113,6 +128,7 @@ _BIOMARKER_LIST = "\n".join(f"  - {v}" for v in BIOMARKER_VALUES)
 _STAGE_LIST = "\n".join(f"  - {v}" for v in STAGE_VALUES)
 _LOT_LIST = "\n".join(f"  - {v}" for v in LINE_OF_THERAPY_VALUES)
 _PREV_TX_LIST = "\n".join(f"  - {v}" for v in PREVIOUS_TREATMENT_VALUES)
+_CANCER_TYPE_INLINE = " | ".join(CANCER_TYPE_VALUES)
 
 # ---------------------------------------------------------------------------
 # Single extraction prompt
@@ -126,9 +142,7 @@ Extract all clinical trial parameters from the trial text below in a single pass
 
 ## Global rule
 This pipeline covers eight skin cancer indications:
-  Cutaneous melanoma | Cutaneous melanoma with Brain/CNS metastasis |
-  Acral Melanoma | Uveal Melanoma | Mucosal Melanoma |
-  Cutaneous Squamous Cell Carcinoma | Basal Cell Carcinoma | Merkel Cell Carcinoma
+  {cancer_type_inline}
 
 Some trials enrol multiple tumour types (basket trials, pan-tumour studies).
 When that is the case, extract every field exclusively from the eligibility
@@ -313,6 +327,7 @@ def build_extraction_prompt(full_text: str) -> str:
         Complete prompt string (system + user) ready to send to the LLM.
     """
     user = _EXTRACTION_USER.format(
+        cancer_type_inline=_CANCER_TYPE_INLINE,
         modality_list=_MODALITY_LIST,
         biomarker_list=_BIOMARKER_LIST,
         stage_list=_STAGE_LIST,

--- a/melanoma/src/domain/trials_extraction_prompts.py
+++ b/melanoma/src/domain/trials_extraction_prompts.py
@@ -143,7 +143,19 @@ performance status), it is valid to use it.
 
 ### treatment_name
 The novel drug or drug combination that is the central subject of this trial.
-Use only the officialTitle and briefSummary sections.
+Use the interventions section as the primary signal for the drug name(s), cross-
+checked against the officialTitle and briefSummary. The interventions list is the
+authoritative set of agents administered in the trial; titles and summaries may
+omit, abbreviate, or use code names.
+
+Ignore intervention entries that are not the investigational treatment: placebo,
+best supportive care, sham, and diagnostic/imaging procedures. A comparator-arm
+drug is not the treatment_name either (apply the single-agent rule below).
+
+When an agent appears under several names (a development code, a brand name, and a
+generic/INN name), prefer the generic (INN) name (e.g. gefitinib over "Iressa" or
+"ZD1839"). Keep the code only when no generic name is available (unnamed
+investigational agents).
 
 Single agent: return the investigational drug name only — not the comparator.
   - Example: "Drug X vs. Nivolumab" → "Drug X"
@@ -165,6 +177,12 @@ Choose the modality value(s) that best describe the mechanism of treatment_name.
 - Use "Other" only if the mechanism is identifiable but fits none of the
   specific categories (e.g. radiation, photodynamic therapy).
 - Return [] if the mechanism is completely unidentifiable.
+- Use the intervention `type` from the interventions section as a prior, not a
+  final answer: GENETIC → CAR-T or TIL Therapy; PROCEDURE → Other (e.g. surgery);
+  RADIATION → Other; DRUG → usually Small Molecule or Chemotherapy; BIOLOGICAL →
+  an immunotherapy class (Monoclonal Antibody, Vaccine, Immunostimulant/Cytokine,
+  Bispecific, Oncolytic Virus). The type narrows the options; decide the exact
+  class from the drug name and mechanism, since type is not one-to-one.
 
 Reference examples (modality → example drug):
   Monoclonal Antibody        → Pembrolizumab (PD-1), Nivolumab, Ipilimumab

--- a/melanoma/src/domain/trials_validation_prompts.py
+++ b/melanoma/src/domain/trials_validation_prompts.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from .trials_extraction_prompts import (
     BIOMARKER_VALUES,
+    CANCER_TYPE_VALUES,
     LINE_OF_THERAPY_VALUES,
     MODALITY_VALUES,
     PREVIOUS_TREATMENT_VALUES,
@@ -37,6 +38,11 @@ _ENUM_VOCAB = (
     f"previous_treatment_criteria:\n{_render(PREVIOUS_TREATMENT_VALUES)}"
 )
 
+# The eight skin-cancer indications, rendered as trusted context (NOT a graded
+# vocabulary). cancer_type is a CT.gov condition-query tag, so the judge uses it
+# to identify the in-scope cohort - it never grades it.
+_CANCER_TYPE_CONTEXT = _render(CANCER_TYPE_VALUES)
+
 _USER_TEMPLATE = """\
 ## Task
 Audit the extracted parameters below against the trial source text. Produce a
@@ -48,6 +54,32 @@ per-field verdict and an overall judgement.
   placebo, or supportive/diagnostic entries.
 - biomarker, stage, line_of_therapy, previous_treatment_criteria: the eligibility
   criteria.
+
+## cancer_type is TRUSTED context - do NOT grade it
+cancer_type is not an extracted value; it is a trusted tag from the CT.gov
+condition query / discovery step. Do NOT produce a field verdict for it, do NOT
+PASS, FAIL, correct, or add it to missed_values. Treat the tags as given.
+
+Its only role here is the SCOPING ANCHOR: it tells you which skin-cancer
+cohort(s) the trial concerns, so you grade the other fields against the right
+slice of eligibility. The eight skin-cancer indications a trial may be tagged
+with:
+{cancer_type_context}
+
+To recognise the cohort in the eligibility text:
+- "Cutaneous Melanoma with Brain/CNS Metastasis" means melanoma patients with
+  brain OR central-nervous-system (CNS, e.g. leptomeningeal, spinal) metastases.
+- Rare Melanoma = Acral, Uveal, or Mucosal melanoma: "ocular / choroidal / iris"
+  is Uveal; "subungual / palmar / plantar" is Acral; "vaginal / anorectal /
+  sinonasal / conjunctival mucosa" is Mucosal.
+
+## Scoping rule (cancer_type bounds every other field)
+Some trials enrol multiple tumour types (basket / pan-tumour studies). Judge
+every field ONLY against the eligibility criteria that apply to the trial's
+skin-cancer indication(s). Discard requirements belonging to other tumour types
+(e.g. NSCLC, RCC, HNSCC, colorectal, bladder): do not FAIL a field for omitting
+such a value, and do not credit a value drawn from a non-skin cohort. Criteria
+shared across all cohorts (e.g. ECOG performance status) remain valid.
 
 ## Values are inferred, not copied
 Extracted values are mapped from source language, they do not appear verbatim.
@@ -90,6 +122,7 @@ Judge whether the source *justifies* the mapped value. Examples:
 def build_validation_prompt(source_text: str, candidate_json: str) -> str:
     """Assemble the full judge prompt for one trial."""
     user = _USER_TEMPLATE.format(
+        cancer_type_context=_CANCER_TYPE_CONTEXT,
         enum_vocab=_ENUM_VOCAB,
         source_text=source_text.strip(),
         candidate_json=candidate_json.strip(),

--- a/melanoma/src/domain/trials_validation_prompts.py
+++ b/melanoma/src/domain/trials_validation_prompts.py
@@ -1,0 +1,97 @@
+"""Prompt builder for the LLM-as-a-Judge validation pass.
+
+Reuses the controlled vocabularies that drive extraction (single source of truth
+in ``trials_extraction_prompts``) so the judge scores against the identical
+allowed values. The judge returns a ``TrialValidationVerdict`` via structured
+output; this module supplies the persona, rules, and per-trial context.
+"""
+
+from __future__ import annotations
+
+from .trials_extraction_prompts import (
+    BIOMARKER_VALUES,
+    LINE_OF_THERAPY_VALUES,
+    MODALITY_VALUES,
+    PREVIOUS_TREATMENT_VALUES,
+    STAGE_VALUES,
+)
+
+_SYSTEM_PROMPT = (
+    "You are a strict, adversarial clinical-data auditor specialising in melanoma "
+    "and skin-cancer trials. You verify that structured parameters extracted from a "
+    "trial were justified by the source text. Assume each extracted value is wrong "
+    "until the source proves it right. Be precise and skeptical; do not be "
+    "agreeable. Return ONLY the requested structured verdict."
+)
+
+
+def _render(values: list[str]) -> str:
+    return "\n".join(f"  - {v}" for v in values)
+
+
+_ENUM_VOCAB = (
+    f"modality:\n{_render(MODALITY_VALUES)}\n\n"
+    f"biomarker:\n{_render(BIOMARKER_VALUES)}\n\n"
+    f"stage:\n{_render(STAGE_VALUES)}\n\n"
+    f"line_of_therapy:\n{_render(LINE_OF_THERAPY_VALUES)}\n\n"
+    f"previous_treatment_criteria:\n{_render(PREVIOUS_TREATMENT_VALUES)}"
+)
+
+_USER_TEMPLATE = """\
+## Task
+Audit the extracted parameters below against the trial source text. Produce a
+per-field verdict and an overall judgement.
+
+## Where each field comes from
+- treatment_name, modality: the officialTitle, briefSummary, and interventions
+  sections. treatment_name is the investigational agent(s), not the comparator,
+  placebo, or supportive/diagnostic entries.
+- biomarker, stage, line_of_therapy, previous_treatment_criteria: the eligibility
+  criteria.
+
+## Values are inferred, not copied
+Extracted values are mapped from source language, they do not appear verbatim.
+Judge whether the source *justifies* the mapped value. Examples:
+  "metastatic" / "advanced" / "unresectable stage IV"      -> stage "Stage IV"
+  "resected" / "unresectable" stage III                    -> stage "Stage III"
+  "treatment-naive" / "no prior systemic therapy"          -> line_of_therapy "1L"
+  relapsed / refractory language                           -> line_of_therapy "R/R"
+  a drug name                                              -> its modality class
+
+## Controlled vocabularies (enum fields may only use these values)
+{enum_vocab}
+
+## Rules for your verdict
+- For every field, set status PASS, FAIL, or UNCERTAIN.
+- PASS requires `source_evidence_quote`: a phrase copied VERBATIM from the source
+  text (it must be a literal substring), plus a `mapping_justification` explaining
+  why that phrase maps to the extracted value. No supporting phrase => never PASS.
+- FAIL when the value is unsupported, the mapping is wrong, or the value is
+  hallucinated. When the source clearly supports a different, in-vocabulary value,
+  put it in `corrected_value` (join multiple with "; "); otherwise leave it null.
+- UNCERTAIN when the source is ambiguous or conflicting - not as a hedge.
+- A legitimately empty field (source carries no signal for it) is PASS, not a FAIL
+  and not a missed value.
+- `corrected_value` and `missed_values.suggested_value` for enum fields MUST be
+  from the vocabularies above. Never invent new values.
+- Report values the source clearly supports but the extractor omitted in
+  `missed_values`, each with a verbatim supporting quote.
+- Set `is_valid` false if any field is FAIL. Set `validation_score` to your overall
+  confidence (0.0-1.0) that the extracted record is correct and complete.
+
+## Source text
+{source_text}
+
+## Extracted parameters (candidate under audit)
+{candidate_json}
+"""
+
+
+def build_validation_prompt(source_text: str, candidate_json: str) -> str:
+    """Assemble the full judge prompt for one trial."""
+    user = _USER_TEMPLATE.format(
+        enum_vocab=_ENUM_VOCAB,
+        source_text=source_text.strip(),
+        candidate_json=candidate_json.strip(),
+    )
+    return f"{_SYSTEM_PROMPT}\n\n{user}"

--- a/melanoma/src/infrastructure/clinical_trials/snapshot_source.py
+++ b/melanoma/src/infrastructure/clinical_trials/snapshot_source.py
@@ -13,6 +13,37 @@ from ...domain.trial_parameter_models import TrialText
 
 logger = logging.getLogger(__name__)
 
+# Intervention entries that are never the trial's treatment. Comparators are NOT
+# filtered here (the extractor needs to see them to tell investigational from
+# comparator); only clearly non-treatment entries are dropped.
+_SKIP_INTERVENTION_TYPES = {"DIAGNOSTIC_TEST"}
+_SKIP_NAME_MARKERS = ("placebo", "best supportive care", "sham")
+
+
+def _render_interventions(interventions: list[dict]) -> str:
+    """Render the CT.gov interventions list as `type - name - description` lines.
+
+    Returns an empty string when nothing survives filtering, so callers can omit
+    the section entirely for trials without usable interventions.
+    """
+    lines: list[str] = []
+    for item in interventions:
+        name = (item.get("name") or "").strip()
+        if not name:
+            continue
+        itype = (item.get("type") or "").strip()
+        if itype.upper() in _SKIP_INTERVENTION_TYPES:
+            continue
+        if any(marker in name.lower() for marker in _SKIP_NAME_MARKERS):
+            continue
+        description = (item.get("description") or "").strip()
+        parts = [p for p in (itype, name) if p]
+        line = " - ".join(parts)
+        if description:
+            line = f"{line} - {description}"
+        lines.append(f"- {line}")
+    return "\n".join(lines)
+
 
 class SnapshotTrialSource:
     """Serves candidate NCTs, cancer types, and trial text from a snapshot.
@@ -57,11 +88,16 @@ class SnapshotTrialSource:
         official_title = row.get("official_title") or row.get("brief_title") or ""
         brief_summary = row.get("brief_summary") or ""
         eligibility = row.get("eligibility_criteria") or ""
+        interventions_text = _render_interventions(row.get("interventions") or [])
 
+        interventions_block = (
+            f"interventions:\n{interventions_text}\n\n" if interventions_text else ""
+        )
         full_text = (
             f"NCT Number: {nct_number}\n\n"
             f"officialTitle:\n{official_title}\n\n"
             f"briefSummary:\n{brief_summary}\n\n"
+            f"{interventions_block}"
             f"eligibilityCriteria:\n{eligibility}\n"
         )
         return TrialText(

--- a/melanoma/src/infrastructure/gemini_service.py
+++ b/melanoma/src/infrastructure/gemini_service.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, TypeVar
 from pydantic import BaseModel, ValidationError
 
 from ..domain.extraction_interfaces import LLMService
+from ..domain.structured_llm_interfaces import StructuredLLMService
 from .cost_calculator import CostCalculator
 
 T = TypeVar("T", bound=BaseModel)
@@ -141,7 +142,7 @@ def _parse_json_response(text: str) -> dict[str, Any]:
     return {}
 
 
-class GeminiLLMService(LLMService):
+class GeminiLLMService(LLMService, StructuredLLMService):
     """LLM service backed by Vertex AI via the google-genai SDK.
 
     Supports two authentication modes:

--- a/melanoma/src/infrastructure/gemini_service.py
+++ b/melanoma/src/infrastructure/gemini_service.py
@@ -35,6 +35,37 @@ GEMINI_CACHE_MIN_TOKENS = 32_768
 # still attempt the SDK call and fall back gracefully on rejection.
 _CHARS_PER_TOKEN_ESTIMATE = 4
 
+# 429 backoff. Vertex Gemini runs on Dynamic Shared Quota: a 429 means demand
+# momentarily exceeded the shared pool and usually clears in 1-5s, so we start
+# small and grow exponentially with jitter rather than sitting on a 60s floor.
+_BACKOFF_BASE_SECONDS = 1.0
+_BACKOFF_CAP_SECONDS = 30.0
+_RETRY_AFTER_RE = re.compile(
+    r"retry[-_ ]?(?:delay|after)['\"\s:]+(\d+(?:\.\d+)?)\s*s", re.IGNORECASE
+)
+
+
+def _parse_retry_after(error: str) -> float | None:
+    """Extract a server-suggested retry delay (seconds) from an error string.
+
+    Vertex RESOURCE_EXHAUSTED errors may carry a ``retryDelay: '7s'`` hint.
+    Returns None when no hint is present.
+    """
+    match = _RETRY_AFTER_RE.search(error)
+    return float(match.group(1)) if match else None
+
+
+def _backoff_seconds(attempt: int, retry_after: float | None = None) -> float:
+    """Seconds to wait before retry ``attempt`` (0-indexed).
+
+    Honors a server-provided ``retry_after`` when present (still capped),
+    otherwise exponential base*2**attempt plus jitter, capped.
+    """
+    if retry_after is not None and retry_after > 0:
+        return min(retry_after, _BACKOFF_CAP_SECONDS)
+    exp = min(_BACKOFF_BASE_SECONDS * (2**attempt), _BACKOFF_CAP_SECONDS)
+    return exp + random.uniform(0, _BACKOFF_BASE_SECONDS)
+
 
 def _inline_pydantic_schema(schema_cls: type[BaseModel]) -> dict[str, Any]:
     """Render a Pydantic JSON schema with all ``$ref`` / ``$defs`` inlined.
@@ -277,10 +308,9 @@ class GeminiLLMService(LLMService, StructuredLLMService):
             except Exception as exc:
                 last_exc = exc
                 if self._is_rate_limit_error(exc) and attempt < max_retries - 1:
-                    # Exponential backoff starting at 60 s with ±5 s jitter,
-                    # capped at 300 s — matches Google's recommended handling
-                    # for RESOURCE_EXHAUSTED / 429 responses.
-                    wait_sec = min(60 * (2**attempt) + random.uniform(0, 5), 300)
+                    # DSQ-aware backoff: honor a server retry hint, else a small
+                    # exponential with jitter (see _backoff_seconds).
+                    wait_sec = _backoff_seconds(attempt, _parse_retry_after(str(exc)))
                     logger.warning(
                         "Rate limit (429) on attempt %d/%d — retrying in %.0fs",
                         attempt + 1,

--- a/melanoma/src/infrastructure/gemini_service.py
+++ b/melanoma/src/infrastructure/gemini_service.py
@@ -40,6 +40,35 @@ _CHARS_PER_TOKEN_ESTIMATE = 4
 # small and grow exponentially with jitter rather than sitting on a 60s floor.
 _BACKOFF_BASE_SECONDS = 1.0
 _BACKOFF_CAP_SECONDS = 30.0
+
+# Bounded per-request timeout (ms). Judge/extraction calls run ~3-8s; 90s is
+# generous over p99 yet caps a stalled socket that would otherwise hang a worker
+# forever (there is no default client timeout).
+_REQUEST_TIMEOUT_MS = 90_000
+
+_RETRYABLE_TOKENS = (
+    "429",
+    "RESOURCE_EXHAUSTED",
+    "RATE_LIMIT",
+    "DEADLINE_EXCEEDED",
+    "504",
+    "TIMEOUT",
+    "TIMED OUT",
+)
+
+
+def _is_retryable_error(exc: BaseException) -> bool:
+    """True for transient errors worth retrying: 429/quota and timeout/deadline.
+
+    Retrying a timed-out generate call is safe - the call is side-effect-free,
+    so at worst a completed-but-undelivered response is re-billed (rare, cheap).
+    """
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+        return True
+    msg = str(exc).upper()
+    return any(token in msg for token in _RETRYABLE_TOKENS)
+
+
 _RETRY_AFTER_RE = re.compile(
     r"retry[-_ ]?(?:delay|after)['\"\s:]+(\d+(?:\.\d+)?)\s*s", re.IGNORECASE
 )
@@ -219,11 +248,18 @@ class GeminiLLMService(LLMService, StructuredLLMService):
 
     def _build_client(self) -> Any:
         from google import genai
+        from google.genai import types
 
+        http_options = types.HttpOptions(timeout=_REQUEST_TIMEOUT_MS)
         if self._api_key:
-            return genai.Client(vertexai=True, api_key=self._api_key)
+            return genai.Client(
+                vertexai=True, api_key=self._api_key, http_options=http_options
+            )
         return genai.Client(
-            vertexai=True, project=self._project, location=self._location
+            vertexai=True,
+            project=self._project,
+            location=self._location,
+            http_options=http_options,
         )
 
     def _record_usage(
@@ -252,11 +288,6 @@ class GeminiLLMService(LLMService, StructuredLLMService):
             success=success,
             error_message=error_message,
         )
-
-    def _is_rate_limit_error(self, exc: BaseException) -> bool:
-        """Return True for 429 / RESOURCE_EXHAUSTED transient quota errors."""
-        msg = str(exc).upper()
-        return "429" in msg or "RESOURCE_EXHAUSTED" in msg or "RATE_LIMIT" in msg
 
     async def generate_response(
         self,
@@ -307,12 +338,12 @@ class GeminiLLMService(LLMService, StructuredLLMService):
                 return text
             except Exception as exc:
                 last_exc = exc
-                if self._is_rate_limit_error(exc) and attempt < max_retries - 1:
+                if _is_retryable_error(exc) and attempt < max_retries - 1:
                     # DSQ-aware backoff: honor a server retry hint, else a small
                     # exponential with jitter (see _backoff_seconds).
                     wait_sec = _backoff_seconds(attempt, _parse_retry_after(str(exc)))
                     logger.warning(
-                        "Rate limit (429) on attempt %d/%d — retrying in %.0fs",
+                        "Transient error (429/timeout) on attempt %d/%d — retrying in %.0fs",
                         attempt + 1,
                         max_retries,
                         wait_sec,
@@ -411,10 +442,10 @@ class GeminiLLMService(LLMService, StructuredLLMService):
                     raise
             except Exception as exc:
                 last_exc = exc
-                if self._is_rate_limit_error(exc) and attempt < max_retries - 1:
+                if _is_retryable_error(exc) and attempt < max_retries - 1:
                     wait_sec = min(60 * (2**attempt) + random.uniform(0, 5), 300)
                     logger.warning(
-                        "Rate limit (429) on attempt %d/%d — retrying in %.0fs",
+                        "Transient error (429/timeout) on attempt %d/%d — retrying in %.0fs",
                         attempt + 1,
                         max_retries,
                         wait_sec,

--- a/melanoma/src/infrastructure/trial_deterministic_validator.py
+++ b/melanoma/src/infrastructure/trial_deterministic_validator.py
@@ -1,0 +1,278 @@
+"""Deterministic validator for one extracted clinical-trial parameter record.
+
+Pure, deterministic functions. No LLM, no I/O, no network. Given a single
+extracted record (a plain dict, the shape produced by
+``TrialParameterResult.to_dict``) plus the cancer types the source declared for
+that trial, return every deterministic rule violation. An empty list means the
+record is clean.
+
+Each violation carries a severity:
+
+- ``DROP`` — an objective violation; the row must be removed.
+- ``FLAG`` — an advisory violation; report it and let a later stage decide.
+
+Follows the style of ``value_validator``: pure functions, full type
+annotations, a module logger, and docstrings. The return shape differs: this
+module reports structured :class:`DeterministicViolation` objects rather than
+``(is_valid, normalized, reason)`` tuples.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+from ..domain.trials_extraction_prompts import (
+    BIOMARKER_VALUES,
+    LINE_OF_THERAPY_VALUES,
+    MODALITY_VALUES,
+    PREVIOUS_TREATMENT_VALUES,
+    STAGE_VALUES,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---- Severities --------------------------------------------------------
+
+DROP = "drop"  # objective violation -> row must be removed
+FLAG = "flag"  # advisory violation -> report, let a later stage decide
+
+# ---- Rule ids ----------------------------------------------------------
+
+_RULE_NCT_FORMAT = "nct_format"
+_RULE_REQUIRED_TREATMENT_NAME = "required_treatment_name"
+_RULE_VOCAB_MEMBERSHIP = "vocab_membership"
+_RULE_CANCER_TYPE_SUBSET = "cancer_type_subset"
+_RULE_LIST_SHAPE = "list_shape"
+_RULE_STATUS_CONSISTENCY = "status_consistency"
+
+# ---- Record field names ------------------------------------------------
+
+_FIELD_NCT = "nct_number"
+_FIELD_TREATMENT_NAME = "treatment_name"
+_FIELD_CANCER_TYPE = "cancer_type"
+_FIELD_MODALITY = "modality"
+_FIELD_BIOMARKER = "biomarker"
+_FIELD_STAGE = "stage"
+_FIELD_LINE_OF_THERAPY = "line_of_therapy"
+_FIELD_PREVIOUS_TREATMENT = "previous_treatment_criteria"
+_FIELD_EXTRACTION_STATUS = "extraction_status"
+_FIELD_ERROR_MESSAGE = "error_message"
+
+# ---- extraction_status values ------------------------------------------
+
+_STATUS_DONE = "done"
+_STATUS_PARTIAL = "partial"
+_STATUS_FAILED = "failed"
+
+# ---- Patterns / vocab wiring -------------------------------------------
+
+_NCT_RE = re.compile(r"^NCT\d{8}$")
+
+# Each controlled-vocabulary field mapped to its allowed value list.
+_VOCAB_FIELDS: dict[str, list[str]] = {
+    _FIELD_MODALITY: MODALITY_VALUES,
+    _FIELD_BIOMARKER: BIOMARKER_VALUES,
+    _FIELD_STAGE: STAGE_VALUES,
+    _FIELD_LINE_OF_THERAPY: LINE_OF_THERAPY_VALUES,
+    _FIELD_PREVIOUS_TREATMENT: PREVIOUS_TREATMENT_VALUES,
+}
+
+# Every list-shaped field: the five vocab fields plus cancer_type.
+_LIST_FIELDS: tuple[str, ...] = (
+    _FIELD_CANCER_TYPE,
+    _FIELD_MODALITY,
+    _FIELD_BIOMARKER,
+    _FIELD_STAGE,
+    _FIELD_LINE_OF_THERAPY,
+    _FIELD_PREVIOUS_TREATMENT,
+)
+
+
+@dataclass(frozen=True)
+class DeterministicViolation:
+    """A single deterministic rule violation for one extracted record."""
+
+    field: str  # e.g. "nct_number", "modality", "cancer_type"
+    rule: str  # short rule id, one of the module _RULE_* constants
+    severity: str  # DROP or FLAG
+    detail: str  # human-readable explanation
+
+
+# ---- Individual rule checks --------------------------------------------
+
+
+def _check_nct_format(trial: dict) -> list[DeterministicViolation]:
+    """nct_number must match ``^NCT\\d{8}$`` (DROP)."""
+    nct = trial.get(_FIELD_NCT)
+    if isinstance(nct, str) and _NCT_RE.match(nct):
+        return []
+    return [
+        DeterministicViolation(
+            field=_FIELD_NCT,
+            rule=_RULE_NCT_FORMAT,
+            severity=DROP,
+            detail=f"nct_number {nct!r} does not match ^NCT\\d{{8}}$",
+        )
+    ]
+
+
+def _check_required_treatment_name(trial: dict) -> list[DeterministicViolation]:
+    """treatment_name must be present and non-empty on a ``done`` row (DROP)."""
+    if trial.get(_FIELD_EXTRACTION_STATUS) != _STATUS_DONE:
+        return []
+    name = trial.get(_FIELD_TREATMENT_NAME)
+    if isinstance(name, str) and name.strip():
+        return []
+    return [
+        DeterministicViolation(
+            field=_FIELD_TREATMENT_NAME,
+            rule=_RULE_REQUIRED_TREATMENT_NAME,
+            severity=DROP,
+            detail="treatment_name must be non-empty when extraction_status is 'done'",
+        )
+    ]
+
+
+def _list_shape_problem(value: object) -> str | None:
+    """Return a description of the first shape problem, or None if the value is
+    a well-formed list (a list, no None elements, no duplicates)."""
+    if not isinstance(value, list):
+        return f"expected a list, got {type(value).__name__}"
+    if any(item is None for item in value):
+        return "list contains None element(s)"
+    seen: list[object] = []
+    duplicates: list[object] = []
+    for item in value:
+        if item in seen:
+            if item not in duplicates:
+                duplicates.append(item)
+        else:
+            seen.append(item)
+    if duplicates:
+        return f"list contains duplicate value(s): {duplicates}"
+    return None
+
+
+def _check_list_shape(trial: dict) -> list[DeterministicViolation]:
+    """Each list field must be a list with no None elements and no duplicates
+    (FLAG, one violation per offending field)."""
+    violations: list[DeterministicViolation] = []
+    for field_name in _LIST_FIELDS:
+        problem = _list_shape_problem(trial.get(field_name))
+        if problem is not None:
+            violations.append(
+                DeterministicViolation(
+                    field=field_name,
+                    rule=_RULE_LIST_SHAPE,
+                    severity=FLAG,
+                    detail=problem,
+                )
+            )
+    return violations
+
+
+def _check_vocab_membership(trial: dict) -> list[DeterministicViolation]:
+    """Every value of each vocab field must be in that field's allowed list
+    (FLAG, one violation per offending field). Non-list values are left to the
+    list_shape rule; None elements are ignored here."""
+    violations: list[DeterministicViolation] = []
+    for field_name, allowed in _VOCAB_FIELDS.items():
+        value = trial.get(field_name)
+        if not isinstance(value, list):
+            continue
+        bad = [item for item in value if item is not None and item not in allowed]
+        if bad:
+            violations.append(
+                DeterministicViolation(
+                    field=field_name,
+                    rule=_RULE_VOCAB_MEMBERSHIP,
+                    severity=FLAG,
+                    detail=f"value(s) not in controlled vocabulary: {bad}",
+                )
+            )
+    return violations
+
+
+def _check_cancer_type_subset(
+    trial: dict, source_cancer_types: list[str]
+) -> list[DeterministicViolation]:
+    """Every cancer_type value must appear in ``source_cancer_types`` (exact,
+    case-sensitive; FLAG). Skipped when the source list is empty."""
+    if not source_cancer_types:
+        return []
+    value = trial.get(_FIELD_CANCER_TYPE)
+    if not isinstance(value, list):
+        return []
+    allowed = set(source_cancer_types)
+    bad = [item for item in value if item is not None and item not in allowed]
+    if not bad:
+        return []
+    return [
+        DeterministicViolation(
+            field=_FIELD_CANCER_TYPE,
+            rule=_RULE_CANCER_TYPE_SUBSET,
+            severity=FLAG,
+            detail=f"cancer_type value(s) not in source {source_cancer_types}: {bad}",
+        )
+    ]
+
+
+def _check_status_consistency(trial: dict) -> list[DeterministicViolation]:
+    """partial/failed must carry a non-empty error_message; done must not
+    (FLAG)."""
+    status = trial.get(_FIELD_EXTRACTION_STATUS)
+    error = trial.get(_FIELD_ERROR_MESSAGE)
+    has_error = isinstance(error, str) and error.strip() != ""
+
+    if status in (_STATUS_PARTIAL, _STATUS_FAILED) and not has_error:
+        return [
+            DeterministicViolation(
+                field=_FIELD_EXTRACTION_STATUS,
+                rule=_RULE_STATUS_CONSISTENCY,
+                severity=FLAG,
+                detail=f"extraction_status {status!r} requires a non-empty error_message",
+            )
+        ]
+    if status == _STATUS_DONE and has_error:
+        return [
+            DeterministicViolation(
+                field=_FIELD_EXTRACTION_STATUS,
+                rule=_RULE_STATUS_CONSISTENCY,
+                severity=FLAG,
+                detail="extraction_status 'done' must not carry an error_message",
+            )
+        ]
+    return []
+
+
+# ---- Public API --------------------------------------------------------
+
+
+def check_trial(
+    trial: dict, source_cancer_types: list[str]
+) -> list[DeterministicViolation]:
+    """Return all deterministic violations for one extracted record.
+
+    Args:
+        trial: One extracted record, shaped like ``TrialParameterResult.to_dict``.
+        source_cancer_types: Cancer types the source declared for this trial;
+            used by the cancer_type_subset rule (skipped when empty).
+
+    Returns:
+        Every violation found, in a stable rule order. Empty means clean.
+    """
+    violations: list[DeterministicViolation] = []
+    violations.extend(_check_nct_format(trial))
+    violations.extend(_check_required_treatment_name(trial))
+    violations.extend(_check_list_shape(trial))
+    violations.extend(_check_vocab_membership(trial))
+    violations.extend(_check_cancer_type_subset(trial, source_cancer_types))
+    violations.extend(_check_status_consistency(trial))
+    return violations
+
+
+def is_droppable(violations: list[DeterministicViolation]) -> bool:
+    """True if any violation has severity DROP."""
+    return any(v.severity == DROP for v in violations)

--- a/melanoma/tests/test_build_industry_results.py
+++ b/melanoma/tests/test_build_industry_results.py
@@ -1,0 +1,79 @@
+"""Tests for the industry CSV -> results.json reshape (validation input rebuild)."""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "build_industry_results_from_csv.py"
+)
+_spec = importlib.util.spec_from_file_location("build_industry_results", _SCRIPT)
+assert _spec and _spec.loader
+build_industry_results = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build_industry_results)
+
+reshape_row = build_industry_results.reshape_row
+load_rows = build_industry_results.load_rows
+
+
+def _csv_row(**overrides: str) -> dict:
+    base = {
+        "nct_number": "NCT00002767",
+        "cancer_type": "Cutaneous melanoma",
+        "treatment_name": "Melacine + Interferon alfa-2b",
+        "modality": "Vaccine; Immunostimulant/Cytokine",
+        "biomarker": "",
+        "stage": "Stage IV",
+        "line_of_therapy": "1L",
+        "previous_treatment_criteria": "IO Naive",
+        "extraction_status": "done",
+        "error_message": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_multivalue_field_splits_on_semicolon() -> None:
+    record = reshape_row(_csv_row())
+    assert record["modality"] == ["Vaccine", "Immunostimulant/Cytokine"]
+
+
+def test_empty_cell_becomes_empty_list() -> None:
+    record = reshape_row(_csv_row(biomarker=""))
+    assert record["biomarker"] == []
+
+
+def test_single_value_becomes_one_element_list() -> None:
+    record = reshape_row(_csv_row())
+    assert record["cancer_type"] == ["Cutaneous melanoma"]
+    assert record["stage"] == ["Stage IV"]
+
+
+def test_scalar_fields_stay_strings() -> None:
+    record = reshape_row(_csv_row())
+    assert record["nct_number"] == "NCT00002767"
+    assert record["treatment_name"] == "Melacine + Interferon alfa-2b"
+    assert record["extraction_status"] == "done"
+    assert record["error_message"] == ""
+
+
+def test_treatment_name_with_plus_is_not_split() -> None:
+    # '+' is not the delimiter; only '; ' separates multi-values.
+    record = reshape_row(_csv_row())
+    assert "+" in record["treatment_name"]
+
+
+def test_load_rows_concatenates_and_sorts(tmp_path: Path) -> None:
+    header = (
+        "nct_number,cancer_type,treatment_name,modality,biomarker,stage,"
+        "line_of_therapy,previous_treatment_criteria,extraction_status,error_message\n"
+    )
+    (tmp_path / "b_trials.csv").write_text(
+        header + "NCT00000002,X,Drug B,Other,,Stage I,1L,None,done,\n"
+    )
+    (tmp_path / "a_trials.csv").write_text(
+        header + "NCT00000001,X,Drug A,Other,,Stage I,1L,None,done,\n"
+    )
+    rows = load_rows(tmp_path)
+    assert [r["nct_number"] for r in rows] == ["NCT00000001", "NCT00000002"]

--- a/melanoma/tests/test_gemini_backoff.py
+++ b/melanoma/tests/test_gemini_backoff.py
@@ -1,0 +1,53 @@
+"""Tests for Gemini 429 backoff timing.
+
+Under Vertex Dynamic Shared Quota a 429 means instantaneous demand exceeded
+supply and typically clears in 1-5s, so the retry backoff must start small
+(seconds, not a 60s floor), grow exponentially with jitter, cap, and honor a
+server-provided retry delay when present.
+"""
+
+from __future__ import annotations
+
+from src.infrastructure.gemini_service import _backoff_seconds, _parse_retry_after
+
+_CAP = 30.0
+
+
+def test_first_attempt_backoff_is_seconds_not_a_minute() -> None:
+    """attempt 0 waits a couple seconds, never the old 60s floor."""
+    for _ in range(50):
+        wait = _backoff_seconds(0)
+        assert 1.0 <= wait < 3.0, wait
+
+
+def test_backoff_grows_exponentially() -> None:
+    """Later attempts wait longer (base doubles each attempt)."""
+    for _ in range(50):
+        assert 4.0 <= _backoff_seconds(2) < 6.0
+
+
+def test_backoff_is_capped() -> None:
+    """A high attempt count is capped, not runaway minutes."""
+    for _ in range(50):
+        assert _backoff_seconds(20) <= _CAP + 1.0
+
+
+def test_retry_after_hint_is_honored() -> None:
+    """A server-provided retry delay overrides the exponential schedule."""
+    assert _backoff_seconds(0, retry_after=5.0) == 5.0
+
+
+def test_retry_after_hint_is_capped() -> None:
+    """A pathological server hint is still bounded by the cap."""
+    assert _backoff_seconds(0, retry_after=999.0) == _CAP
+
+
+def test_parse_retry_after_from_google_style_error() -> None:
+    """Extract retryDelay seconds from a RESOURCE_EXHAUSTED error string."""
+    msg = "429 RESOURCE_EXHAUSTED ... 'retryDelay': '7s' ..."
+    assert _parse_retry_after(msg) == 7.0
+
+
+def test_parse_retry_after_absent_returns_none() -> None:
+    """No retry hint in the error yields None (fall back to exponential)."""
+    assert _parse_retry_after("429 RESOURCE_EXHAUSTED quota exceeded") is None

--- a/melanoma/tests/test_gemini_timeout.py
+++ b/melanoma/tests/test_gemini_timeout.py
@@ -1,0 +1,70 @@
+"""Tests for the Gemini request timeout and retryable-error classification.
+
+A stalled Vertex socket with no client timeout hangs a worker forever (it bit
+the 1771-trial validation run). The client must carry a bounded request timeout,
+and a timeout/deadline must be treated as a retryable transient so the existing
+backoff loop retries it instead of failing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.infrastructure.gemini_service import (
+    _REQUEST_TIMEOUT_MS,
+    GeminiLLMService,
+    _is_retryable_error,
+)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "429 RESOURCE_EXHAUSTED quota exceeded",
+        "RATE_LIMIT reached",
+        "504 DEADLINE_EXCEEDED",
+        "Timeout of 90000ms exceeded",
+        "request timed out",
+    ],
+)
+def test_retryable_errors(message: str) -> None:
+    assert _is_retryable_error(Exception(message)) is True
+
+
+def test_asyncio_timeout_is_retryable() -> None:
+    assert _is_retryable_error(asyncio.TimeoutError()) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    ["invalid JSON in response", "400 INVALID_ARGUMENT", "permission denied"],
+)
+def test_non_retryable_errors(message: str) -> None:
+    assert _is_retryable_error(Exception(message)) is False
+
+
+def test_client_built_with_request_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SDK client is constructed with a bounded http request timeout."""
+    from google import genai
+
+    captured: dict[str, Any] = {}
+
+    def _fake_client(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(genai, "Client", _fake_client)
+
+    GeminiLLMService(api_key="test-key")
+
+    http_options = captured.get("http_options")
+    assert http_options is not None, "client built without http_options"
+    assert http_options.timeout == _REQUEST_TIMEOUT_MS
+
+
+def test_request_timeout_is_bounded_and_sane() -> None:
+    """Timeout is generous over p99 (~8s) but far below 'forever'."""
+    assert 30_000 <= _REQUEST_TIMEOUT_MS <= 180_000

--- a/melanoma/tests/test_snapshot_source.py
+++ b/melanoma/tests/test_snapshot_source.py
@@ -91,3 +91,64 @@ def test_load_trial_missing_nct_raises() -> None:
     src = SnapshotTrialSource(_snapshot([_TRIAL_A]))
     with pytest.raises(KeyError):
         src.load_trial("NCT99999999")
+
+
+_TRIAL_WITH_INTERVENTIONS = {
+    "nct_id": "NCT00000010",
+    "cancer_type": ["Cutaneous Melanoma"],
+    "official_title": "Study of Nivolumab",
+    "brief_title": "Nivo Trial",
+    "brief_summary": "Testing nivolumab.",
+    "eligibility_criteria": "Inclusion: stage IV.",
+    "interventions": [
+        {
+            "type": "BIOLOGICAL",
+            "name": "Nivolumab",
+            "description": "Anti-PD-1 antibody given IV.",
+        },
+        # Comparator drug — kept, so the extractor can tell it from the treatment.
+        {"type": "DRUG", "name": "Dacarbazine", "description": ""},
+        # Non-treatment entries — must be filtered out.
+        {"type": "DRUG", "name": "Placebo", "description": "Matching placebo."},
+        {"type": "DIAGNOSTIC_TEST", "name": "CT scan", "description": "Imaging."},
+        {"type": "PROCEDURE", "name": "Sham surgery", "description": ""},
+        {"type": "OTHER", "name": "Best Supportive Care", "description": ""},
+        # No name — skipped.
+        {"type": "DRUG", "name": "", "description": "orphan"},
+    ],
+}
+
+
+def test_load_trial_renders_interventions_section() -> None:
+    src = SnapshotTrialSource(_snapshot([_TRIAL_WITH_INTERVENTIONS]))
+    trial = src.load_trial("NCT00000010")
+    assert (
+        "interventions:\n"
+        "- BIOLOGICAL - Nivolumab - Anti-PD-1 antibody given IV.\n"
+        "- DRUG - Dacarbazine\n\n"
+    ) in trial.full_text
+    # Section sits between briefSummary and eligibilityCriteria.
+    assert trial.full_text.index("interventions:") < trial.full_text.index(
+        "eligibilityCriteria:"
+    )
+
+
+def test_load_trial_interventions_filters_non_treatments() -> None:
+    src = SnapshotTrialSource(_snapshot([_TRIAL_WITH_INTERVENTIONS]))
+    full_text = src.load_trial("NCT00000010").full_text
+    for dropped in ("Placebo", "CT scan", "Sham surgery", "Best Supportive Care"):
+        assert dropped not in full_text
+    assert "orphan" not in full_text
+
+
+def test_load_trial_no_interventions_omits_section() -> None:
+    src = SnapshotTrialSource(_snapshot([_TRIAL_A]))
+    assert "interventions:" not in src.load_trial("NCT00000001").full_text
+
+
+def test_load_trial_all_interventions_filtered_omits_section() -> None:
+    trial = dict(_TRIAL_A)
+    trial["nct_id"] = "NCT00000011"
+    trial["interventions"] = [{"type": "DRUG", "name": "Placebo", "description": ""}]
+    src = SnapshotTrialSource(_snapshot([trial]))
+    assert "interventions:" not in src.load_trial("NCT00000011").full_text

--- a/melanoma/tests/test_trial_deterministic_validator.py
+++ b/melanoma/tests/test_trial_deterministic_validator.py
@@ -1,0 +1,338 @@
+"""Unit tests for the deterministic trial-parameter validator.
+
+Pure functions over an in-memory record dict; no LLM, no network, no files.
+"""
+from __future__ import annotations
+
+from src.infrastructure.trial_deterministic_validator import (
+    DROP,
+    FLAG,
+    DeterministicViolation,
+    check_trial,
+    is_droppable,
+)
+
+_SOURCE_CANCER_TYPES = ["Cutaneous Melanoma", "Uveal Melanoma"]
+
+
+def _valid_trial() -> dict:
+    """A fully-valid, clean record."""
+    return {
+        "nct_number": "NCT00000001",
+        "cancer_type": ["Cutaneous Melanoma"],
+        "treatment_name": "Pembrolizumab",
+        "modality": ["Monoclonal Antibody"],
+        "biomarker": ["BRAF (V600)"],
+        "stage": ["Stage IV"],
+        "line_of_therapy": ["1L"],
+        "previous_treatment_criteria": ["IO Naive"],
+        "extraction_status": "done",
+        "error_message": None,
+    }
+
+
+def _rules(violations: list[DeterministicViolation]) -> set[str]:
+    return {v.rule for v in violations}
+
+
+def _by_field(
+    violations: list[DeterministicViolation], field: str
+) -> list[DeterministicViolation]:
+    return [v for v in violations if v.field == field]
+
+
+# ---- Clean record ------------------------------------------------------
+
+
+def test_fully_valid_record_has_no_violations() -> None:
+    assert check_trial(_valid_trial(), _SOURCE_CANCER_TYPES) == []
+
+
+def test_valid_record_is_not_droppable() -> None:
+    assert is_droppable(check_trial(_valid_trial(), _SOURCE_CANCER_TYPES)) is False
+
+
+# ---- nct_format (DROP) -------------------------------------------------
+
+
+def test_bad_nct_format_is_drop() -> None:
+    trial = _valid_trial()
+    trial["nct_number"] = "NCT123"
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    nct = _by_field(violations, "nct_number")
+    assert len(nct) == 1
+    assert nct[0].rule == "nct_format"
+    assert nct[0].severity == DROP
+    assert is_droppable(violations) is True
+
+
+def test_none_nct_is_drop() -> None:
+    trial = _valid_trial()
+    trial["nct_number"] = None
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert any(v.rule == "nct_format" and v.severity == DROP for v in violations)
+
+
+def test_nct_with_too_many_digits_is_drop() -> None:
+    trial = _valid_trial()
+    trial["nct_number"] = "NCT000000012"
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert any(v.rule == "nct_format" for v in violations)
+
+
+# ---- required_treatment_name (DROP) ------------------------------------
+
+
+def test_none_treatment_name_on_done_is_drop() -> None:
+    trial = _valid_trial()
+    trial["treatment_name"] = None
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    tn = _by_field(violations, "treatment_name")
+    assert len(tn) == 1
+    assert tn[0].rule == "required_treatment_name"
+    assert tn[0].severity == DROP
+    assert is_droppable(violations) is True
+
+
+def test_empty_treatment_name_on_done_is_drop() -> None:
+    trial = _valid_trial()
+    trial["treatment_name"] = "   "
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert any(
+        v.rule == "required_treatment_name" and v.severity == DROP for v in violations
+    )
+
+
+def test_empty_treatment_name_on_partial_is_not_drop() -> None:
+    trial = _valid_trial()
+    trial["treatment_name"] = None
+    trial["extraction_status"] = "partial"
+    trial["error_message"] = "could not determine treatment"
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert not any(v.rule == "required_treatment_name" for v in violations)
+    assert is_droppable(violations) is False
+
+
+# ---- vocab_membership (FLAG) -------------------------------------------
+
+
+def test_out_of_vocab_modality_is_flag_naming_value() -> None:
+    trial = _valid_trial()
+    trial["modality"] = ["Monoclonal Antibody", "Laser Beam"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    mod = _by_field(violations, "modality")
+    assert len(mod) == 1
+    assert mod[0].rule == "vocab_membership"
+    assert mod[0].severity == FLAG
+    assert "Laser Beam" in mod[0].detail
+
+
+def test_out_of_vocab_biomarker_is_flag() -> None:
+    trial = _valid_trial()
+    trial["biomarker"] = ["ALK"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    bio = _by_field(violations, "biomarker")
+    assert len(bio) == 1
+    assert bio[0].rule == "vocab_membership"
+    assert "ALK" in bio[0].detail
+
+
+def test_out_of_vocab_stage_is_flag() -> None:
+    trial = _valid_trial()
+    trial["stage"] = ["Stage V"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    stg = _by_field(violations, "stage")
+    assert len(stg) == 1
+    assert stg[0].rule == "vocab_membership"
+    assert "Stage V" in stg[0].detail
+
+
+def test_out_of_vocab_line_of_therapy_is_flag() -> None:
+    trial = _valid_trial()
+    trial["line_of_therapy"] = ["4L"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    lot = _by_field(violations, "line_of_therapy")
+    assert len(lot) == 1
+    assert lot[0].rule == "vocab_membership"
+    assert "4L" in lot[0].detail
+
+
+def test_out_of_vocab_previous_treatment_is_flag() -> None:
+    trial = _valid_trial()
+    trial["previous_treatment_criteria"] = ["Prior Chemo"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    prev = _by_field(violations, "previous_treatment_criteria")
+    assert len(prev) == 1
+    assert prev[0].rule == "vocab_membership"
+    assert "Prior Chemo" in prev[0].detail
+
+
+def test_vocab_flags_never_droppable() -> None:
+    trial = _valid_trial()
+    trial["modality"] = ["Nonsense"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert is_droppable(violations) is False
+
+
+# ---- cancer_type_subset (FLAG) -----------------------------------------
+
+
+def test_cancer_type_not_subset_is_flag() -> None:
+    trial = _valid_trial()
+    trial["cancer_type"] = ["Cutaneous Melanoma", "Basal Cell Carcinoma"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    ct = _by_field(violations, "cancer_type")
+    assert len(ct) == 1
+    assert ct[0].rule == "cancer_type_subset"
+    assert ct[0].severity == FLAG
+    assert "Basal Cell Carcinoma" in ct[0].detail
+
+
+def test_cancer_type_match_is_case_sensitive() -> None:
+    trial = _valid_trial()
+    trial["cancer_type"] = ["cutaneous melanoma"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert any(v.rule == "cancer_type_subset" for v in violations)
+
+
+def test_cancer_type_non_list_skips_subset_and_flags_shape() -> None:
+    trial = _valid_trial()
+    trial["cancer_type"] = "Cutaneous Melanoma"
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    # Subset rule cannot run on a non-list; list_shape catches it instead.
+    assert not any(v.rule == "cancer_type_subset" for v in violations)
+    assert any(v.rule == "list_shape" and v.field == "cancer_type" for v in violations)
+
+
+def test_cancer_type_rule_skipped_when_source_empty() -> None:
+    trial = _valid_trial()
+    trial["cancer_type"] = ["Anything At All"]
+    violations = check_trial(trial, [])
+    assert not any(v.rule == "cancer_type_subset" for v in violations)
+
+
+# ---- list_shape (FLAG) -------------------------------------------------
+
+
+def test_duplicate_values_is_list_shape_flag() -> None:
+    trial = _valid_trial()
+    trial["modality"] = ["Monoclonal Antibody", "Monoclonal Antibody"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    shape = [v for v in _by_field(violations, "modality") if v.rule == "list_shape"]
+    assert len(shape) == 1
+    assert shape[0].severity == FLAG
+    assert "duplicate" in shape[0].detail.lower()
+
+
+def test_none_element_is_list_shape_flag() -> None:
+    trial = _valid_trial()
+    trial["biomarker"] = [None]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    shape = [v for v in _by_field(violations, "biomarker") if v.rule == "list_shape"]
+    assert len(shape) == 1
+    assert shape[0].severity == FLAG
+    # A None element must not also be reported as a vocab violation.
+    assert not any(
+        v.rule == "vocab_membership" for v in _by_field(violations, "biomarker")
+    )
+
+
+def test_non_list_value_is_list_shape_flag() -> None:
+    trial = _valid_trial()
+    trial["stage"] = "Stage IV"
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    shape = [v for v in _by_field(violations, "stage") if v.rule == "list_shape"]
+    assert len(shape) == 1
+    assert shape[0].severity == FLAG
+    # A non-list must not crash the vocab check nor be reported by it.
+    assert not any(v.rule == "vocab_membership" for v in _by_field(violations, "stage"))
+
+
+def test_none_value_is_list_shape_flag_not_crash() -> None:
+    trial = _valid_trial()
+    trial["line_of_therapy"] = None
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert any(
+        v.rule == "list_shape" and v.field == "line_of_therapy" for v in violations
+    )
+
+
+def test_list_shape_flags_never_droppable() -> None:
+    trial = _valid_trial()
+    trial["modality"] = ["Monoclonal Antibody", "Monoclonal Antibody"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert is_droppable(violations) is False
+
+
+# ---- status_consistency (FLAG) -----------------------------------------
+
+
+def test_partial_without_error_message_is_flag() -> None:
+    trial = _valid_trial()
+    trial["extraction_status"] = "partial"
+    trial["error_message"] = None
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    status = _by_field(violations, "extraction_status")
+    assert len(status) == 1
+    assert status[0].rule == "status_consistency"
+    assert status[0].severity == FLAG
+
+
+def test_failed_with_empty_error_message_is_flag() -> None:
+    trial = _valid_trial()
+    trial["extraction_status"] = "failed"
+    trial["treatment_name"] = None
+    trial["error_message"] = "   "
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert any(v.rule == "status_consistency" for v in violations)
+
+
+def test_done_with_error_message_is_flag() -> None:
+    trial = _valid_trial()
+    trial["error_message"] = "something odd happened"
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    status = _by_field(violations, "extraction_status")
+    assert len(status) == 1
+    assert status[0].rule == "status_consistency"
+    assert status[0].severity == FLAG
+
+
+def test_partial_with_error_message_is_clean() -> None:
+    trial = _valid_trial()
+    trial["extraction_status"] = "partial"
+    trial["error_message"] = "only some fields extracted"
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert not any(v.rule == "status_consistency" for v in violations)
+
+
+def test_status_flag_is_not_droppable() -> None:
+    trial = _valid_trial()
+    trial["extraction_status"] = "partial"
+    trial["error_message"] = None
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert is_droppable(violations) is False
+
+
+# ---- is_droppable ------------------------------------------------------
+
+
+def test_is_droppable_true_only_when_drop_present() -> None:
+    drop_only = [DeterministicViolation("nct_number", "nct_format", DROP, "bad")]
+    flag_only = [DeterministicViolation("modality", "vocab_membership", FLAG, "bad")]
+    mixed = drop_only + flag_only
+    assert is_droppable(drop_only) is True
+    assert is_droppable(flag_only) is False
+    assert is_droppable(mixed) is True
+    assert is_droppable([]) is False
+
+
+def test_multiple_violations_accumulate() -> None:
+    trial = _valid_trial()
+    trial["nct_number"] = "bad"
+    trial["modality"] = ["Nope"]
+    trial["cancer_type"] = ["Basal Cell Carcinoma"]
+    violations = check_trial(trial, _SOURCE_CANCER_TYPES)
+    assert {"nct_format", "vocab_membership", "cancer_type_subset"} <= _rules(
+        violations
+    )
+    assert is_droppable(violations) is True

--- a/melanoma/tests/test_trials_validation_prompt.py
+++ b/melanoma/tests/test_trials_validation_prompt.py
@@ -1,0 +1,75 @@
+"""Unit tests for the LLM-as-a-Judge validation prompt content.
+
+cancer_type is a TRUSTED tag from the CT.gov condition query - not an LLM
+extraction - so the judge must not grade it. It is provided only as the scoping
+anchor: it identifies the skin-cancer cohort so every other field is graded
+against that cohort's eligibility and other tumour types are discarded.
+"""
+
+from __future__ import annotations
+
+from src.domain.trials_extraction_prompts import CANCER_TYPE_VALUES
+from src.domain.trials_validation_prompts import _ENUM_VOCAB, build_validation_prompt
+
+_SOURCE = (
+    "officialTitle:\nStudy of Nivolumab in advanced melanoma\n\n"
+    "eligibilityCriteria:\nStage IV cutaneous melanoma; brain metastases allowed."
+)
+_CANDIDATE = '{\n  "cancer_type": ["Cutaneous Melanoma"]\n}'
+
+
+def test_cancer_type_values_match_live_tags() -> None:
+    """The SSOT vocabulary is exactly the 8 tags emitted by discovery/Supabase."""
+    assert set(CANCER_TYPE_VALUES) == {
+        "Cutaneous Melanoma",
+        "Cutaneous Squamous Cell Carcinoma",
+        "Cutaneous Melanoma with Brain/CNS Metastasis",
+        "Uveal Melanoma",
+        "Acral Melanoma",
+        "Mucosal Melanoma",
+        "Basal Cell Carcinoma",
+        "Merkel Cell Carcinoma",
+    }
+
+
+def test_cancer_type_not_in_graded_vocabulary() -> None:
+    """cancer_type is not a graded enum - the judge never PASS/FAILs it."""
+    assert "cancer_type" not in _ENUM_VOCAB
+
+
+def test_cancer_type_marked_trusted_not_audited() -> None:
+    """The prompt tells the judge cancer_type is a trusted, given tag, not audited."""
+    prompt = build_validation_prompt(_SOURCE, _CANDIDATE).lower()
+    assert "cancer_type" in prompt
+    assert "trusted" in prompt or "not audit" in prompt or "do not grade" in prompt
+    # sourced from the CT.gov query, not the eligibility text
+    assert "ct.gov" in prompt or "condition query" in prompt or "discovery" in prompt
+
+
+def test_cancer_type_indications_listed_as_context() -> None:
+    """The 8 skin-cancer indications appear as context to identify the cohort."""
+    prompt = build_validation_prompt(_SOURCE, _CANDIDATE)
+    for value in CANCER_TYPE_VALUES:
+        assert value in prompt, f"missing cancer_type value: {value}"
+
+
+def test_brain_cns_interpretation_rule() -> None:
+    """Combined Brain/CNS tag is understood as brain OR CNS metastases."""
+    prompt = build_validation_prompt(_SOURCE, _CANDIDATE).lower()
+    assert "brain" in prompt and "cns" in prompt
+    assert " or " in prompt  # brain OR CNS
+
+
+def test_rare_melanoma_grouping_rule() -> None:
+    """Rare Melanoma is defined as Acral / Uveal / Mucosal."""
+    prompt = build_validation_prompt(_SOURCE, _CANDIDATE)
+    assert "Rare Melanoma" in prompt
+    lowered = prompt.lower()
+    assert "acral" in lowered and "uveal" in lowered and "mucosal" in lowered
+
+
+def test_basket_trial_scoping_rule() -> None:
+    """The judge grades every other field only against the skin-cancer cohort."""
+    prompt = build_validation_prompt(_SOURCE, _CANDIDATE).lower()
+    assert "basket" in prompt or "multiple tumour" in prompt or "pan-tumour" in prompt
+    assert "discard" in prompt or "ignore" in prompt or "only" in prompt

--- a/melanoma/tests/test_trials_validation_routing.py
+++ b/melanoma/tests/test_trials_validation_routing.py
@@ -1,0 +1,187 @@
+"""Unit tests for the pure validation routing logic (no LLM).
+
+Covers the quote guard, correction parsing, and the decision matrix in both
+advisory (detect-only) and mature (apply_fixes) modes.
+"""
+
+from __future__ import annotations
+
+from src.app.trials_validation_service import (
+    parse_corrected_value,
+    quote_grounded,
+    route_trial,
+)
+from src.domain.trial_validation_models import (
+    FieldEvaluation,
+    TrialValidationVerdict,
+    ValidationDecision,
+    ValidationFieldStatus,
+)
+
+_SOURCE = (
+    "officialTitle:\nStudy of Nivolumab in unresectable metastatic melanoma\n\n"
+    "eligibilityCriteria:\nStage IV disease; BRAF V600E-positive required."
+)
+
+
+def _ev(name: str, status: str, **kw: object) -> FieldEvaluation:
+    return FieldEvaluation(field_name=name, status=status, **kw)  # type: ignore[arg-type]
+
+
+def _verdict(
+    evals: list[FieldEvaluation], score: float = 0.9
+) -> TrialValidationVerdict:
+    is_valid = all(e.status != ValidationFieldStatus.FAIL for e in evals)
+    return TrialValidationVerdict(
+        is_valid=is_valid, validation_score=score, field_evaluations=evals
+    )
+
+
+# --- quote_grounded ---------------------------------------------------------
+
+
+def test_quote_grounded_substring() -> None:
+    assert quote_grounded("unresectable metastatic melanoma", _SOURCE)
+
+
+def test_quote_grounded_whitespace_normalised() -> None:
+    assert quote_grounded("Study of  Nivolumab", _SOURCE)
+
+
+def test_quote_grounded_missing_or_absent() -> None:
+    assert not quote_grounded(None, _SOURCE)
+    assert not quote_grounded("", _SOURCE)
+    assert not quote_grounded("pembrolizumab combination", _SOURCE)
+
+
+# --- parse_corrected_value --------------------------------------------------
+
+
+def test_parse_corrected_value_enum_filters_vocab() -> None:
+    assert parse_corrected_value("stage", "Stage III; Bogus") == ["Stage III"]
+
+
+def test_parse_corrected_value_treatment_name_is_string() -> None:
+    assert parse_corrected_value("treatment_name", "  Nivolumab ") == "Nivolumab"
+
+
+# --- route_trial: detect-only (advisory) ------------------------------------
+
+
+def _pass_ev() -> FieldEvaluation:
+    return _ev(
+        "stage",
+        "PASS",
+        extracted_value="Stage IV",
+        source_evidence_quote="unresectable metastatic melanoma",
+    )
+
+
+def test_detect_only_all_pass_kept() -> None:
+    outcome = route_trial(
+        _verdict([_pass_ev()]), _SOURCE, apply_fixes=False, score_threshold=0.75
+    )
+    assert outcome.decision == ValidationDecision.KEPT
+
+
+def test_detect_only_fail_goes_hitl_not_dropped() -> None:
+    fail = _ev("modality", "FAIL", extracted_value="Vaccine", issue_description="wrong")
+    outcome = route_trial(
+        _verdict([fail]), _SOURCE, apply_fixes=False, score_threshold=0.75
+    )
+    assert outcome.decision == ValidationDecision.HITL
+
+
+def test_detect_only_empty_field_pass_needs_no_quote() -> None:
+    # A legitimately-empty field PASSes without a quote and must not be downgraded.
+    empty = _ev("biomarker", "PASS", extracted_value="")
+    empty_list = _ev("line_of_therapy", "PASS", extracted_value="[]")
+    outcome = route_trial(
+        _verdict([_pass_ev(), empty, empty_list]),
+        _SOURCE,
+        apply_fixes=False,
+        score_threshold=0.75,
+    )
+    assert outcome.decision == ValidationDecision.KEPT
+
+
+def test_detect_only_ungrounded_pass_treated_uncertain() -> None:
+    bad = _ev(
+        "stage",
+        "PASS",
+        extracted_value="Stage IV",
+        source_evidence_quote="not in source",
+    )
+    outcome = route_trial(
+        _verdict([bad]), _SOURCE, apply_fixes=False, score_threshold=0.75
+    )
+    assert outcome.decision == ValidationDecision.HITL
+
+
+# --- route_trial: mature (apply_fixes) --------------------------------------
+
+
+def test_apply_fixes_gated_correction_applied() -> None:
+    fail = _ev(
+        "stage",
+        "FAIL",
+        extracted_value="Stage III",
+        corrected_value="Stage IV",
+        source_evidence_quote="unresectable metastatic melanoma",
+    )
+    outcome = route_trial(
+        _verdict([fail], score=0.9), _SOURCE, apply_fixes=True, score_threshold=0.75
+    )
+    assert outcome.decision == ValidationDecision.FIXED
+    assert outcome.applied_corrections[0]["field"] == "stage"
+    assert outcome.applied_corrections[0]["corrected"] == ["Stage IV"]
+
+
+def test_apply_fixes_out_of_vocab_correction_dropped() -> None:
+    fail = _ev(
+        "stage",
+        "FAIL",
+        extracted_value="Stage III",
+        corrected_value="Stage 99",
+        source_evidence_quote="unresectable metastatic melanoma",
+    )
+    outcome = route_trial(
+        _verdict([fail], score=0.9), _SOURCE, apply_fixes=True, score_threshold=0.75
+    )
+    assert outcome.decision == ValidationDecision.DROPPED
+
+
+def test_apply_fixes_ungrounded_quote_dropped() -> None:
+    fail = _ev(
+        "stage",
+        "FAIL",
+        extracted_value="Stage III",
+        corrected_value="Stage IV",
+        source_evidence_quote="fabricated phrase not present",
+    )
+    outcome = route_trial(
+        _verdict([fail], score=0.9), _SOURCE, apply_fixes=True, score_threshold=0.75
+    )
+    assert outcome.decision == ValidationDecision.DROPPED
+
+
+def test_apply_fixes_below_threshold_dropped() -> None:
+    fail = _ev(
+        "stage",
+        "FAIL",
+        extracted_value="Stage III",
+        corrected_value="Stage IV",
+        source_evidence_quote="unresectable metastatic melanoma",
+    )
+    outcome = route_trial(
+        _verdict([fail], score=0.5), _SOURCE, apply_fixes=True, score_threshold=0.75
+    )
+    assert outcome.decision == ValidationDecision.DROPPED
+
+
+def test_apply_fixes_uncertain_goes_hitl() -> None:
+    unc = _ev("biomarker", "UNCERTAIN", extracted_value="PD-L1")
+    outcome = route_trial(
+        _verdict([unc]), _SOURCE, apply_fixes=True, score_threshold=0.75
+    )
+    assert outcome.decision == ValidationDecision.HITL

--- a/melanoma/tests/test_validation_result_writer.py
+++ b/melanoma/tests/test_validation_result_writer.py
@@ -1,0 +1,32 @@
+"""Tests for ValidationResultWriter persistence, including cost reporting."""
+
+import json
+from pathlib import Path
+
+from src.app.trials_validation_service import ValidationResultWriter
+from src.infrastructure.cost_calculator import CostCalculator
+
+
+def test_write_cost_report_persists_summary(tmp_path: Path) -> None:
+    """write_cost_report writes cost_report.json with the calculator's totals.
+
+    Mirrors the extraction pipeline so a validation run leaves a standalone
+    cost artifact (and a mid-run kill preserves spend recorded so far).
+    """
+    writer = ValidationResultWriter(tmp_path)
+    calc = CostCalculator()
+    calc.record_api_call(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        model="gemini-3.1-pro-preview",
+        operation="trial_validation",
+        attribute_type="trial_validation",
+    )
+
+    path = writer.write_cost_report(calc)
+
+    assert path == tmp_path / "cost_report.json"
+    report = json.loads(path.read_text())
+    assert report["summary"]["total_requests"] == 1
+    assert report["summary"]["total_tokens"] == 1200
+    assert report["summary"]["total_cost"] > 0


### PR DESCRIPTION
## Summary

Adds an LLM-as-a-Judge validation pipeline for extracted clinical trial parameters, plus the deterministic checks, prompts, and cohort inputs it runs on. Extraction itself also gets grounded on the trial's `interventions` field so treatment/modality values stop being invented from free text.

The judge reviews each extracted trial field-by-field and returns a decision (keep / fix / HITL / drop) with a rationale, so a human reviews the disputed subset instead of all of it.

## What's here

**Validation service** - `src/app/trials_validation_service.py` orchestrates the run: batches trials, calls the judge, merges deterministic findings, and writes `validation.json` alongside the cohort's `results.json`. Domain models in `src/domain/trial_validation_models.py`, prompts in `src/domain/trials_validation_prompts.py`.

**Deterministic validator** - `src/infrastructure/trial_deterministic_validator.py` catches what an LLM shouldn't be asked to catch: type/range violations, impossible enrollment and date combinations, and values contradicting the source record. Cheap, reproducible, and it runs before the judge so obvious breakage never costs a token. 100% line coverage.

**Judge scoping + cost reporting** - the judge is scoped by cancer type rather than run globally, and each run emits a cost report so the spend per cohort is visible rather than inferred.

**Gemini reliability** - two fixes found by running this at cohort scale: the 429 backoff floor dropped from 60s to ~1s (a 60s floor on a sequential run over ~1.7k trials dominated wall-clock time for no benefit), and requests now carry a 90s timeout with retry, since a hung request previously stalled a run indefinitely.

**Cohort inputs** - `scripts/download_clinical_trials_snapshot.py` gains `--exclude-interventions` and `--all-study-types`, which is what the industry cohort needs to be built correctly.

**Extraction grounding** - `trials_extraction_prompts.py` now anchors treatment and modality on the structured `interventions` field instead of prose.

## Testing

`make quality` clean on this branch:

| Check | Result |
|---|---|
| `ruff check src/ tests/` | clean |
| `black --check src/ tests/` | 151 files unchanged |
| `mypy src/` | no issues in 108 source files |
| `pytest` | 458 passed, 13 skipped |

8 new test files covering the deterministic validator (338 lines), judge routing, prompt construction, result writing, the Gemini backoff and timeout paths, the snapshot source, and industry-results building.

## Notes for review

- **Runs are sequential.** A full cohort (~1.7k trials) takes hours. Moving to bounded async concurrency is the obvious next step but is deliberately not in this PR - it changes the failure and rate-limit behaviour and deserves its own change.
- **`--apply-fixes` is off by default.** The judge proposes fixes; nothing is written back to extracted data without an explicit opt-in. Calibration and any regeneration stay human-gated.
- `cancer_type` is treated as a trusted anchor rather than something the judge may overturn.
