### PR TITLE
feat(melanoma): LLM-as-a-Judge validation for extracted efficacy and safety results

### DIFF
--- a/melanoma/run_results_validation.py
+++ b/melanoma/run_results_validation.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""CLI runner for the abstract / publication results validation pipeline.
+
+Validates an extraction run's ``extraction_results_*.json`` against the source
+markdown each document was extracted from, and writes validation.json plus the
+routed cohort files (results.cleaned.json, validation_hitl.json,
+missed_values.json, dropped-arms.json).
+
+Backend is Vertex AI / Gemini via ADC, same as run_trials_validation.py.
+
+Usage
+-----
+# Dry run - resolve every document to a source file, spend nothing
+poetry run python3 run_results_validation.py \
+    --results data/output/Publications_May_2026/extraction_results_Publications_final_70.json \
+    --dry-run
+
+# Advisory (detect-only) sample run
+poetry run python3 run_results_validation.py --results <results.json> --sample 3
+
+# Gold-set spot check
+poetry run python3 run_results_validation.py --results <results.json> \
+    --doc-id Batch-II_1 --doc-id Batch-I_22
+
+# Abstracts (12 conference-year files in one run)
+poetry run python3 run_results_validation.py --source-type abstract \
+    --results data/output/Abstracts_April_2026/extraction_results_ASCO_2023.json \
+    --results data/output/Abstracts_April_2026/extraction_results_ESMO_2023.json
+
+# Enable gated auto-fix (only after gold-set calibration)
+poetry run python3 run_results_validation.py --results <results.json> \
+    --apply-fixes --score-threshold 0.8
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_MELANOMA_ROOT = Path(__file__).resolve().parent
+load_dotenv(_MELANOMA_ROOT / ".env")
+
+from src.app.results_validation_service import (  # noqa: E402
+    ResultsValidationConfig,
+    ResultsValidationService,
+)
+from src.domain.models import DocumentType  # noqa: E402
+from src.infrastructure.cost_calculator import CostCalculator  # noqa: E402
+from src.infrastructure.document_source_loader import (  # noqa: E402
+    AbstractSourceLoader,
+    DocumentSourceLoader,
+    PublicationSourceLoader,
+)
+from src.infrastructure.gemini_service import GeminiLLMService  # noqa: E402
+
+_DEFAULT_MODEL = "gemini-3.1-pro-preview"
+_DEFAULT_SOURCE_ROOT = _MELANOMA_ROOT / "data" / "postprocessed"
+_PUBLICATIONS_SUBDIR = "Publications"
+_ABSTRACT_SUBDIRS = {"ASCO": "ASCO_Abstracts", "ESMO": "ESMO_Abstracts"}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="run_results_validation",
+        description="Validate extracted abstract / publication results with an "
+        "LLM judge.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        action="append",
+        dest="results_paths",
+        required=True,
+        metavar="PATH",
+        help="Extraction results JSON to validate. Repeatable - abstracts are "
+        "split across one file per conference-year.",
+    )
+    parser.add_argument(
+        "--source-type",
+        choices=[DocumentType.PUBLICATION.value, DocumentType.ABSTRACT.value],
+        default=DocumentType.PUBLICATION.value,
+        help="Which extraction pipeline produced the results (default: publication).",
+    )
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        default=_DEFAULT_SOURCE_ROOT,
+        metavar="DIR",
+        help=f"Postprocessed markdown root (default: {_DEFAULT_SOURCE_ROOT}).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Output directory (default: <results dir>/validation).",
+    )
+    parser.add_argument("--model", default=_DEFAULT_MODEL, metavar="MODEL_ID")
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Max documents judged in parallel. Each document issues 3 group "
+        "calls at once, so in-flight requests are 3x this (default: 3).",
+    )
+    parser.add_argument(
+        "--apply-fixes",
+        action="store_true",
+        help="Enable gated auto-fix (default: off / advisory).",
+    )
+    parser.add_argument(
+        "--score-threshold",
+        type=float,
+        default=0.75,
+        metavar="F",
+        help="Minimum validation_score for a correction to be auto-applied.",
+    )
+    parser.add_argument(
+        "--sample",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Validate only the first N documents (after sorting/allowlist).",
+    )
+    parser.add_argument(
+        "--doc-id",
+        metavar="DOC_ID",
+        action="append",
+        dest="doc_ids",
+        help="Validate only the given document id(s). Repeatable.",
+    )
+    parser.add_argument(
+        "--no-resume",
+        dest="resume",
+        action="store_false",
+        help="Re-validate all documents, ignoring the checkpoint.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and report what would run; no LLM calls.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser
+
+
+def _configure_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    for noisy in ("httpx", "httpcore", "google_genai"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+
+def _validate_env() -> tuple[str, str]:
+    project = os.getenv("GOOGLE_CLOUD_PROJECT")
+    location = os.getenv("GOOGLE_CLOUD_LOCATION")
+    missing = [
+        name
+        for name, value in (
+            ("GOOGLE_CLOUD_PROJECT", project),
+            ("GOOGLE_CLOUD_LOCATION", location),
+        )
+        if not value
+    ]
+    if missing:
+        print(
+            f"ERROR: {', '.join(missing)} is not set. Add it to melanoma/.env.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    assert project and location
+    return project, location
+
+
+def _build_source_loader(source_type: str, source_dir: Path) -> DocumentSourceLoader:
+    if source_type == DocumentType.PUBLICATION.value:
+        return PublicationSourceLoader(source_dir / _PUBLICATIONS_SUBDIR)
+    return AbstractSourceLoader(
+        {
+            conference: source_dir / subdir
+            for conference, subdir in _ABSTRACT_SUBDIRS.items()
+        }
+    )
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    _configure_logging(args.verbose)
+    logger = logging.getLogger(__name__)
+
+    for path in args.results_paths:
+        if not path.exists():
+            print(f"ERROR: not found: {path}", file=sys.stderr)
+            sys.exit(1)
+    if not args.source_dir.exists():
+        print(f"ERROR: source directory not found: {args.source_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    output_dir = args.output_dir or args.results_paths[0].parent / "validation"
+    config = ResultsValidationConfig(
+        results_paths=args.results_paths,
+        doc_type=args.source_type,
+        output_dir=output_dir,
+        model=args.model,
+        concurrency=args.concurrency,
+        apply_fixes=args.apply_fixes,
+        score_threshold=args.score_threshold,
+        sample=args.sample,
+        resume=args.resume,
+        dry_run=args.dry_run,
+        doc_allowlist=args.doc_ids,
+    )
+    source_loader = _build_source_loader(args.source_type, args.source_dir)
+
+    logger.info("=" * 60)
+    logger.info("Results Validation Pipeline")
+    logger.info("Source type : %s", config.doc_type)
+    logger.info("Model       : %s", config.model)
+    logger.info("Apply fixes : %s", config.apply_fixes)
+    logger.info("Output dir  : %s", config.output_dir)
+    logger.info("=" * 60)
+
+    cost_calculator = CostCalculator()
+    if config.dry_run:
+        # No credentials needed to resolve sources and count the work.
+        service = ResultsValidationService.from_config(
+            config, _NullLLM(), source_loader, cost_calculator
+        )
+        asyncio.run(service.run())
+        return
+
+    project, location = _validate_env()
+    llm = GeminiLLMService(
+        model=config.model,
+        cost_calculator=cost_calculator,
+        project=project,
+        location=location,
+    )
+    service = ResultsValidationService.from_config(
+        config, llm, source_loader, cost_calculator
+    )
+
+    try:
+        results = asyncio.run(service.run())
+    except KeyboardInterrupt:
+        logger.warning("Interrupted - partial results saved.")
+        sys.exit(130)
+
+    counts: dict[str, int] = {}
+    for document in results:
+        for arm in document.arms:
+            counts[arm.decision.value] = counts.get(arm.decision.value, 0) + 1
+    missed = sum(len(arm.missed_values) for d in results for arm in d.arms)
+
+    print("\n" + "=" * 60)
+    print("VALIDATION COMPLETE")
+    print("=" * 60)
+    print(f"  Documents: {len(results)}")
+    for decision in ("kept", "fixed", "dropped", "hitl"):
+        print(f"  {decision.capitalize():9} arms: {counts.get(decision, 0)}")
+    print(f"  Missed values flagged: {missed}")
+    cost = cost_calculator.get_summary()
+    print(f"  Cost     : ${cost.total_cost:.4f} ({cost.total_tokens:,} tokens)")
+    print(f"  Output   : {config.output_dir}")
+    print("=" * 60)
+
+
+class _NullLLM:
+    """Stands in for the judge during --dry-run, which makes no LLM calls."""
+
+    async def generate_structured(self, *args: object, **kwargs: object) -> object:
+        raise AssertionError("dry run must not call the judge")
+
+
+if __name__ == "__main__":
+    main()

--- a/melanoma/src/app/results_validation_service.py
+++ b/melanoma/src/app/results_validation_service.py
@@ -90,6 +90,8 @@ _MIDDLE_DOT_DECIMAL = re.compile(r"(?<=\d)[·•∙⋅](?=\d)")
 # (the same normalisation `value_validator.validate_ci` performs).
 _RANGE_TO = re.compile(r"(?<=\d)\s+to\s+(?=\d)", re.IGNORECASE)
 _HAS_DIGIT = re.compile(r"\d")
+#: "24" / "24.0" / "24.00" - a whole number, however the extractor spelled it.
+_INTEGRAL_FLOAT = re.compile(r"(\d+)(?:\.0+)?")
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +116,10 @@ def value_supported_by_quote(value: str, quote: str) -> bool:
     A value carrying no digits at all ("NR", "Significant") is a token the source
     states in words ("not reached"), which containment cannot express - such a
     value is left to the quote-grounding check alone.
+
+    A whole number stored as a float ("24.0") matches a source that prints it as an
+    integer ("24%") and vice versa: abstracts store every percentage as a float, so
+    without this most abstract percentages would be downgraded.
     """
     if not value.strip() or not quote.strip():
         return False
@@ -121,8 +127,16 @@ def value_supported_by_quote(value: str, quote: str) -> bool:
     if not _HAS_DIGIT.search(needle):
         return True
     haystack = _normalise_numerals(quote)
-    pattern = rf"(?<![\d.]){re.escape(needle)}(?![\d])"
-    return re.search(pattern, haystack) is not None
+    integral = _INTEGRAL_FLOAT.fullmatch(needle)
+    if integral:
+        # A whole number matches either spelling, but must not be satisfied by a
+        # different decimal: "24.0" may match "24" or "24.00", never "24.5".
+        core = rf"{re.escape(integral.group(1))}(?:\.0+)?"
+        tail = r"(?![\d])(?!\.\d)"
+    else:
+        core = re.escape(needle)
+        tail = r"(?![\d])"
+    return re.search(rf"(?<![\d.]){core}{tail}", haystack) is not None
 
 
 def effective_status(

--- a/melanoma/src/app/results_validation_service.py
+++ b/melanoma/src/app/results_validation_service.py
@@ -169,6 +169,48 @@ def effective_status(
     return ValidationFieldStatus.PASS
 
 
+def _merge_cost_report(prior_calls: list[dict], report: dict) -> dict:
+    """Fold `prior_calls` into `report`, recomputing totals from the union.
+
+    Every summary and breakdown figure is derivable from the call list, so the
+    merged report is recomputed rather than added up field by field.
+    """
+    calls = [*prior_calls, *report.get("api_calls", [])]
+    successes = sum(1 for c in calls if c.get("success"))
+    prompt = sum(c.get("prompt_tokens", 0) for c in calls)
+    completion = sum(c.get("completion_tokens", 0) for c in calls)
+    by_operation: dict[str, float] = {}
+    by_attribute: dict[str, float] = {}
+    by_model: dict[str, float] = {}
+    for call in calls:
+        cost = call.get("cost", 0.0)
+        for bucket, key in (
+            (by_operation, call.get("operation")),
+            (by_attribute, call.get("attribute_type")),
+            (by_model, call.get("model")),
+        ):
+            if key is not None:
+                bucket[key] = bucket.get(key, 0.0) + cost
+    return {
+        "summary": {
+            "total_requests": len(calls),
+            "total_prompt_tokens": prompt,
+            "total_completion_tokens": completion,
+            "total_tokens": prompt + completion,
+            "total_cost": sum(c.get("cost", 0.0) for c in calls),
+            "successful_requests": successes,
+            "failed_requests": len(calls) - successes,
+            "success_rate": successes / max(len(calls), 1) * 100,
+        },
+        "breakdown": {
+            "by_operation": by_operation,
+            "by_attribute": by_attribute,
+            "by_model": by_model,
+        },
+        "api_calls": calls,
+    }
+
+
 @dataclass
 class RouteOutcome:
     decision: ValidationDecision
@@ -297,9 +339,14 @@ class ValidationCheckpointManager:
 class ResultsValidationWriter:
     """Writes validation.json (merge-upsert) plus the derived routing files."""
 
-    def __init__(self, output_dir: Path) -> None:
+    def __init__(self, output_dir: Path, carry_forward_cost: bool = False) -> None:
         self._output_dir = output_dir
         output_dir.mkdir(parents=True, exist_ok=True)
+        # Snapshotted once: write_cost_report runs after every document, so
+        # re-reading the file each time would compound the carried spend.
+        self._prior_cost_calls: list[dict] = (
+            self._read_cost_calls() if carry_forward_cost else []
+        )
 
     def write_validation(
         self,
@@ -364,10 +411,26 @@ class ResultsValidationWriter:
         )
 
     def write_cost_report(self, cost_calculator: CostCalculator) -> Path:
-        """Write cost_report.json incrementally, so a mid-run kill keeps the spend."""
+        """Write cost_report.json incrementally, so a mid-run kill keeps the spend.
+
+        On a resumed run the previous report's calls are folded in, so the file
+        reports what the cohort cost rather than what the last pass cost. A fresh
+        run (``--no-resume``) re-validates everything, so it starts from zero.
+        """
         path = self._output_dir / ResultsValidation.COST_REPORT_FILE
         cost_calculator.save_detailed_report(str(path))
+        if self._prior_cost_calls:
+            report = json.loads(path.read_text())
+            report = _merge_cost_report(self._prior_cost_calls, report)
+            path.write_text(json.dumps(report, indent=2))
         return path
+
+    def _read_cost_calls(self) -> list[dict]:
+        path = self._output_dir / ResultsValidation.COST_REPORT_FILE
+        if not path.exists():
+            return []
+        calls = json.loads(path.read_text()).get("api_calls", [])
+        return calls if isinstance(calls, list) else []
 
     def _write(self, filename: str, payload: dict) -> None:
         (self._output_dir / filename).write_text(
@@ -415,7 +478,9 @@ class ResultsValidationService:
             checkpoint=ValidationCheckpointManager(
                 config.output_dir / ResultsValidation.CHECKPOINT_FILE
             ),
-            writer=ResultsValidationWriter(config.output_dir),
+            writer=ResultsValidationWriter(
+                config.output_dir, carry_forward_cost=config.resume
+            ),
             cost_calculator=cost_calculator,
         )
 

--- a/melanoma/src/app/results_validation_service.py
+++ b/melanoma/src/app/results_validation_service.py
@@ -1,0 +1,769 @@
+"""LLM-as-a-Judge validation pipeline for extracted abstract / publication results.
+
+Reads an extraction run's ``extraction_results_*.json``, re-loads the source
+markdown each document was extracted from, runs a deterministic pre-pass, then
+asks a Gemini judge three questions per document - one per attribute group
+(identification, efficacy, safety) - each seeing the full source text and every
+treatment arm together. Arms are then routed keep / fix / drop / HITL.
+
+Mirrors ``trials_validation_service`` (config -> ``from_config`` factory ->
+collaborator classes -> ``run()`` loop -> checkpoint -> merge-upsert writer, with
+bounded concurrency and a lock around disk writes). Two things differ, because
+the data differs:
+
+* The unit of judgement is a **treatment arm**, not a document. A document's three
+  group verdicts are demultiplexed back onto its arms before routing.
+* Extraction normalises values as it reads them, so "the extracted value must
+  appear in its supporting quote" only holds for the derivations that preserve the
+  number. ``effective_status`` enforces it exactly there and nowhere else.
+
+Authority is staged, as in the trials pipeline:
+
+* ``apply_fixes=False`` (default) - the judge is advisory: everything it flags
+  goes to the HITL queue and nothing is edited on its say-so.
+* ``apply_fixes=True`` (after gold-set calibration) - a FAIL carrying a grounded,
+  above-threshold correction is applied. A FAIL without one still goes to HITL
+  rather than dropping the arm: one bad value among 165 is not grounds to discard
+  an arm's good data.
+
+The pure decision logic lives in module functions (``value_supported_by_quote``,
+``effective_status``, ``route_arm``) so it is unit-testable without an LLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from ..domain.constants import ResultsValidation
+from ..domain.models import DocumentType
+from ..domain.results_validation_models import (
+    ArmFieldEvaluation,
+    ArmValidationResult,
+    AttributeGroup,
+    DocValidationResult,
+    GroupVerdict,
+    MissedValue,
+    ResultsValidationRunSummary,
+    ValidationDecision,
+    ValidationFieldStatus,
+)
+from ..domain.results_validation_prompts import build_group_prompt, group_for_field
+from ..domain.structured_llm_interfaces import StructuredLLMService
+from ..infrastructure.cost_calculator import CostCalculator
+from ..infrastructure.document_source_loader import (
+    DocumentSourceLoader,
+    SourceDocumentNotFoundError,
+)
+from ..infrastructure.results_deterministic_validator import (
+    DeterministicViolation,
+    check_arm,
+    has_value,
+    is_droppable,
+    render_value,
+    violation_dict,
+)
+from .trials_validation_service import quote_grounded
+
+logger = logging.getLogger(__name__)
+
+# Where each document type's records live in an extraction results file, and
+# which key carries the document id.
+_RESULTS_LAYOUT: dict[str, tuple[str, str]] = {
+    DocumentType.ABSTRACT.value: ("abstracts", "abstract_id"),
+    DocumentType.PUBLICATION.value: ("publications", "pub_id"),
+}
+
+# Derivations that preserve the extracted number, so it must appear in the quote.
+_LITERAL_DERIVATIONS = {"VERBATIM", "UNIT_STRIPPED"}
+
+_DASHES = re.compile(r"[–—]")
+# The Lancet and JCO set decimal points as a middle dot ("11·0"). Only rewrite one
+# that sits between two digits, so markdown bullets are left alone.
+_MIDDLE_DOT_DECIMAL = re.compile(r"(?<=\d)[·•∙⋅](?=\d)")
+# Sources write interval bounds as "0.43 to 0.76"; the extractor stores "0.43-0.76"
+# (the same normalisation `value_validator.validate_ci` performs).
+_RANGE_TO = re.compile(r"(?<=\d)\s+to\s+(?=\d)", re.IGNORECASE)
+_HAS_DIGIT = re.compile(r"\d")
+
+
+# ---------------------------------------------------------------------------
+# Pure logic (no I/O) - unit-testable without an LLM
+# ---------------------------------------------------------------------------
+
+
+def _normalise_numerals(text: str) -> str:
+    """Fold typographic dash, decimal-point and range-separator variants to ASCII."""
+    folded = _MIDDLE_DOT_DECIMAL.sub(".", _DASHES.sub("-", text))
+    return _RANGE_TO.sub("-", folded)
+
+
+def value_supported_by_quote(value: str, quote: str) -> bool:
+    """Whether `value` appears as a distinct number inside `quote`.
+
+    Percent signs, dash styles, middle-dot decimals and "0.43 to 0.76" ranges are
+    normalised away: the extractor strips or rewrites all of them, so a raw
+    comparison would reject correct values. The lookarounds stop "56" from being
+    satisfied by "561" or "5.6".
+
+    A value carrying no digits at all ("NR", "Significant") is a token the source
+    states in words ("not reached"), which containment cannot express - such a
+    value is left to the quote-grounding check alone.
+    """
+    if not value.strip() or not quote.strip():
+        return False
+    needle = _normalise_numerals(value.strip().rstrip("%").strip())
+    if not _HAS_DIGIT.search(needle):
+        return True
+    haystack = _normalise_numerals(quote)
+    pattern = rf"(?<![\d.]){re.escape(needle)}(?![\d])"
+    return re.search(pattern, haystack) is not None
+
+
+def effective_status(
+    evaluation: ArmFieldEvaluation, source_text: str
+) -> ValidationFieldStatus:
+    """The status after applying the anti-hallucination guards.
+
+    A PASS the judge cannot defend is downgraded rather than trusted:
+
+    * no quote, or a quote that is not literally in the source -> UNCERTAIN.
+    * a quote-preserving derivation whose value is missing from its own quote
+      -> UNCERTAIN. Summed / computed / percent-of-count values are exempt: their
+      number legitimately does not appear in the text.
+    * a value the judge says belongs to another arm -> FAIL, whatever it claimed.
+    """
+    if not evaluation.arm_attribution_ok:
+        return ValidationFieldStatus.FAIL
+    if evaluation.status is not ValidationFieldStatus.PASS:
+        return evaluation.status
+
+    quote = evaluation.source_evidence_quote
+    if not quote_grounded(quote, source_text):
+        return ValidationFieldStatus.UNCERTAIN
+    assert quote is not None  # quote_grounded rejects None/blank
+    derivation = evaluation.derivation.value if evaluation.derivation else None
+    if derivation in _LITERAL_DERIVATIONS and not value_supported_by_quote(
+        evaluation.extracted_value, quote
+    ):
+        return ValidationFieldStatus.UNCERTAIN
+    return ValidationFieldStatus.PASS
+
+
+@dataclass
+class RouteOutcome:
+    decision: ValidationDecision
+    applied_corrections: list[dict] = field(default_factory=list)
+
+
+def _correction_is_gated(
+    evaluation: ArmFieldEvaluation,
+    source_text: str,
+    validation_score: float,
+    score_threshold: float,
+) -> bool:
+    """Whether a FAIL's proposed correction clears every safety gate."""
+    if not evaluation.corrected_value or not evaluation.corrected_value.strip():
+        return False
+    if validation_score < score_threshold:
+        return False
+    return quote_grounded(evaluation.source_evidence_quote, source_text)
+
+
+def route_arm(
+    *,
+    evaluations: list[ArmFieldEvaluation],
+    missed_values: list[MissedValue],
+    violations: list[DeterministicViolation],
+    source_text: str,
+    validation_score: float,
+    apply_fixes: bool,
+    score_threshold: float,
+) -> RouteOutcome:
+    """Decide one arm's fate from its deterministic and judge findings (pure)."""
+    if is_droppable(violations):
+        return RouteOutcome(ValidationDecision.DROPPED)
+
+    fails: list[ArmFieldEvaluation] = []
+    uncertain = False
+    for evaluation in evaluations:
+        status = effective_status(evaluation, source_text)
+        if status is ValidationFieldStatus.FAIL:
+            fails.append(evaluation)
+        elif status is ValidationFieldStatus.UNCERTAIN:
+            uncertain = True
+
+    flagged = bool(fails) or uncertain or bool(missed_values) or bool(violations)
+    if not flagged:
+        return RouteOutcome(ValidationDecision.KEPT)
+
+    if not apply_fixes:
+        # Advisory mode: never act on the judge, queue everything it flagged.
+        return RouteOutcome(ValidationDecision.HITL)
+
+    # Mature mode. Anything a correction cannot express needs a human: an
+    # ambiguous source, a value the extractor omitted, a deterministic warning.
+    if uncertain or missed_values or violations:
+        return RouteOutcome(ValidationDecision.HITL)
+
+    corrections: list[dict] = []
+    for evaluation in fails:
+        if not _correction_is_gated(
+            evaluation, source_text, validation_score, score_threshold
+        ):
+            return RouteOutcome(ValidationDecision.HITL)
+        corrections.append(
+            {
+                "field": evaluation.field_name,
+                "corrected": (evaluation.corrected_value or "").strip(),
+                "evidence_quote": evaluation.source_evidence_quote,
+                "score": validation_score,
+            }
+        )
+    return RouteOutcome(ValidationDecision.FIXED, corrections)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResultsValidationConfig:
+    """Runtime configuration for a results-validation run."""
+
+    results_paths: list[Path]
+    doc_type: str
+    output_dir: Path
+    model: str
+    concurrency: int = 5
+    apply_fixes: bool = False
+    score_threshold: float = 0.75
+    sample: int | None = None
+    resume: bool = True
+    dry_run: bool = False
+    doc_allowlist: list[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint (resume across runs)
+# ---------------------------------------------------------------------------
+
+
+class ValidationCheckpointManager:
+    """Persists which documents have been validated so a run can resume."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._done: dict[str, dict] = {}
+        if path.exists():
+            self._done = json.loads(path.read_text())
+
+    def is_done(self, doc_id: str) -> bool:
+        return doc_id in self._done
+
+    def record(self, doc_id: str, decision: str) -> None:
+        self._done[doc_id] = {
+            "decision": decision,
+            "recorded_at": datetime.utcnow().isoformat(),
+        }
+        self._path.write_text(json.dumps(self._done, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Result writer
+# ---------------------------------------------------------------------------
+
+
+class ResultsValidationWriter:
+    """Writes validation.json (merge-upsert) plus the derived routing files."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self._output_dir = output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    def write_validation(
+        self,
+        results: list[DocValidationResult],
+        summary: ResultsValidationRunSummary,
+    ) -> Path:
+        path = self._output_dir / ResultsValidation.VALIDATION_FILE
+        merged: dict[str, dict] = {}
+        if path.exists():
+            existing = json.loads(path.read_text())
+            for row in existing.get("documents", []):
+                merged[row["doc_id"]] = row
+        for result in results:
+            merged[result.doc_id] = result.to_dict()
+        rows = list(merged.values())
+
+        arms = [arm for row in rows for arm in row["arms"]]
+        decisions = [arm["decision"] for arm in arms]
+        metadata = summary.to_dict()
+        metadata["total_documents"] = len(rows)
+        metadata["total_arms"] = len(arms)
+        metadata["kept"] = decisions.count(ValidationDecision.KEPT.value)
+        metadata["fixed"] = decisions.count(ValidationDecision.FIXED.value)
+        metadata["dropped"] = decisions.count(ValidationDecision.DROPPED.value)
+        metadata["hitl"] = decisions.count(ValidationDecision.HITL.value)
+        metadata["errored"] = sum(1 for r in rows if r["error_message"])
+        metadata["total_missed_values"] = sum(len(a["missed_values"]) for a in arms)
+
+        path.write_text(
+            json.dumps(
+                {"metadata": metadata, "documents": rows},
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return path
+
+    def write_derived(
+        self,
+        *,
+        cleaned: dict,
+        hitl: list[dict],
+        dropped: list[dict],
+        missed_by_field: dict[str, list[dict]],
+    ) -> None:
+        """Write the cleaned cohort and the review / drop / recall side files."""
+        self._write(ResultsValidation.CLEANED_FILE, cleaned)
+        self._write(ResultsValidation.HITL_FILE, {"arms": hitl})
+        self._write(ResultsValidation.DROPPED_ARMS_FILE, {"arms": dropped})
+        self._write(
+            ResultsValidation.MISSED_VALUES_FILE,
+            {
+                "total": sum(len(v) for v in missed_by_field.values()),
+                "by_field": dict(
+                    sorted(
+                        missed_by_field.items(),
+                        key=lambda item: len(item[1]),
+                        reverse=True,
+                    )
+                ),
+            },
+        )
+
+    def write_cost_report(self, cost_calculator: CostCalculator) -> Path:
+        """Write cost_report.json incrementally, so a mid-run kill keeps the spend."""
+        path = self._output_dir / ResultsValidation.COST_REPORT_FILE
+        cost_calculator.save_detailed_report(str(path))
+        return path
+
+    def _write(self, filename: str, payload: dict) -> None:
+        (self._output_dir / filename).write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class ResultsValidationService:
+    """Orchestrates deterministic + LLM validation over an extraction run."""
+
+    def __init__(
+        self,
+        config: ResultsValidationConfig,
+        llm: StructuredLLMService,
+        source_loader: DocumentSourceLoader,
+        checkpoint: ValidationCheckpointManager,
+        writer: ResultsValidationWriter,
+        cost_calculator: CostCalculator,
+    ) -> None:
+        self._config = config
+        self._llm = llm
+        self._sources = source_loader
+        self._checkpoint = checkpoint
+        self._writer = writer
+        self._cost_calculator = cost_calculator
+        self._write_lock = asyncio.Lock()
+
+    @classmethod
+    def from_config(
+        cls,
+        config: ResultsValidationConfig,
+        llm: StructuredLLMService,
+        source_loader: DocumentSourceLoader,
+        cost_calculator: CostCalculator,
+    ) -> ResultsValidationService:
+        return cls(
+            config=config,
+            llm=llm,
+            source_loader=source_loader,
+            checkpoint=ValidationCheckpointManager(
+                config.output_dir / ResultsValidation.CHECKPOINT_FILE
+            ),
+            writer=ResultsValidationWriter(config.output_dir),
+            cost_calculator=cost_calculator,
+        )
+
+    # -- candidate selection ------------------------------------------------
+
+    def _documents(self) -> list[dict]:
+        """Every extracted document across the configured results files."""
+        container, id_key = _RESULTS_LAYOUT[self._config.doc_type]
+        documents: list[dict] = []
+        for path in self._config.results_paths:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            for record in payload.get(container, []):
+                documents.append({**record, "doc_id": record[id_key]})
+
+        if self._config.doc_allowlist:
+            wanted = set(self._config.doc_allowlist)
+            documents = [d for d in documents if d["doc_id"] in wanted]
+        documents.sort(key=lambda d: str(d["doc_id"]))
+        if self._config.sample is not None:
+            documents = documents[: self._config.sample]
+        return documents
+
+    # -- per-document validation -------------------------------------------
+
+    async def _validate_document(self, record: dict) -> DocValidationResult:
+        doc_id = str(record["doc_id"])
+        source = self._sources.load(doc_id)
+        arms: dict[str, dict] = record.get("arm_results") or {}
+
+        deterministic = {arm_id: check_arm(arm) for arm_id, arm in arms.items()}
+        judged_arms = {
+            arm_id: arm
+            for arm_id, arm in arms.items()
+            if not is_droppable(deterministic[arm_id])
+        }
+
+        verdicts: dict[AttributeGroup, GroupVerdict] = {}
+        if judged_arms:
+            verdicts = await self._judge_groups(source.text, judged_arms)
+
+        evaluations_by_arm: dict[str, list[ArmFieldEvaluation]] = {a: [] for a in arms}
+        missed_by_arm: dict[str, list[MissedValue]] = {a: [] for a in arms}
+        unknown_arm_ids: set[str] = set()
+        for verdict in verdicts.values():
+            for evaluation in verdict.field_evaluations:
+                if evaluation.arm_id in evaluations_by_arm:
+                    evaluations_by_arm[evaluation.arm_id].append(evaluation)
+                else:
+                    unknown_arm_ids.add(evaluation.arm_id)
+            for missed in verdict.missed_values:
+                if missed.arm_id in missed_by_arm:
+                    missed_by_arm[missed.arm_id].append(missed)
+                else:
+                    unknown_arm_ids.add(missed.arm_id)
+        if unknown_arm_ids:
+            # Findings against an arm that does not exist cannot be routed. Losing
+            # them silently would understate the review queue.
+            logger.warning(
+                "%s: judge referenced %d unknown arm id(s), findings discarded: %s",
+                doc_id,
+                len(unknown_arm_ids),
+                ", ".join(sorted(unknown_arm_ids)),
+            )
+
+        worst_score = min((v.validation_score for v in verdicts.values()), default=1.0)
+        arm_results = [
+            self._route_one_arm(
+                doc_id=doc_id,
+                arm_id=arm_id,
+                arm=arm,
+                violations=deterministic[arm_id],
+                evaluations=evaluations_by_arm[arm_id],
+                missed_values=missed_by_arm[arm_id],
+                source_text=source.text,
+                validation_score=worst_score,
+            )
+            for arm_id, arm in arms.items()
+        ]
+
+        return DocValidationResult(
+            doc_id=doc_id,
+            doc_type=self._config.doc_type,
+            arms=arm_results,
+            source_sha256=source.sha256,
+            source_path=str(source.path),
+            group_scores={
+                group.value: verdict.validation_score
+                for group, verdict in verdicts.items()
+            },
+        )
+
+    async def _judge_groups(
+        self, source_text: str, arms: dict[str, dict]
+    ) -> dict[AttributeGroup, GroupVerdict]:
+        """Run all three group judges for one document concurrently."""
+        groups = list(AttributeGroup)
+        verdicts = await asyncio.gather(
+            *(self._judge_group(group, source_text, arms) for group in groups)
+        )
+        return dict(zip(groups, verdicts))
+
+    async def _judge_group(
+        self, group: AttributeGroup, source_text: str, arms: dict[str, dict]
+    ) -> GroupVerdict:
+        prompt = build_group_prompt(
+            group=group,
+            doc_type=self._config.doc_type,
+            source_text=source_text,
+            arms_json=_candidate_json(arms, group),
+            arm_count=len(arms),
+        )
+        return await self._llm.generate_structured(
+            prompt,
+            response_schema=GroupVerdict,
+            operation=ResultsValidation.OPERATION,
+            attribute_type=f"{ResultsValidation.ATTRIBUTE_TYPE}_{group.value}",
+        )
+
+    def _route_one_arm(
+        self,
+        *,
+        doc_id: str,
+        arm_id: str,
+        arm: dict,
+        violations: list[DeterministicViolation],
+        evaluations: list[ArmFieldEvaluation],
+        missed_values: list[MissedValue],
+        source_text: str,
+        validation_score: float,
+    ) -> ArmValidationResult:
+        outcome = route_arm(
+            evaluations=evaluations,
+            missed_values=missed_values,
+            violations=violations,
+            source_text=source_text,
+            validation_score=validation_score,
+            apply_fixes=self._config.apply_fixes,
+            score_threshold=self._config.score_threshold,
+        )
+        return ArmValidationResult(
+            doc_id=doc_id,
+            arm_id=arm_id,
+            arm_name=arm.get("arm_name"),
+            decision=outcome.decision,
+            is_valid=outcome.decision
+            in (ValidationDecision.KEPT, ValidationDecision.FIXED),
+            validation_score=validation_score,
+            deterministic_violations=[violation_dict(v) for v in violations],
+            field_evaluations=[
+                {
+                    **e.model_dump(mode="json"),
+                    "effective_status": effective_status(e, source_text).value,
+                }
+                for e in evaluations
+            ],
+            missed_values=[m.model_dump(mode="json") for m in missed_values],
+            applied_corrections=outcome.applied_corrections,
+        )
+
+    # -- run loop -----------------------------------------------------------
+
+    async def run(self) -> list[DocValidationResult]:
+        run_start = datetime.utcnow()
+        summary = ResultsValidationRunSummary(
+            model=self._config.model,
+            run_date=run_start,
+            doc_type=self._config.doc_type,
+            apply_fixes=self._config.apply_fixes,
+        )
+
+        documents = self._documents()
+        pending = [
+            d
+            for d in documents
+            if not (self._config.resume and self._checkpoint.is_done(str(d["doc_id"])))
+        ]
+        logger.info(
+            "Validation starting | documents=%d pending=%d apply_fixes=%s",
+            len(documents),
+            len(pending),
+            self._config.apply_fixes,
+        )
+
+        if self._config.dry_run:
+            self._report_dry_run(pending)
+            return []
+
+        results: list[DocValidationResult] = []
+        semaphore = asyncio.Semaphore(max(1, self._config.concurrency))
+
+        async def _worker(record: dict) -> None:
+            doc_id = str(record["doc_id"])
+            async with semaphore:
+                try:
+                    result = await self._validate_document(record)
+                except (SourceDocumentNotFoundError, ValueError, KeyError) as exc:
+                    logger.error("Validation failed for %s: %s", doc_id, exc)
+                    result = DocValidationResult(
+                        doc_id=doc_id,
+                        doc_type=self._config.doc_type,
+                        error_message=str(exc),
+                    )
+                except Exception as exc:  # noqa: BLE001 - recorded, not swallowed
+                    logger.exception("Unexpected failure validating %s", doc_id)
+                    result = DocValidationResult(
+                        doc_id=doc_id,
+                        doc_type=self._config.doc_type,
+                        error_message=f"{type(exc).__name__}: {exc}",
+                    )
+                async with self._write_lock:
+                    results.append(result)
+                    if result.error_message is None:
+                        # Errored documents stay off the checkpoint so --resume
+                        # retries them; a transient timeout must not silently
+                        # exclude a document from the cohort forever.
+                        self._checkpoint.record(result.doc_id, result.decision.value)
+                    self._record_cost(summary)
+                    self._writer.write_validation(results, summary)
+                    self._writer.write_cost_report(self._cost_calculator)
+                    logger.info(
+                        "Validated %d/%d | %s | %s | %d arm(s)",
+                        len(results),
+                        len(pending),
+                        result.doc_id,
+                        result.decision.value,
+                        len(result.arms),
+                    )
+
+        await asyncio.gather(*(_worker(record) for record in pending))
+
+        self._write_derived_outputs(documents)
+        self._record_cost(summary)
+        self._writer.write_validation(results, summary)
+        self._writer.write_cost_report(self._cost_calculator)
+        logger.info("Validation complete | %d documents", len(results))
+        return results
+
+    def _record_cost(self, summary: ResultsValidationRunSummary) -> None:
+        cost = self._cost_calculator.get_summary()
+        summary.total_cost_usd = cost.total_cost
+        summary.total_tokens = cost.total_tokens
+
+    def _report_dry_run(self, pending: list[dict]) -> None:
+        """Confirm every pending document resolves to a source before spending."""
+        available = self._sources.available_ids()
+        missing = [
+            str(d["doc_id"]) for d in pending if str(d["doc_id"]) not in available
+        ]
+        arms = sum(len(d.get("arm_results") or {}) for d in pending)
+        logger.info(
+            "Dry run | %d document(s), %d arm(s), %d judge call(s) would run",
+            len(pending),
+            arms,
+            len(pending) * len(AttributeGroup),
+        )
+        if missing:
+            logger.error(
+                "%d document(s) have no source markdown: %s",
+                len(missing),
+                ", ".join(missing[:10]),
+            )
+        else:
+            logger.info("All %d document(s) resolved to a source file.", len(pending))
+
+    # -- derived outputs ----------------------------------------------------
+
+    def _write_derived_outputs(self, documents: list[dict]) -> None:
+        """Recompute the cleaned cohort and side files from validation.json."""
+        validation = json.loads(
+            (self._config.output_dir / ResultsValidation.VALIDATION_FILE).read_text()
+        )
+        verdicts = {row["doc_id"]: row for row in validation.get("documents", [])}
+        container, _ = _RESULTS_LAYOUT[self._config.doc_type]
+
+        cleaned_documents: list[dict] = []
+        hitl: list[dict] = []
+        dropped: list[dict] = []
+        missed_by_field: dict[str, list[dict]] = {}
+
+        for record in documents:
+            doc_id = str(record["doc_id"])
+            verdict = verdicts.get(doc_id)
+            if verdict is None:
+                continue
+            arms: dict[str, dict] = record.get("arm_results") or {}
+            kept_arms: dict[str, dict] = {}
+
+            for arm_verdict in verdict["arms"]:
+                arm_id = arm_verdict["arm_id"]
+                arm = arms.get(arm_id)
+                if arm is None:
+                    continue
+                decision = arm_verdict["decision"]
+                if decision == ValidationDecision.KEPT.value:
+                    kept_arms[arm_id] = arm
+                elif decision == ValidationDecision.FIXED.value:
+                    kept_arms[arm_id] = _apply_corrections(arm, arm_verdict)
+                elif decision == ValidationDecision.DROPPED.value:
+                    dropped.append(arm_verdict)
+                else:
+                    hitl.append(arm_verdict)
+
+                for missed in arm_verdict["missed_values"]:
+                    missed_by_field.setdefault(missed["field_name"], []).append(
+                        {"doc_id": doc_id, **missed}
+                    )
+
+            cleaned_documents.append(
+                {**record, "arm_results": kept_arms, "total_arms": len(kept_arms)}
+            )
+
+        cleaned = {
+            "source": f"{self._config.doc_type}_validation",
+            "total_documents": len(cleaned_documents),
+            "total_arms": sum(len(d["arm_results"]) for d in cleaned_documents),
+            container: cleaned_documents,
+        }
+        self._writer.write_derived(
+            cleaned=cleaned,
+            hitl=hitl,
+            dropped=dropped,
+            missed_by_field=missed_by_field,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _candidate_json(arms: dict[str, dict], group: AttributeGroup) -> str:
+    """Render the arms' candidate values for one group as the judge's input.
+
+    Empty values are kept but collapsed to a single sentinel, so the judge can see
+    which attributes the extractor claimed to find nothing for - that claim is what
+    the recall sweep tests.
+    """
+    payload: dict[str, dict] = {}
+    for arm_id, arm in arms.items():
+        extracted: dict[str, str] = {}
+        for name, attribute in (arm.get("attributes") or {}).items():
+            if group_for_field(name) is not group:
+                continue
+            raw = attribute.get("value") if isinstance(attribute, dict) else attribute
+            rendered = render_value(raw)
+            extracted[name] = rendered if has_value(rendered) else ""
+        payload[arm_id] = {
+            "arm_name": arm.get("arm_name"),
+            "generic_name": arm.get("generic_name"),
+            "patient_count": arm.get("patient_count"),
+            "arm_source_text": arm.get("source_text"),
+            "extracted": extracted,
+        }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _apply_corrections(arm: dict, arm_verdict: dict) -> dict:
+    """Return a copy of `arm` with the judge's gated corrections applied."""
+    fixed = json.loads(json.dumps(arm))
+    attributes = fixed.setdefault("attributes", {})
+    for correction in arm_verdict.get("applied_corrections", []):
+        attribute = attributes.setdefault(correction["field"], {})
+        attribute["value"] = correction["corrected"]
+        attribute["source"] = ResultsValidation.OPERATION
+    return fixed

--- a/melanoma/src/domain/constants.py
+++ b/melanoma/src/domain/constants.py
@@ -567,3 +567,31 @@ class PublicationPostprocessingPatterns:
     ORIGINAL_ARTICLE_WITH_JOURNAL: Final[
         str
     ] = r"^#{0,4}\s*\*?\*?original\s+article\s+.*\*?\*?$"
+
+
+# =============================================================================
+# RESULTS VALIDATION (abstract / publication LLM-as-a-Judge pipeline)
+# =============================================================================
+
+
+class ResultsValidation:
+    """Constants for the abstract / publication validation pipeline."""
+
+    # Sentinels the extractor writes when a source carries no value for a field.
+    # "NR" ("not reached") is a real clinical value, not an absence marker.
+    EMPTY_VALUE_TOKENS: Final[frozenset[str]] = frozenset(
+        {"", "not found", "n/a", "na", "none", "null", "not reported", "-"}
+    )
+
+    # Cost-calculator labels for the judge's LLM calls.
+    OPERATION: Final[str] = "results_validation"
+    ATTRIBUTE_TYPE: Final[str] = "results_validation"
+
+    # Output filenames written to the validation output directory.
+    VALIDATION_FILE: Final[str] = "validation.json"
+    CLEANED_FILE: Final[str] = "results.cleaned.json"
+    HITL_FILE: Final[str] = "validation_hitl.json"
+    MISSED_VALUES_FILE: Final[str] = "missed_values.json"
+    DROPPED_ARMS_FILE: Final[str] = "dropped-arms.json"
+    COST_REPORT_FILE: Final[str] = "cost_report.json"
+    CHECKPOINT_FILE: Final[str] = "validation_checkpoint.json"

--- a/melanoma/src/domain/results_validation_models.py
+++ b/melanoma/src/domain/results_validation_models.py
@@ -1,0 +1,267 @@
+"""Domain models for LLM-as-a-Judge validation of extracted results attributes.
+
+Sibling of ``trial_validation_models`` for the abstract / publication cohorts. The
+unit of judgement differs: a trial is one record with eight controlled-vocabulary
+fields, whereas an abstract or publication carries several *treatment arms*, each
+with 120-165 numeric attributes of which only a handful are populated. So the
+judge grades per arm, and routing decisions are per arm too.
+
+Two kinds of model live here, same split as the trials validator:
+
+* ``GroupVerdict`` and its parts are the *LLM contract* - the typed structured
+  output the judge returns for one (document, attribute-group) pair.
+* ``ArmValidationResult`` / ``DocValidationResult`` / ``ResultsValidationRunSummary``
+  are the *pipeline records* written to disk.
+
+``ValidationFieldStatus`` and ``ValidationDecision`` are imported from
+``trial_validation_models`` rather than redefined - the per-field verdict and the
+routing outcomes are identical concepts across both validators.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from .trial_validation_models import ValidationDecision, ValidationFieldStatus
+
+__all__ = [
+    "ArmFieldEvaluation",
+    "ArmValidationResult",
+    "AttributeGroup",
+    "DerivationKind",
+    "DocValidationResult",
+    "GroupVerdict",
+    "MissedValue",
+    "ResultsValidationRunSummary",
+    "ValidationDecision",
+    "ValidationFieldStatus",
+]
+
+
+class AttributeGroup(str, Enum):
+    """One judge call per group, per document.
+
+    Groups partition ``extraction_models.FAMILY_TO_ATTRIBUTES`` so every attribute
+    the extractor can emit is audited exactly once.
+    """
+
+    IDENTIFICATION = "identification"
+    EFFICACY = "efficacy"
+    SAFETY = "safety"
+
+
+class DerivationKind(str, Enum):
+    """How an extracted value relates to the text it was drawn from.
+
+    Extraction normalises as it reads (strips ``%`` and units, reads ``N (X%)`` as
+    ``X``, sums G3+G4+G5 for ``grade_3_plus_*``, may compute ORR from CR+PR), so an
+    extracted value is often absent from its own supporting quote. The judge labels
+    which transform it believes was applied; the service uses the label to decide
+    whether "the value must appear in the quote" is a check it can enforce.
+    """
+
+    VERBATIM = "VERBATIM"
+    UNIT_STRIPPED = "UNIT_STRIPPED"
+    PERCENT_OF_COUNT = "PERCENT_OF_COUNT"
+    SUMMED = "SUMMED"
+    COMPUTED = "COMPUTED"
+
+
+#: Derivations where the extracted number is expected to survive into the quote,
+#: so a literal value-in-quote check is meaningful.
+LITERAL_DERIVATIONS: frozenset[DerivationKind] = frozenset(
+    {DerivationKind.VERBATIM, DerivationKind.UNIT_STRIPPED}
+)
+
+
+# ---------------------------------------------------------------------------
+# LLM contract (Pydantic) - the judge's structured output
+# ---------------------------------------------------------------------------
+
+
+class ArmFieldEvaluation(BaseModel):
+    """The judge's verdict on one extracted attribute of one treatment arm."""
+
+    arm_id: str = Field(description="The arm the value was filed under, e.g. 'arm_1'.")
+    field_name: str = Field(description="Canonical attribute name, e.g. 'median_pfs'.")
+    extracted_value: str = Field(description="The value under review, as text.")
+    status: ValidationFieldStatus
+    source_evidence_quote: str | None = Field(
+        default=None,
+        description="Verbatim phrase from the source that justifies the value. "
+        "Required to PASS; must be a literal substring of the source text.",
+    )
+    derivation: DerivationKind | None = Field(
+        default=None,
+        description="Which transform maps the quoted text to the extracted value.",
+    )
+    derivation_justification: str | None = Field(
+        default=None,
+        description="For SUMMED / PERCENT_OF_COUNT / COMPUTED, the arithmetic: "
+        "which numbers from the quote combine to the extracted value.",
+    )
+    arm_attribution_ok: bool = Field(
+        default=True,
+        description="False when the quoted value belongs to a different arm or to "
+        "the study total rather than to this arm.",
+    )
+    corrected_value: str | None = Field(
+        default=None,
+        description="On FAIL, the value the source actually supports for this arm. "
+        "Null when no correction can be justified.",
+    )
+    issue_description: str | None = Field(default=None)
+
+
+class MissedValue(BaseModel):
+    """An endpoint the source reports for an arm that the extractor left empty."""
+
+    arm_id: str
+    field_name: str
+    suggested_value: str = Field(
+        description="The value the source supports, in the extractor's output format."
+    )
+    source_evidence_quote: str = Field(
+        description="Verbatim phrase from the source supporting the addition."
+    )
+
+
+class GroupVerdict(BaseModel):
+    """Judge verdict for one (document, attribute-group) pair - the response schema."""
+
+    is_valid: bool = Field(description="True when no field evaluation is FAIL.")
+    validation_score: float = Field(
+        ge=0.0, le=1.0, description="Overall confidence, 0.0-1.0."
+    )
+    field_evaluations: list[ArmFieldEvaluation] = Field(default_factory=list)
+    missed_values: list[MissedValue] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline records (dataclasses) - written to disk
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ArmValidationResult:
+    """Outcome of validating one treatment arm of one document."""
+
+    doc_id: str
+    arm_id: str
+    decision: ValidationDecision
+    arm_name: str | None = None
+    is_valid: bool = True
+    validation_score: float = 1.0
+    # Serialised infra ``DeterministicViolation`` objects, so the domain stays
+    # free of infrastructure imports.
+    deterministic_violations: list[dict] = field(default_factory=list)
+    # Every judge evaluation for this arm, serialised.
+    field_evaluations: list[dict] = field(default_factory=list)
+    # Values the judge says the source supports but the extractor omitted.
+    missed_values: list[dict] = field(default_factory=list)
+    # Corrections actually applied to the cleaned record (--apply-fixes only).
+    applied_corrections: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "doc_id": self.doc_id,
+            "arm_id": self.arm_id,
+            "arm_name": self.arm_name,
+            "decision": self.decision.value,
+            "is_valid": self.is_valid,
+            "validation_score": round(self.validation_score, 4),
+            "deterministic_violations": self.deterministic_violations,
+            "field_evaluations": self.field_evaluations,
+            "missed_values": self.missed_values,
+            "applied_corrections": self.applied_corrections,
+        }
+
+
+@dataclass
+class DocValidationResult:
+    """Outcome of validating one abstract or publication and all of its arms."""
+
+    doc_id: str
+    doc_type: str
+    arms: list[ArmValidationResult] = field(default_factory=list)
+    # Recorded at validation time. Extraction did not pin a source hash, so this
+    # establishes provenance going forward rather than verifying the past.
+    source_sha256: str | None = None
+    source_path: str | None = None
+    # validation_score per AttributeGroup value, for spotting a group that the
+    # judge systematically distrusts.
+    group_scores: dict[str, float] = field(default_factory=dict)
+    error_message: str | None = None
+    validated_at: datetime = field(default_factory=datetime.utcnow)
+
+    @property
+    def decision(self) -> ValidationDecision:
+        """Worst arm decision, used for checkpoint and progress reporting."""
+        if self.error_message is not None:
+            return ValidationDecision.ERROR
+        ranking = [
+            ValidationDecision.ERROR,
+            ValidationDecision.DROPPED,
+            ValidationDecision.HITL,
+            ValidationDecision.FIXED,
+            ValidationDecision.KEPT,
+        ]
+        for decision in ranking:
+            if any(arm.decision is decision for arm in self.arms):
+                return decision
+        return ValidationDecision.KEPT
+
+    def to_dict(self) -> dict:
+        return {
+            "doc_id": self.doc_id,
+            "doc_type": self.doc_type,
+            "decision": self.decision.value,
+            "source_sha256": self.source_sha256,
+            "source_path": self.source_path,
+            "group_scores": {k: round(v, 4) for k, v in self.group_scores.items()},
+            "error_message": self.error_message,
+            "validated_at": self.validated_at.isoformat(),
+            "arms": [arm.to_dict() for arm in self.arms],
+        }
+
+
+@dataclass
+class ResultsValidationRunSummary:
+    """High-level summary written to the validation.json metadata block."""
+
+    model: str
+    run_date: datetime
+    doc_type: str
+    apply_fixes: bool = False
+    total_documents: int = 0
+    total_arms: int = 0
+    kept: int = 0
+    fixed: int = 0
+    dropped: int = 0
+    hitl: int = 0
+    errored: int = 0
+    total_missed_values: int = 0
+    total_cost_usd: float = 0.0
+    total_tokens: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "run_date": self.run_date.isoformat(),
+            "doc_type": self.doc_type,
+            "apply_fixes": self.apply_fixes,
+            "total_documents": self.total_documents,
+            "total_arms": self.total_arms,
+            "kept": self.kept,
+            "fixed": self.fixed,
+            "dropped": self.dropped,
+            "hitl": self.hitl,
+            "errored": self.errored,
+            "total_missed_values": self.total_missed_values,
+            "total_cost_usd": round(self.total_cost_usd, 6),
+            "total_tokens": self.total_tokens,
+        }

--- a/melanoma/src/domain/results_validation_prompts.py
+++ b/melanoma/src/domain/results_validation_prompts.py
@@ -1,0 +1,259 @@
+"""Prompt builder for the abstract / publication validation judge.
+
+One judge call per (document, attribute group). Each call sees the full source
+text and every treatment arm side by side - arm attribution is only checkable when
+the sibling arms are visible.
+
+The prompt embeds the extractor's own instructions verbatim
+(``SHARED_EXTRACTION_RULES`` plus the group's ``FAMILY_PROMPTS`` bodies) rather
+than restating endpoint definitions. The judge's question is "did the extractor
+follow these rules?", so handing it the same rules keeps a single source of truth:
+when an extraction rule changes, the judge changes with it.
+"""
+
+from __future__ import annotations
+
+from .constants import ResultsValidation
+from .extraction_models import (
+    ABSTRACT_ATTRIBUTES,
+    FAMILY_TO_ATTRIBUTES,
+    PUBLICATION_ATTRIBUTES,
+    AttributeFamily,
+    AttributeType,
+)
+from .models import DocumentType
+from .prompt_templates import FAMILY_PROMPTS, SHARED_EXTRACTION_RULES
+from .results_validation_models import AttributeGroup
+
+__all__ = [
+    "FILE_PATH_SOURCED_ATTRIBUTES",
+    "GROUP_TO_ATTRIBUTES",
+    "GROUP_TO_FAMILIES",
+    "TRIALS_PIPELINE_ATTRIBUTES",
+    "UNAUDITED_ATTRIBUTES",
+    "allowed_fields_for",
+    "build_group_prompt",
+    "group_for_field",
+]
+
+# Read from the filename by the extraction pipelines (``source: "file_path"``),
+# not from the document body. An LLM asked to find them in the text would
+# manufacture failures, so they are audited by no group.
+FILE_PATH_SOURCED_ATTRIBUTES: frozenset[AttributeType] = frozenset(
+    {
+        AttributeType.CONFERENCE,
+        AttributeType.PUBLISHED_YEAR,
+        AttributeType.PDF_NUMBER,
+    }
+)
+
+# Trial-level drug classifications, derived from pharmacological knowledge rather
+# than read from the document. They are owned by the trials validation pipeline
+# (``trials_validation_service``), which grades them against CT.gov - auditing
+# them again here would duplicate that judgement against a source that never
+# states them.
+TRIALS_PIPELINE_ATTRIBUTES: frozenset[AttributeType] = frozenset(
+    {
+        AttributeType.MODALITY,
+        AttributeType.TARGET,
+    }
+)
+
+#: Everything this pipeline deliberately does not audit.
+UNAUDITED_ATTRIBUTES: frozenset[AttributeType] = (
+    FILE_PATH_SOURCED_ATTRIBUTES | TRIALS_PIPELINE_ATTRIBUTES
+)
+
+GROUP_TO_FAMILIES: dict[AttributeGroup, tuple[AttributeFamily, ...]] = {
+    AttributeGroup.IDENTIFICATION: (AttributeFamily.IDENTIFICATION,),
+    AttributeGroup.EFFICACY: (
+        AttributeFamily.RESPONSE_RATES,
+        AttributeFamily.PFS_FAMILY,
+        AttributeFamily.OS_FAMILY,
+        AttributeFamily.EFS_RFS_MFS,
+        AttributeFamily.TIME_TO_METRICS,
+    ),
+    AttributeGroup.SAFETY: (
+        AttributeFamily.AE_GENERAL,
+        AttributeFamily.AE_GRADE3_SPECIFIC,
+        AttributeFamily.TEAE_GENERAL,
+        AttributeFamily.TEAE_GRADE3_SPECIFIC,
+        AttributeFamily.TRAE_GENERAL,
+        AttributeFamily.TRAE_GRADE3_SPECIFIC,
+    ),
+}
+
+# Attributes that belong to no AttributeFamily but are still extracted from the
+# document body, so they must be audited. ``number_of_patients`` comes from the
+# arm separator; the publication metadata comes from the citation block.
+_UNFAMILIED_IDENTIFICATION: tuple[AttributeType, ...] = (
+    AttributeType.NUMBER_OF_PATIENTS,
+    AttributeType.PUBLICATION_NAME,
+    AttributeType.PUBLICATION_YEAR,
+)
+
+
+def _build_group_attributes() -> dict[AttributeGroup, tuple[AttributeType, ...]]:
+    """Expand the family mapping into a flat, ordered attribute list per group."""
+    mapping: dict[AttributeGroup, tuple[AttributeType, ...]] = {}
+    for group, families in GROUP_TO_FAMILIES.items():
+        members: list[AttributeType] = []
+        if group is AttributeGroup.IDENTIFICATION:
+            members.extend(_UNFAMILIED_IDENTIFICATION)
+        for family in families:
+            members.extend(FAMILY_TO_ATTRIBUTES[family])
+        # De-duplicate while preserving order; families do not overlap today, but
+        # the mapping is data and could grow one.
+        mapping[group] = tuple(dict.fromkeys(members))
+    return mapping
+
+
+GROUP_TO_ATTRIBUTES: dict[
+    AttributeGroup, tuple[AttributeType, ...]
+] = _build_group_attributes()
+
+_GROUP_BY_FIELD: dict[str, AttributeGroup] = {
+    attribute.value: group
+    for group, attributes in GROUP_TO_ATTRIBUTES.items()
+    for attribute in attributes
+}
+
+_ATTRIBUTES_BY_DOC_TYPE: dict[str, frozenset[AttributeType]] = {
+    DocumentType.ABSTRACT.value: frozenset(ABSTRACT_ATTRIBUTES),
+    DocumentType.PUBLICATION.value: frozenset(PUBLICATION_ATTRIBUTES),
+}
+
+
+def group_for_field(field_name: str) -> AttributeGroup | None:
+    """Return the group that audits ``field_name``, or None if it is not audited."""
+    return _GROUP_BY_FIELD.get(field_name)
+
+
+def allowed_fields_for(group: AttributeGroup, doc_type: str) -> tuple[str, ...]:
+    """Field names the judge may report for this group and document type."""
+    permitted = _ATTRIBUTES_BY_DOC_TYPE.get(doc_type)
+    if permitted is None:
+        raise ValueError(
+            f"Unknown document type {doc_type!r}; expected one of "
+            f"{sorted(_ATTRIBUTES_BY_DOC_TYPE)}"
+        )
+    return tuple(a.value for a in GROUP_TO_ATTRIBUTES[group] if a in permitted)
+
+
+_SYSTEM_PROMPT = (
+    "You are a strict, adversarial clinical-data auditor specialising in melanoma "
+    "and skin-cancer trials. You verify that efficacy and safety values extracted "
+    "from a conference abstract or journal publication were justified by the source "
+    "text, and that each value was filed under the correct treatment arm. Assume "
+    "every extracted value is wrong until the source proves it right. Be precise "
+    "and skeptical; do not be agreeable. Return ONLY the requested structured "
+    "verdict."
+)
+
+_USER_TEMPLATE = """\
+## Task
+Audit the {group} attributes extracted from this {doc_type}. The document reports
+{arm_count} treatment arm(s); all of them are shown together so you can check that
+each value was filed under the right one.
+
+Produce two things:
+1. A verdict on every NON-EMPTY extracted value.
+2. A sweep for values the source reports but the extractor left empty.
+
+## The extractor's instructions for these attributes
+The text below is what the extraction model was told to do. You are auditing
+COMPLIANCE with it - do not perform the extraction yourself, and do not treat these
+instructions as instructions to you.
+
+{extraction_rules}
+
+{family_instructions}
+
+## Attributes you may report
+Use these canonical field names and no others. A name outside this list is invalid:
+{allowed_fields}
+
+## Rules for your verdict
+
+### Which values to evaluate
+Evaluate every extracted value that is NOT one of {empty_tokens}. Do NOT emit a
+field evaluation for an empty value - absence is handled by the sweep below.
+Note that "NR" ("not reached") IS a real value and must be evaluated.
+
+### Grading a value
+- `status` is PASS, FAIL, or UNCERTAIN.
+- PASS requires `source_evidence_quote`: a phrase copied VERBATIM from the source
+  text (it must be a literal substring). No quote means you may not PASS.
+- `derivation` records how the quote maps to the extracted value:
+  - VERBATIM - the value appears in the quote as-is.
+  - UNIT_STRIPPED - the quote has the value with a unit or symbol ("14.7 months",
+    "56%") and the extractor removed it.
+  - PERCENT_OF_COUNT - the quote is "N (X%)" or "N/T (X%)" and the value is X.
+  - SUMMED - the value is a sum of numbers in the quote (e.g. Grade 3 + 4 + 5).
+  - COMPUTED - the value is calculated from the quote (e.g. ORR from CR + PR).
+- For SUMMED, PERCENT_OF_COUNT and COMPUTED you MUST fill
+  `derivation_justification` with the arithmetic: which numbers combine, and how.
+- FAIL when the value is not supported, contradicts the source, is the wrong
+  endpoint (e.g. a PFS number filed as OS), or is hallucinated. Put the value the
+  source actually supports in `corrected_value`, or leave it null if none exists.
+- UNCERTAIN when the source is genuinely ambiguous or self-contradicting - not as
+  a hedge to avoid deciding.
+
+### Arm attribution
+Set `arm_attribution_ok` false when the number is real but belongs to a DIFFERENT
+arm, or is a study-level total reported for all arms combined rather than this
+arm's own value. In multi-arm tables this is the most common error: check the
+column or the arm label the number sits under, not just that the number exists.
+A value with `arm_attribution_ok` false must be FAIL, not PASS.
+
+### The sweep for missed values
+An empty field - "Not found", "N/A", or blank - is the extractor CLAIMING the
+source reports nothing for that attribute. Treat it as a claim to be tested, not
+as a blank to skip over. Read the results text, the safety text, and every table. When the
+source clearly reports one of the allowed attributes for an arm and the extracted
+record leaves it empty, add it to `missed_values` with the value in the
+extractor's output format and a verbatim supporting quote.
+Do NOT invent a missed value from an endpoint the source never reports, and do not
+report one that is merely implied or must be inferred from other numbers.
+
+### Overall
+Set `is_valid` false if any field evaluation is FAIL. Set `validation_score` to
+your confidence (0.0-1.0) that this group's extracted values are correct AND
+complete for every arm.
+
+## Source document
+{source_text}
+
+## Extracted arms (candidates under audit)
+{arms_json}
+"""
+
+
+def build_group_prompt(
+    *,
+    group: AttributeGroup,
+    doc_type: str,
+    source_text: str,
+    arms_json: str,
+    arm_count: int = 1,
+) -> str:
+    """Assemble the full judge prompt for one (document, attribute-group) pair."""
+    family_instructions = "\n\n".join(
+        FAMILY_PROMPTS[family].replace("{arms_block}", "").strip()
+        for family in GROUP_TO_FAMILIES[group]
+    )
+    allowed = allowed_fields_for(group, doc_type)
+    user = _USER_TEMPLATE.format(
+        group=group.value,
+        doc_type=doc_type,
+        arm_count=arm_count,
+        extraction_rules=SHARED_EXTRACTION_RULES,
+        family_instructions=family_instructions,
+        allowed_fields="\n".join(f"  - {name}" for name in allowed),
+        empty_tokens=", ".join(
+            repr(t) for t in sorted(ResultsValidation.EMPTY_VALUE_TOKENS) if t
+        ),
+        source_text=source_text.strip(),
+        arms_json=arms_json.strip(),
+    )
+    return f"{_SYSTEM_PROMPT}\n\n{user}"

--- a/melanoma/src/infrastructure/document_source_loader.py
+++ b/melanoma/src/infrastructure/document_source_loader.py
@@ -1,0 +1,153 @@
+"""Load the source markdown an abstract or publication was extracted from.
+
+The validation judge must grade against the same text the extractor read, so the
+document split here mirrors the extraction pipelines exactly:
+
+* publications - one ``.md`` per document, ``pub_id`` is the file stem
+  (``run_publication_pipeline.py``).
+* abstracts - one ``.md`` per conference-year holding many abstracts, split on
+  ``### Abstract ID:`` and keyed ``{CONFERENCE}_{YEAR}_{ID}``
+  (``run_abstract_pipeline.py``).
+
+Each loaded document carries the SHA-256 of the exact text handed to the judge.
+The extraction runs recorded no such hash, so this establishes provenance from now
+on rather than verifying that the corpus has not drifted since extraction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..domain.constants import AbstractPatterns, FileExtensions
+
+logger = logging.getLogger(__name__)
+
+# The extractor splits on the header without its trailing space, then prepends the
+# same token back onto every block.
+_ABSTRACT_SPLIT_TOKEN = AbstractPatterns.ABSTRACT_ID_HEADER.rstrip()
+# Conference-year filenames, e.g. "ASCO_2023.md".
+_YEAR_FILE_RE = re.compile(r"^(?P<conference>[A-Za-z]+)_(?P<year>\d{4})$")
+
+
+class SourceDocumentNotFoundError(LookupError):
+    """Raised when an extracted record's source document cannot be located."""
+
+
+@dataclass(frozen=True)
+class SourceDocument:
+    """The source text for one extracted document, with its provenance hash."""
+
+    doc_id: str
+    text: str
+    sha256: str
+    path: Path
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class DocumentSourceLoader(ABC):
+    """Resolves a ``doc_id`` from an extraction run to its source text."""
+
+    @abstractmethod
+    def load(self, doc_id: str) -> SourceDocument:
+        """Return the source document, or raise ``SourceDocumentNotFoundError``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def available_ids(self) -> set[str]:
+        """Every ``doc_id`` this loader can resolve - used by ``--dry-run``."""
+        raise NotImplementedError
+
+
+class PublicationSourceLoader(DocumentSourceLoader):
+    """One markdown file per publication, named after its ``pub_id``."""
+
+    def __init__(self, publications_dir: Path) -> None:
+        self._dir = publications_dir
+
+    def load(self, doc_id: str) -> SourceDocument:
+        path = self._dir / f"{doc_id}{FileExtensions.MARKDOWN}"
+        if not path.exists():
+            raise SourceDocumentNotFoundError(
+                f"No source markdown for publication {doc_id!r} at {path}"
+            )
+        text = path.read_text(encoding="utf-8")
+        return SourceDocument(doc_id=doc_id, text=text, sha256=_digest(text), path=path)
+
+    def available_ids(self) -> set[str]:
+        if not self._dir.exists():
+            return set()
+        return {p.stem for p in self._dir.glob(f"*{FileExtensions.MARKDOWN}")}
+
+
+class AbstractSourceLoader(DocumentSourceLoader):
+    """Many abstracts per conference-year file, split on the abstract-ID header.
+
+    Conference-year files are parsed once on first use and cached, since a single
+    validation run reads every abstract in a year file.
+    """
+
+    def __init__(self, conference_dirs: dict[str, Path]) -> None:
+        self._conference_dirs = conference_dirs
+        self._documents: dict[str, SourceDocument] | None = None
+
+    def load(self, doc_id: str) -> SourceDocument:
+        document = self._index().get(doc_id)
+        if document is None:
+            raise SourceDocumentNotFoundError(
+                f"No source abstract for {doc_id!r} in "
+                f"{', '.join(str(d) for d in self._conference_dirs.values())}"
+            )
+        return document
+
+    def available_ids(self) -> set[str]:
+        return set(self._index())
+
+    def _index(self) -> dict[str, SourceDocument]:
+        if self._documents is None:
+            self._documents = self._build_index()
+        return self._documents
+
+    def _build_index(self) -> dict[str, SourceDocument]:
+        documents: dict[str, SourceDocument] = {}
+        for conference, directory in self._conference_dirs.items():
+            if not directory.exists():
+                logger.warning("Abstract directory not found, skipping: %s", directory)
+                continue
+            for path in sorted(directory.glob(f"*{FileExtensions.MARKDOWN}")):
+                match = _YEAR_FILE_RE.match(path.stem)
+                if match is None:
+                    logger.warning(
+                        "Skipping abstract file with unexpected name: %s", path.name
+                    )
+                    continue
+                documents.update(
+                    self._split_year_file(
+                        conference=conference, year=match.group("year"), path=path
+                    )
+                )
+        return documents
+
+    @staticmethod
+    def _split_year_file(
+        *, conference: str, year: str, path: Path
+    ) -> dict[str, SourceDocument]:
+        """Split one conference-year file the way the extraction pipeline does."""
+        content = path.read_text(encoding="utf-8")
+        documents: dict[str, SourceDocument] = {}
+        for index, block in enumerate(content.split(_ABSTRACT_SPLIT_TOKEN)[1:]):
+            first_line = block.strip().split("\n")[0].strip()
+            raw_id = first_line if first_line else f"{index + 1:03d}"
+            doc_id = f"{conference}_{year}_{raw_id}"
+            text = _ABSTRACT_SPLIT_TOKEN + block
+            documents[doc_id] = SourceDocument(
+                doc_id=doc_id, text=text, sha256=_digest(text), path=path
+            )
+        return documents

--- a/melanoma/src/infrastructure/gemini_service.py
+++ b/melanoma/src/infrastructure/gemini_service.py
@@ -41,9 +41,10 @@ _CHARS_PER_TOKEN_ESTIMATE = 4
 _BACKOFF_BASE_SECONDS = 1.0
 _BACKOFF_CAP_SECONDS = 30.0
 
-# Bounded per-request timeout (ms). Judge/extraction calls run ~3-8s; 90s is
-# generous over p99 yet caps a stalled socket that would otherwise hang a worker
-# forever (there is no default client timeout).
+# Bounded per-request timeout (ms); there is no default client timeout, so a
+# stalled socket would otherwise hang a worker forever. On the streamed path
+# (generate_structured) this bounds the gap between chunks, not total generation
+# time - so a long response is free to take as long as it needs.
 _REQUEST_TIMEOUT_MS = 90_000
 
 _RETRYABLE_TOKENS = (
@@ -405,31 +406,39 @@ class GeminiLLMService(LLMService, StructuredLLMService):
             response_schema=_inline_pydantic_schema(response_schema),
         )
 
-        def _sync_call() -> Any:
-            return self._client.models.generate_content(
+        def _sync_call() -> tuple[str, Any]:
+            # Streamed, not buffered: a non-streaming call sends nothing until the
+            # whole generation finishes, so the client read timeout ends up bounding
+            # total generation time and long judge responses trip it. Streaming makes
+            # the same timeout bound the gap between chunks instead.
+            text_parts: list[str] = []
+            usage: Any = None
+            for chunk in self._client.models.generate_content_stream(
                 model=effective_model,
                 contents=prompt,
                 config=config,
-            )
+            ):
+                part = chunk.text
+                if part:
+                    text_parts.append(part)
+                # Usage arrives on the final chunk.
+                if getattr(chunk, "usage_metadata", None) is not None:
+                    usage = chunk.usage_metadata
+            return "".join(text_parts), usage
 
         last_exc: Optional[Exception] = None
         for attempt in range(max_retries):
             try:
-                response = await asyncio.to_thread(_sync_call)
+                text, usage_metadata = await asyncio.to_thread(_sync_call)
                 self._record_usage(
-                    response.usage_metadata,
+                    usage_metadata,
                     model=effective_model,
                     operation=operation,
                     attribute_type=attribute_type,
                     success=True,
                 )
-                # SDK exposes `parsed` when response_schema is a Pydantic class.
-                parsed = getattr(response, "parsed", None)
-                if isinstance(parsed, response_schema):
-                    return parsed
-                # Fallback: parse from JSON text (covers SDK versions that don't
-                # populate `parsed` reliably).
-                text = response.text or ""
+                # `response.parsed` is not populated for streamed responses, so the
+                # accumulated text always goes through the JSON path below.
                 try:
                     return response_schema.model_validate_json(text)
                 except ValidationError:
@@ -443,7 +452,7 @@ class GeminiLLMService(LLMService, StructuredLLMService):
             except Exception as exc:
                 last_exc = exc
                 if _is_retryable_error(exc) and attempt < max_retries - 1:
-                    wait_sec = min(60 * (2**attempt) + random.uniform(0, 5), 300)
+                    wait_sec = _backoff_seconds(attempt, _parse_retry_after(str(exc)))
                     logger.warning(
                         "Transient error (429/timeout) on attempt %d/%d — retrying in %.0fs",
                         attempt + 1,

--- a/melanoma/src/infrastructure/results_deterministic_validator.py
+++ b/melanoma/src/infrastructure/results_deterministic_validator.py
@@ -1,0 +1,352 @@
+"""Deterministic validator for one extracted treatment arm.
+
+Pure, deterministic functions. No LLM, no I/O, no network. Given a single arm
+record - the shape the abstract / publication pipelines write under
+``arm_results`` - return every rule violation found. An empty list means the arm
+is clean on this pass.
+
+Two kinds of rule run here:
+
+* **Atomic format** - delegated to :mod:`value_validator`, which already knows the
+  expected shape of every attribute (hazard ratio, CI range, p-value, percentage,
+  median in months, NCT identifier).
+* **Cross-field consistency** - relationships no single-value validator can see:
+  a complete response larger than the objective response rate, a grade 3+ rate
+  exceeding its all-grade total, a confidence interval that excludes its own
+  hazard ratio, a survival curve that rises with time.
+
+Each violation carries a severity:
+
+- ``DROP`` - the arm cannot be interpreted at all; it is discarded before any LLM
+  call. Reserved for *identity* failures: an arm with no name, or an impossible
+  patient count. A malformed value is never a drop - the document, not the NCT,
+  keys this pipeline, and a human may still want to correct the number.
+- ``FLAG`` - advisory; the arm continues to the judge and lands in the review
+  queue.
+
+Mirrors ``trial_deterministic_validator`` in shape and severity vocabulary.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+from ..domain.constants import ResultsValidation
+from ..domain.extraction_models import AttributeType
+from .value_validator import validate_for_attribute
+
+logger = logging.getLogger(__name__)
+
+# ---- Severities --------------------------------------------------------
+
+DROP = "drop"  # arm cannot be interpreted -> discard before the judge runs
+FLAG = "flag"  # advisory violation -> report, route to review
+
+# ---- Rule ids ----------------------------------------------------------
+
+_RULE_VALUE_FORMAT = "value_format"
+_RULE_ARM_IDENTITY = "arm_identity"
+_RULE_PATIENT_COUNT = "patient_count"
+_RULE_RESPONSE_ORDERING = "response_ordering"
+_RULE_AE_SUBSET = "ae_subset"
+_RULE_CI_BRACKETS_HR = "ci_brackets_hr"
+_RULE_RATE_MONOTONICITY = "rate_monotonicity"
+_RULE_PFS_OS_ORDERING = "pfs_os_ordering"
+
+# ---- Cross-field rule wiring -------------------------------------------
+
+# (subset, superset) - the first value can never exceed the second.
+_SUBSET_PAIRS: tuple[tuple[AttributeType, AttributeType], ...] = (
+    (AttributeType.COMPLETE_RESPONSE, AttributeType.OBJECTIVE_RESPONSE_RATE),
+    (AttributeType.OBJECTIVE_RESPONSE_RATE, AttributeType.DISEASE_CONTROL_RATE),
+)
+_AE_SUBSET_PAIRS: tuple[tuple[AttributeType, AttributeType], ...] = (
+    (AttributeType.GRADE_3_PLUS_AE, AttributeType.AE),
+    (AttributeType.GRADE_3_PLUS_TEAE, AttributeType.TEAE),
+    (AttributeType.GRADE_3_PLUS_TRAE, AttributeType.TRAE),
+    (AttributeType.GRADE_3_TEAE, AttributeType.GRADE_3_PLUS_TEAE),
+    (AttributeType.GRADE_4_TEAE, AttributeType.GRADE_3_PLUS_TEAE),
+    (AttributeType.GRADE_5_TEAE, AttributeType.GRADE_3_PLUS_TEAE),
+    (AttributeType.GRADE_3_TRAE, AttributeType.GRADE_3_PLUS_TRAE),
+    (AttributeType.GRADE_4_TRAE, AttributeType.GRADE_3_PLUS_TRAE),
+    (AttributeType.GRADE_5_TRAE, AttributeType.GRADE_3_PLUS_TRAE),
+)
+# Survival-rate curves, ordered by timepoint. A rate can only fall over time.
+_RATE_CURVES: tuple[tuple[AttributeType, ...], ...] = (
+    (
+        AttributeType.PFS_RATE_6M,
+        AttributeType.PFS_RATE_9M,
+        AttributeType.PFS_RATE_12M,
+        AttributeType.PFS_RATE_18M,
+        AttributeType.PFS_RATE_24M,
+        AttributeType.PFS_RATE_36M,
+        AttributeType.PFS_RATE_48M,
+    ),
+    (
+        AttributeType.OS_RATE_6M,
+        AttributeType.OS_RATE_9M,
+        AttributeType.OS_RATE_12M,
+        AttributeType.OS_RATE_18M,
+        AttributeType.OS_RATE_24M,
+        AttributeType.OS_RATE_36M,
+        AttributeType.OS_RATE_48M,
+    ),
+)
+# (hazard ratio, its confidence interval)
+_HR_CI_PAIRS: tuple[tuple[AttributeType, AttributeType], ...] = (
+    (AttributeType.HR_PFS, AttributeType.CI_HR_PFS),
+    (AttributeType.HR_OS, AttributeType.CI_HR_OS),
+    (AttributeType.HR_EFS, AttributeType.CI_HR_EFS),
+    (AttributeType.HR_RFS, AttributeType.CI_HR_RFS),
+    (AttributeType.HR_MFS, AttributeType.CI_HR_MFS),
+    (AttributeType.HR_TTP, AttributeType.CI_HR_TTP),
+)
+
+_CI_RANGE_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)\s*$")
+# "not reached" - a real clinical result, not a number to compare against.
+_NOT_REACHED = "NR"
+
+_ATTRIBUTE_BY_NAME: dict[str, AttributeType] = {a.value: a for a in AttributeType}
+
+
+@dataclass(frozen=True)
+class DeterministicViolation:
+    """One rule violation found on an extracted arm."""
+
+    field: str
+    rule: str
+    severity: str
+    detail: str
+
+
+# ---- Value helpers -----------------------------------------------------
+
+
+def render_value(raw: object) -> str:
+    """Render a stored attribute value as the text the validators expect."""
+    if raw is None:
+        return ""
+    return str(raw).strip()
+
+
+def has_value(rendered: str) -> bool:
+    """Whether a rendered value is a real value rather than an absence sentinel."""
+    return rendered.lower() not in ResultsValidation.EMPTY_VALUE_TOKENS
+
+
+def _numeric(values: dict[str, str], attribute: AttributeType) -> float | None:
+    """Return an attribute's value as a float, or None when absent/non-numeric.
+
+    ``NR`` is deliberately not numeric: "not reached" is longer than any measured
+    value, so comparing it as a number would invert every ordering rule.
+    """
+    rendered = values.get(attribute.value, "")
+    if not has_value(rendered) or rendered.upper() == _NOT_REACHED:
+        return None
+    try:
+        return float(rendered.rstrip("%").strip())
+    except ValueError:
+        return None
+
+
+def _extracted_values(arm: dict) -> dict[str, str]:
+    """Flatten ``attributes`` to ``{field_name: rendered_value}``."""
+    values: dict[str, str] = {}
+    for name, payload in (arm.get("attributes") or {}).items():
+        raw = payload.get("value") if isinstance(payload, dict) else payload
+        values[name] = render_value(raw)
+    return values
+
+
+# ---- Rules -------------------------------------------------------------
+
+
+def _check_identity(arm: dict) -> list[DeterministicViolation]:
+    """An arm must be nameable and, if counted, counted plausibly."""
+    violations: list[DeterministicViolation] = []
+    name = render_value(arm.get("arm_name")) or render_value(arm.get("generic_name"))
+    if not has_value(name):
+        violations.append(
+            DeterministicViolation(
+                field="arm_name",
+                rule=_RULE_ARM_IDENTITY,
+                severity=DROP,
+                detail="arm has neither an arm_name nor a generic_name",
+            )
+        )
+
+    patient_count = arm.get("patient_count")
+    if patient_count is not None:
+        try:
+            count = int(patient_count)
+        except (TypeError, ValueError):
+            violations.append(
+                DeterministicViolation(
+                    field="patient_count",
+                    rule=_RULE_PATIENT_COUNT,
+                    severity=DROP,
+                    detail=f"patient_count is not an integer: {patient_count!r}",
+                )
+            )
+        else:
+            if count <= 0:
+                violations.append(
+                    DeterministicViolation(
+                        field="patient_count",
+                        rule=_RULE_PATIENT_COUNT,
+                        severity=DROP,
+                        detail=f"patient_count must be positive, got {count}",
+                    )
+                )
+    return violations
+
+
+def _check_formats(values: dict[str, str]) -> list[DeterministicViolation]:
+    """Atomic per-attribute format checks, delegated to ``value_validator``."""
+    violations: list[DeterministicViolation] = []
+    for name, rendered in values.items():
+        if not has_value(rendered):
+            continue
+        attribute = _ATTRIBUTE_BY_NAME.get(name)
+        if attribute is None:
+            continue
+        is_valid, _normalized, reason = validate_for_attribute(attribute, rendered)
+        if not is_valid:
+            violations.append(
+                DeterministicViolation(
+                    field=name,
+                    rule=_RULE_VALUE_FORMAT,
+                    severity=FLAG,
+                    detail=f"{reason}: {rendered!r}",
+                )
+            )
+    return violations
+
+
+def _check_ordering(
+    values: dict[str, str],
+    pairs: tuple[tuple[AttributeType, AttributeType], ...],
+    rule: str,
+) -> list[DeterministicViolation]:
+    """Flag every pair where the subset value exceeds its superset value."""
+    violations: list[DeterministicViolation] = []
+    for subset, superset in pairs:
+        low = _numeric(values, subset)
+        high = _numeric(values, superset)
+        if low is None or high is None or low <= high:
+            continue
+        violations.append(
+            DeterministicViolation(
+                field=subset.value,
+                rule=rule,
+                severity=FLAG,
+                detail=(
+                    f"{subset.value} ({low}) exceeds {superset.value} ({high}); "
+                    "the first is a subset of the second"
+                ),
+            )
+        )
+    return violations
+
+
+def _check_rate_curves(values: dict[str, str]) -> list[DeterministicViolation]:
+    """A survival rate at a later timepoint cannot exceed an earlier one."""
+    violations: list[DeterministicViolation] = []
+    for curve in _RATE_CURVES:
+        previous: tuple[AttributeType, float] | None = None
+        for attribute in curve:
+            rate = _numeric(values, attribute)
+            if rate is None:
+                continue
+            if previous is not None and rate > previous[1]:
+                violations.append(
+                    DeterministicViolation(
+                        field=attribute.value,
+                        rule=_RULE_RATE_MONOTONICITY,
+                        severity=FLAG,
+                        detail=(
+                            f"{attribute.value} ({rate}) exceeds the earlier "
+                            f"{previous[0].value} ({previous[1]}); a survival rate "
+                            "cannot rise over time"
+                        ),
+                    )
+                )
+            previous = (attribute, rate)
+    return violations
+
+
+def _check_ci_brackets_hr(values: dict[str, str]) -> list[DeterministicViolation]:
+    """A hazard ratio must lie inside its own confidence interval."""
+    violations: list[DeterministicViolation] = []
+    for hr_attribute, ci_attribute in _HR_CI_PAIRS:
+        hazard_ratio = _numeric(values, hr_attribute)
+        match = _CI_RANGE_RE.match(values.get(ci_attribute.value, ""))
+        if hazard_ratio is None or match is None:
+            continue
+        low, high = float(match.group(1)), float(match.group(2))
+        if low <= hazard_ratio <= high:
+            continue
+        violations.append(
+            DeterministicViolation(
+                field=ci_attribute.value,
+                rule=_RULE_CI_BRACKETS_HR,
+                severity=FLAG,
+                detail=(
+                    f"{ci_attribute.value} ({low}-{high}) does not contain "
+                    f"{hr_attribute.value} ({hazard_ratio})"
+                ),
+            )
+        )
+    return violations
+
+
+def _check_pfs_os_ordering(values: dict[str, str]) -> list[DeterministicViolation]:
+    """Progression is an event on the way to death, so median PFS <= median OS."""
+    median_pfs = _numeric(values, AttributeType.MEDIAN_PFS)
+    median_os = _numeric(values, AttributeType.MEDIAN_OS)
+    if median_pfs is None or median_os is None or median_pfs <= median_os:
+        return []
+    return [
+        DeterministicViolation(
+            field=AttributeType.MEDIAN_PFS.value,
+            rule=_RULE_PFS_OS_ORDERING,
+            severity=FLAG,
+            detail=(
+                f"median_pfs ({median_pfs}) exceeds median_os ({median_os}); "
+                "progression precedes death"
+            ),
+        )
+    ]
+
+
+# ---- Entry points ------------------------------------------------------
+
+
+def check_arm(arm: dict) -> list[DeterministicViolation]:
+    """Return every deterministic violation on one extracted arm record."""
+    values = _extracted_values(arm)
+    violations = _check_identity(arm)
+    violations.extend(_check_formats(values))
+    violations.extend(_check_ordering(values, _SUBSET_PAIRS, _RULE_RESPONSE_ORDERING))
+    violations.extend(_check_ordering(values, _AE_SUBSET_PAIRS, _RULE_AE_SUBSET))
+    violations.extend(_check_ci_brackets_hr(values))
+    violations.extend(_check_rate_curves(values))
+    violations.extend(_check_pfs_os_ordering(values))
+    return violations
+
+
+def is_droppable(violations: list[DeterministicViolation]) -> bool:
+    """Whether the arm must be discarded before the judge is asked about it."""
+    return any(v.severity == DROP for v in violations)
+
+
+def violation_dict(violation: DeterministicViolation) -> dict:
+    """Serialise a violation for the JSON output files."""
+    return {
+        "field": violation.field,
+        "rule": violation.rule,
+        "severity": violation.severity,
+        "detail": violation.detail,
+    }

--- a/melanoma/tests/test_gemini_streaming.py
+++ b/melanoma/tests/test_gemini_streaming.py
@@ -1,0 +1,132 @@
+"""Tests for streaming structured generation.
+
+Non-streaming `generate_content` buffers the whole generation server-side, so
+the client's read timeout measures total generation time. A long judge response
+(the results validator emits ~3k completion tokens) blows the 90s budget and
+retrying at the same budget fails identically - Batch-I_22 timed out twice.
+
+Streaming makes the same timeout measure the gap *between* chunks, which is what
+it was meant to bound: a stalled socket still dies, a long generation completes.
+`GenerateContentResponse.parsed` is documented as unavailable for streaming, so
+the accumulated text must be parsed by the existing JSON path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from src.infrastructure.gemini_service import GeminiLLMService
+
+
+class _DummySchema(BaseModel):
+    answer: str
+
+
+def _chunk(text: str | None, usage: Any = None) -> MagicMock:
+    chunk = MagicMock()
+    chunk.text = text
+    chunk.usage_metadata = usage
+    return chunk
+
+
+def _service(cost_calculator: Any = None) -> GeminiLLMService:
+    svc = GeminiLLMService(api_key="test-key", cost_calculator=cost_calculator)
+    svc._client = MagicMock()
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_structured_generation_streams_and_reassembles_split_json() -> None:
+    """JSON split across chunks is concatenated before parsing."""
+    svc = _service()
+    chunks = [_chunk('{"ans'), _chunk('wer": "st'), _chunk('reamed"}')]
+    svc._client.models.generate_content_stream.return_value = iter(chunks)
+
+    result = await svc.generate_structured("PROMPT", response_schema=_DummySchema)
+
+    assert result.answer == "streamed"
+    svc._client.models.generate_content_stream.assert_called_once()
+    svc._client.models.generate_content.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_structured_generation_skips_textless_chunks() -> None:
+    """Chunks carrying no text (e.g. a trailing usage-only chunk) are ignored."""
+    svc = _service()
+    chunks = [_chunk('{"answer":'), _chunk(None), _chunk(' "ok"}'), _chunk("")]
+    svc._client.models.generate_content_stream.return_value = iter(chunks)
+
+    result = await svc.generate_structured("PROMPT", response_schema=_DummySchema)
+
+    assert result.answer == "ok"
+
+
+@pytest.mark.asyncio
+async def test_usage_metadata_from_final_chunk_is_recorded() -> None:
+    """Token accounting survives streaming - usage arrives on the last chunk."""
+    cost_calculator = MagicMock()
+    svc = _service(cost_calculator)
+    usage = MagicMock(prompt_token_count=1200, candidates_token_count=340)
+    chunks = [
+        _chunk('{"answer": "ok"}', usage=None),
+        _chunk(None, usage=usage),
+    ]
+    svc._client.models.generate_content_stream.return_value = iter(chunks)
+
+    await svc.generate_structured("PROMPT", response_schema=_DummySchema)
+
+    cost_calculator.record_api_call.assert_called_once()
+    kwargs = cost_calculator.record_api_call.call_args.kwargs
+    assert kwargs["prompt_tokens"] == 1200
+    assert kwargs["completion_tokens"] == 340
+    assert kwargs["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_truncated_json_is_repaired() -> None:
+    """A stream cut short still goes through the existing JSON repair path."""
+    svc = _service()
+    svc._client.models.generate_content_stream.return_value = iter(
+        [_chunk('{"answer": "cut off"')]
+    )
+
+    result = await svc.generate_structured("PROMPT", response_schema=_DummySchema)
+
+    assert result.answer == "cut off"
+
+
+@pytest.mark.asyncio
+async def test_stream_error_is_retried_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mid-stream transient failure retries the whole call."""
+    slept: list[float] = []
+
+    async def _no_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    monkeypatch.setattr("src.infrastructure.gemini_service.asyncio.sleep", _no_sleep)
+
+    svc = _service()
+    calls: list[int] = []
+
+    def _stream(**_kwargs: Any) -> Iterator[MagicMock]:
+        calls.append(1)
+        if len(calls) == 1:
+            raise Exception("504 DEADLINE_EXCEEDED")
+        return iter([_chunk('{"answer": "second"}')])
+
+    svc._client.models.generate_content_stream.side_effect = _stream
+
+    result = await svc.generate_structured("PROMPT", response_schema=_DummySchema)
+
+    assert result.answer == "second"
+    assert len(calls) == 2
+    # Backoff must not sit on the old 60s floor - commit 476fd77 shrank it for
+    # generate_response but left the structured path untouched.
+    assert slept and slept[0] <= 30.0

--- a/melanoma/tests/test_results_deterministic_validator.py
+++ b/melanoma/tests/test_results_deterministic_validator.py
@@ -1,0 +1,250 @@
+"""Tests for the deterministic (no-LLM) pre-pass over an extracted arm.
+
+Every rule gets a clean case and a violating case. The clean cases matter as much
+as the violations: a validator that flags correct data floods the HITL queue and
+gets ignored.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.infrastructure.results_deterministic_validator import (
+    DROP,
+    FLAG,
+    check_arm,
+    is_droppable,
+)
+
+
+def _arm(**attributes: Any) -> dict:
+    """Build an arm record in the shape the extraction pipelines emit."""
+    return {
+        "arm_id": "arm_1",
+        "arm_name": "Pembrolizumab",
+        "generic_name": "Pembrolizumab",
+        "patient_count": 100,
+        "attributes": {
+            name: {"value": value, "confidence": 0.8}
+            for name, value in attributes.items()
+        },
+    }
+
+
+def _rules(violations: list) -> set[str]:
+    return {v.rule for v in violations}
+
+
+def _fields(violations: list) -> set[str]:
+    return {v.field for v in violations}
+
+
+# ---------------------------------------------------------------------------
+# Clean records
+# ---------------------------------------------------------------------------
+
+
+def test_a_clean_arm_has_no_violations() -> None:
+    arm = _arm(
+        nct_number="NCT03005782",
+        objective_response_rate="61.2",
+        complete_response="12.2",
+        disease_control_rate="80.0",
+        median_pfs="15.3",
+        median_os="NR",
+        hr_pfs="0.81",
+        ci_hr_pfs="0.67-0.97",
+        p_value_pfs="0.001",
+        pfs_rate_12m="56",
+        pfs_rate_24m="42",
+        ae="95.0",
+        grade_3_plus_ae="43.9",
+    )
+
+    assert check_arm(arm) == []
+
+
+def test_empty_and_not_found_sentinels_are_not_violations() -> None:
+    arm = _arm(
+        median_pfs="Not found",
+        hr_os="",
+        ci_hr_os="N/A",
+        objective_response_rate=None,
+    )
+
+    assert check_arm(arm) == []
+
+
+def test_nr_is_a_value_for_medians_but_not_for_a_hazard_ratio() -> None:
+    assert check_arm(_arm(median_os="NR")) == []
+
+    assert "value_format" in _rules(check_arm(_arm(hr_os="NR")))
+
+
+# ---------------------------------------------------------------------------
+# Atomic format rules (delegated to value_validator)
+# ---------------------------------------------------------------------------
+
+
+def test_a_malformed_hazard_ratio_is_flagged() -> None:
+    violations = check_arm(_arm(hr_pfs="zero point eight"))
+
+    assert _rules(violations) == {"value_format"}
+    assert _fields(violations) == {"hr_pfs"}
+    assert violations[0].severity == FLAG
+
+
+def test_a_percentage_above_one_hundred_is_flagged() -> None:
+    violations = check_arm(_arm(objective_response_rate="150"))
+
+    assert _rules(violations) == {"value_format"}
+
+
+def test_a_malformed_nct_is_flagged_but_never_drops_the_arm() -> None:
+    """The doc_id keys this pipeline, not the NCT - a bad NCT must not discard
+    otherwise-good efficacy data."""
+    violations = check_arm(_arm(nct_number="NCT123"))
+
+    assert _rules(violations) == {"value_format"}
+    assert not is_droppable(violations)
+
+
+# ---------------------------------------------------------------------------
+# Identity rules (the only droppable class)
+# ---------------------------------------------------------------------------
+
+
+def test_an_arm_with_no_name_at_all_is_droppable() -> None:
+    arm = _arm()
+    arm["arm_name"] = ""
+    arm["generic_name"] = None
+
+    violations = check_arm(arm)
+
+    assert _rules(violations) == {"arm_identity"}
+    assert violations[0].severity == DROP
+    assert is_droppable(violations)
+
+
+def test_a_generic_name_alone_identifies_the_arm() -> None:
+    arm = _arm()
+    arm["arm_name"] = ""
+
+    assert check_arm(arm) == []
+
+
+def test_a_non_positive_patient_count_is_droppable() -> None:
+    arm = _arm()
+    arm["patient_count"] = 0
+
+    violations = check_arm(arm)
+
+    assert _rules(violations) == {"patient_count"}
+    assert is_droppable(violations)
+
+
+def test_a_missing_patient_count_is_not_a_violation() -> None:
+    arm = _arm()
+    arm["patient_count"] = None
+
+    assert check_arm(arm) == []
+
+
+# ---------------------------------------------------------------------------
+# Cross-field consistency rules
+# ---------------------------------------------------------------------------
+
+
+def test_complete_response_above_objective_response_rate_is_flagged() -> None:
+    violations = check_arm(_arm(complete_response="40", objective_response_rate="30"))
+
+    assert _rules(violations) == {"response_ordering"}
+    assert not is_droppable(violations)
+
+
+def test_objective_response_rate_above_disease_control_rate_is_flagged() -> None:
+    violations = check_arm(
+        _arm(objective_response_rate="70", disease_control_rate="60")
+    )
+
+    assert _rules(violations) == {"response_ordering"}
+
+
+def test_grade_3_plus_above_its_all_grade_total_is_flagged() -> None:
+    violations = check_arm(_arm(ae="40", grade_3_plus_ae="60"))
+
+    assert _rules(violations) == {"ae_subset"}
+    assert _fields(violations) == {"grade_3_plus_ae"}
+
+
+def test_a_single_grade_above_its_grade_3_plus_total_is_flagged() -> None:
+    violations = check_arm(_arm(grade_3_plus_trae="20", grade_4_trae="35"))
+
+    assert _rules(violations) == {"ae_subset"}
+
+
+def test_a_confidence_interval_that_excludes_its_hazard_ratio_is_flagged() -> None:
+    violations = check_arm(_arm(hr_os="0.50", ci_hr_os="0.67-0.97"))
+
+    assert _rules(violations) == {"ci_brackets_hr"}
+    assert _fields(violations) == {"ci_hr_os"}
+
+
+def test_a_confidence_interval_containing_its_hazard_ratio_is_clean() -> None:
+    assert check_arm(_arm(hr_os="0.82", ci_hr_os="0.67-1.02")) == []
+
+
+def test_a_rising_survival_rate_curve_is_flagged() -> None:
+    """A survival rate cannot increase with time - later timepoints are subsets."""
+    violations = check_arm(_arm(os_rate_12m="50", os_rate_24m="65"))
+
+    assert _rules(violations) == {"rate_monotonicity"}
+    assert _fields(violations) == {"os_rate_24m"}
+
+
+def test_a_falling_survival_rate_curve_is_clean() -> None:
+    arm = _arm(
+        os_rate_6m="90",
+        os_rate_12m="80",
+        os_rate_24m="61.8",
+        os_rate_36m="54.1",
+        os_rate_48m="51.5",
+    )
+
+    assert check_arm(arm) == []
+
+
+def test_a_rate_curve_with_gaps_compares_only_present_timepoints() -> None:
+    assert check_arm(_arm(pfs_rate_6m="80", pfs_rate_48m="20")) == []
+    assert "rate_monotonicity" in _rules(
+        check_arm(_arm(pfs_rate_6m="20", pfs_rate_48m="80"))
+    )
+
+
+def test_median_pfs_longer_than_median_os_is_flagged() -> None:
+    violations = check_arm(_arm(median_pfs="30", median_os="20"))
+
+    assert _rules(violations) == {"pfs_os_ordering"}
+
+
+def test_median_pfs_is_not_compared_against_an_unreached_median_os() -> None:
+    assert check_arm(_arm(median_pfs="30", median_os="NR")) == []
+
+
+# ---------------------------------------------------------------------------
+# is_droppable
+# ---------------------------------------------------------------------------
+
+
+def test_is_droppable_is_false_for_an_empty_violation_list() -> None:
+    assert not is_droppable([])
+
+
+def test_is_droppable_is_true_only_when_a_drop_severity_is_present() -> None:
+    arm = _arm(hr_pfs="bad")
+    arm["patient_count"] = -5
+
+    violations = check_arm(arm)
+
+    assert {v.severity for v in violations} == {FLAG, DROP}
+    assert is_droppable(violations)

--- a/melanoma/tests/test_results_source_loader.py
+++ b/melanoma/tests/test_results_source_loader.py
@@ -1,0 +1,215 @@
+"""Tests for the abstract / publication source loaders.
+
+The abstract loader must reproduce the extractor's document split exactly - if it
+slices differently, the judge grades a different text than the one the values came
+from. The final assertions therefore run against the real corpus rather than a
+hand-written fixture.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from src.infrastructure.document_source_loader import (
+    AbstractSourceLoader,
+    PublicationSourceLoader,
+    SourceDocumentNotFoundError,
+)
+
+_MELANOMA_ROOT = Path(__file__).resolve().parent.parent
+_ASCO_DIR = _MELANOMA_ROOT / "data" / "postprocessed" / "ASCO_Abstracts"
+_ESMO_DIR = _MELANOMA_ROOT / "data" / "postprocessed" / "ESMO_Abstracts"
+_PUBLICATIONS_DIR = _MELANOMA_ROOT / "data" / "postprocessed" / "Publications"
+
+_ABSTRACT_MARKDOWN = """\
+### Abstract ID: 9501
+
+#### Title:
+First trial.
+
+#### Results:
+ORR was 61.2%.
+
+---
+
+### Abstract ID: 9502
+
+#### Title:
+Second trial.
+
+#### Results:
+Median PFS was 10.2 months.
+"""
+
+
+@pytest.fixture()
+def asco_dir(tmp_path: Path) -> Path:
+    conference_dir = tmp_path / "ASCO_Abstracts"
+    conference_dir.mkdir()
+    (conference_dir / "ASCO_2023.md").write_text(_ABSTRACT_MARKDOWN, encoding="utf-8")
+    return conference_dir
+
+
+# ---------------------------------------------------------------------------
+# PublicationSourceLoader
+# ---------------------------------------------------------------------------
+
+
+def test_publication_loader_reads_the_matching_markdown_file(tmp_path: Path) -> None:
+    (tmp_path / "Batch-I_22.md").write_text("# Study\n\nORR 45%.", encoding="utf-8")
+    loader = PublicationSourceLoader(tmp_path)
+
+    doc = loader.load("Batch-I_22")
+
+    assert doc.doc_id == "Batch-I_22"
+    assert doc.text == "# Study\n\nORR 45%."
+    assert doc.path == tmp_path / "Batch-I_22.md"
+
+
+def test_publication_loader_hashes_the_exact_text_it_returns(tmp_path: Path) -> None:
+    (tmp_path / "Batch-I_22.md").write_text("# Study", encoding="utf-8")
+
+    doc = PublicationSourceLoader(tmp_path).load("Batch-I_22")
+
+    assert doc.sha256 == hashlib.sha256(b"# Study").hexdigest()
+
+
+def test_publication_loader_raises_for_an_unknown_doc_id(tmp_path: Path) -> None:
+    loader = PublicationSourceLoader(tmp_path)
+
+    with pytest.raises(SourceDocumentNotFoundError, match="Nope"):
+        loader.load("Nope")
+
+
+def test_publication_loader_lists_available_ids(tmp_path: Path) -> None:
+    (tmp_path / "Batch-I_1.md").write_text("a", encoding="utf-8")
+    (tmp_path / "Batch-II_2.md").write_text("b", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("ignored", encoding="utf-8")
+
+    assert PublicationSourceLoader(tmp_path).available_ids() == {
+        "Batch-I_1",
+        "Batch-II_2",
+    }
+
+
+# ---------------------------------------------------------------------------
+# AbstractSourceLoader
+# ---------------------------------------------------------------------------
+
+
+def test_abstract_loader_keys_documents_by_conference_year_and_id(
+    asco_dir: Path,
+) -> None:
+    loader = AbstractSourceLoader({"ASCO": asco_dir})
+
+    assert loader.available_ids() == {"ASCO_2023_9501", "ASCO_2023_9502"}
+
+
+def test_abstract_loader_restores_the_header_stripped_by_the_split(
+    asco_dir: Path,
+) -> None:
+    """The extractor prepends '### Abstract ID:' back onto each block; so must we."""
+    doc = AbstractSourceLoader({"ASCO": asco_dir}).load("ASCO_2023_9501")
+
+    assert doc.text.startswith("### Abstract ID: 9501")
+    assert "ORR was 61.2%." in doc.text
+
+
+def test_abstract_loader_slices_only_the_requested_abstract(asco_dir: Path) -> None:
+    doc = AbstractSourceLoader({"ASCO": asco_dir}).load("ASCO_2023_9501")
+
+    assert "Second trial." not in doc.text
+    assert "9502" not in doc.text
+
+
+def test_abstract_loader_hashes_the_slice_not_the_whole_year_file(
+    asco_dir: Path,
+) -> None:
+    loader = AbstractSourceLoader({"ASCO": asco_dir})
+    first = loader.load("ASCO_2023_9501")
+    second = loader.load("ASCO_2023_9502")
+    whole_file = hashlib.sha256((asco_dir / "ASCO_2023.md").read_bytes()).hexdigest()
+
+    assert first.sha256 != second.sha256
+    assert first.sha256 != whole_file
+    assert first.sha256 == hashlib.sha256(first.text.encode("utf-8")).hexdigest()
+
+
+def test_abstract_loader_falls_back_to_a_positional_id_for_an_empty_block(
+    tmp_path: Path,
+) -> None:
+    """Mirrors the extractor's `f"{idx+1:03d}"` fallback for an empty block."""
+    conference_dir = tmp_path / "ESMO_Abstracts"
+    conference_dir.mkdir()
+    (conference_dir / "ESMO_2021.md").write_text(
+        "### Abstract ID:\n\n### Abstract ID: 42\n\n#### Title:\nNumbered.\n",
+        encoding="utf-8",
+    )
+
+    loader = AbstractSourceLoader({"ESMO": conference_dir})
+
+    assert loader.available_ids() == {"ESMO_2021_001", "ESMO_2021_42"}
+
+
+def test_abstract_loader_takes_the_id_from_the_first_non_blank_line(
+    tmp_path: Path,
+) -> None:
+    """The extractor strips the block before reading line 1, so blank lines after
+    the header are skipped - and a bare header inherits the next line as its id.
+    Reproduced deliberately: parity with extraction beats a tidier rule."""
+    conference_dir = tmp_path / "ESMO_Abstracts"
+    conference_dir.mkdir()
+    (conference_dir / "ESMO_2021.md").write_text(
+        "### Abstract ID:\n\n#### Title:\nUnnumbered.\n", encoding="utf-8"
+    )
+
+    loader = AbstractSourceLoader({"ESMO": conference_dir})
+
+    assert loader.available_ids() == {"ESMO_2021_#### Title:"}
+
+
+def test_abstract_loader_raises_for_an_unknown_doc_id(asco_dir: Path) -> None:
+    loader = AbstractSourceLoader({"ASCO": asco_dir})
+
+    with pytest.raises(SourceDocumentNotFoundError, match="ASCO_2023_9999"):
+        loader.load("ASCO_2023_9999")
+
+
+def test_abstract_loader_ignores_directories_that_do_not_exist(tmp_path: Path) -> None:
+    loader = AbstractSourceLoader({"ASCO": tmp_path / "missing"})
+
+    assert loader.available_ids() == set()
+
+
+# ---------------------------------------------------------------------------
+# Against the real corpus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _ASCO_DIR.exists(), reason="abstract corpus not present")
+def test_abstract_loader_split_matches_the_extraction_pipeline_on_real_data() -> None:
+    """Re-implements run_abstract_pipeline's split and asserts loader parity."""
+    raw = (_ASCO_DIR / "ASCO_2023.md").read_text(encoding="utf-8")
+    expected = {
+        f"ASCO_2023_{block.strip().split(chr(10))[0].strip() or f'{idx + 1:03d}'}"
+        for idx, block in enumerate(raw.split("### Abstract ID:")[1:])
+    }
+
+    loader = AbstractSourceLoader({"ASCO": _ASCO_DIR, "ESMO": _ESMO_DIR})
+    asco_2023 = {i for i in loader.available_ids() if i.startswith("ASCO_2023_")}
+
+    assert asco_2023 == expected
+    assert len(asco_2023) == 110
+
+
+@pytest.mark.skipif(
+    not _PUBLICATIONS_DIR.exists(), reason="publication corpus not present"
+)
+def test_publication_loader_resolves_a_known_gold_set_document() -> None:
+    doc = PublicationSourceLoader(_PUBLICATIONS_DIR).load("Batch-I_22")
+
+    assert len(doc.text) > 1000
+    assert doc.sha256 == hashlib.sha256(doc.text.encode("utf-8")).hexdigest()

--- a/melanoma/tests/test_results_validation_prompts.py
+++ b/melanoma/tests/test_results_validation_prompts.py
@@ -1,0 +1,207 @@
+"""Tests for the judge's attribute grouping and prompt assembly.
+
+The partition tests are the important ones: an attribute that belongs to no group
+is never audited, and the omission is silent. These assert coverage is total and
+that every exclusion is deliberate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.domain.extraction_models import (
+    ABSTRACT_ATTRIBUTES,
+    PUBLICATION_ATTRIBUTES,
+    AttributeType,
+)
+from src.domain.results_validation_models import AttributeGroup
+from src.domain.results_validation_prompts import (
+    FILE_PATH_SOURCED_ATTRIBUTES,
+    GROUP_TO_ATTRIBUTES,
+    TRIALS_PIPELINE_ATTRIBUTES,
+    UNAUDITED_ATTRIBUTES,
+    allowed_fields_for,
+    build_group_prompt,
+    group_for_field,
+)
+
+_ARMS_JSON = '{"arm_1": {"median_pfs": "15.3"}}'
+_SOURCE = "Median PFS was 15.3 months."
+
+
+# ---------------------------------------------------------------------------
+# Partition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "attributes"),
+    [("abstract", ABSTRACT_ATTRIBUTES), ("publication", PUBLICATION_ATTRIBUTES)],
+)
+def test_groups_plus_exclusions_cover_every_extracted_attribute(
+    label: str, attributes: list[AttributeType]
+) -> None:
+    grouped: set[AttributeType] = set()
+    for members in GROUP_TO_ATTRIBUTES.values():
+        grouped |= set(members)
+
+    uncovered = set(attributes) - grouped - UNAUDITED_ATTRIBUTES
+
+    assert uncovered == set(), f"{label} attributes audited by no group: {uncovered}"
+
+
+def test_groups_are_mutually_disjoint() -> None:
+    seen: set[AttributeType] = set()
+    for group, members in GROUP_TO_ATTRIBUTES.items():
+        overlap = seen & set(members)
+        assert overlap == set(), f"{group} repeats {overlap}"
+        seen |= set(members)
+
+
+def test_excluded_attributes_are_only_the_file_path_sourced_ones() -> None:
+    """These are read from the filename, not the document body - grading them
+    against the text would manufacture false failures."""
+    assert {a.value for a in FILE_PATH_SOURCED_ATTRIBUTES} == {
+        "conference",
+        "published_year",
+        "pdf_number",
+    }
+
+
+def test_modality_and_target_are_left_to_the_trials_validation_pipeline() -> None:
+    """They are drug classifications, not values stated in the document body."""
+    assert {a.value for a in TRIALS_PIPELINE_ATTRIBUTES} == {"modality", "target"}
+    assert group_for_field("modality") is None
+    assert group_for_field("target") is None
+
+
+def test_no_excluded_attribute_is_also_grouped() -> None:
+    for members in GROUP_TO_ATTRIBUTES.values():
+        assert not (set(members) & UNAUDITED_ATTRIBUTES)
+
+
+def test_every_group_has_at_least_one_attribute() -> None:
+    for group in AttributeGroup:
+        assert GROUP_TO_ATTRIBUTES[group], f"{group} is empty"
+
+
+# ---------------------------------------------------------------------------
+# Lookups
+# ---------------------------------------------------------------------------
+
+
+def test_group_for_field_routes_known_attributes() -> None:
+    assert group_for_field("nct_number") is AttributeGroup.IDENTIFICATION
+    assert group_for_field("median_pfs") is AttributeGroup.EFFICACY
+    assert group_for_field("grade_3_plus_trae") is AttributeGroup.SAFETY
+
+
+def test_group_for_field_returns_none_for_unaudited_and_unknown_fields() -> None:
+    assert group_for_field("conference") is None
+    assert group_for_field("not_an_attribute") is None
+
+
+def test_unfamilied_document_attributes_are_audited_as_identification() -> None:
+    for field in ("number_of_patients", "publication_name", "publication_year"):
+        assert group_for_field(field) is AttributeGroup.IDENTIFICATION
+
+
+def test_allowed_fields_are_scoped_to_the_document_type() -> None:
+    abstract_fields = allowed_fields_for(AttributeGroup.IDENTIFICATION, "abstract")
+    publication_fields = allowed_fields_for(
+        AttributeGroup.IDENTIFICATION, "publication"
+    )
+
+    assert "abstract_number" in abstract_fields
+    assert "publication_name" not in abstract_fields
+    assert "publication_name" in publication_fields
+
+
+def test_allowed_fields_rejects_an_unknown_document_type() -> None:
+    with pytest.raises(ValueError, match="poster"):
+        allowed_fields_for(AttributeGroup.EFFICACY, "poster")
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_embeds_the_source_the_candidates_and_the_allowed_fields() -> None:
+    prompt = build_group_prompt(
+        group=AttributeGroup.EFFICACY,
+        doc_type="publication",
+        source_text=_SOURCE,
+        arms_json=_ARMS_JSON,
+    )
+
+    assert _SOURCE in prompt
+    assert _ARMS_JSON in prompt
+    assert "median_pfs" in prompt
+
+
+def test_prompt_carries_the_extractors_own_transform_rules() -> None:
+    """The judge must know the extractor was told to strip '%' and sum G3+G4+G5,
+    otherwise it fails correct values for not matching the source verbatim."""
+    prompt = build_group_prompt(
+        group=AttributeGroup.SAFETY,
+        doc_type="publication",
+        source_text=_SOURCE,
+        arms_json=_ARMS_JSON,
+    )
+
+    assert "no % symbol" in prompt
+    assert "sum Grade 3% + Grade 4% + Grade 5%" in prompt
+
+
+def test_prompt_states_that_not_found_is_a_claim_to_be_tested() -> None:
+    prompt = build_group_prompt(
+        group=AttributeGroup.EFFICACY,
+        doc_type="publication",
+        source_text=_SOURCE,
+        arms_json=_ARMS_JSON,
+    )
+
+    assert "Not found" in prompt
+    assert "missed_values" in prompt
+
+
+def test_prompt_leaves_no_unfilled_template_placeholder() -> None:
+    """The family prompts contain JSON examples, so a bare '{' proves nothing -
+    check for the specific placeholder names the template substitutes."""
+    placeholders = [
+        "{arms_block}",
+        "{group}",
+        "{doc_type}",
+        "{arm_count}",
+        "{extraction_rules}",
+        "{family_instructions}",
+        "{allowed_fields}",
+        "{empty_tokens}",
+        "{source_text}",
+        "{arms_json}",
+    ]
+
+    for group in AttributeGroup:
+        prompt = build_group_prompt(
+            group=group,
+            doc_type="publication",
+            source_text=_SOURCE,
+            arms_json=_ARMS_JSON,
+        )
+
+        for placeholder in placeholders:
+            assert placeholder not in prompt
+
+
+def test_each_group_prompt_names_only_its_own_attributes_as_allowed() -> None:
+    prompt = build_group_prompt(
+        group=AttributeGroup.IDENTIFICATION,
+        doc_type="publication",
+        source_text=_SOURCE,
+        arms_json=_ARMS_JSON,
+    )
+    allowed_block = prompt.split("## Attributes you may report")[1].split("##")[0]
+
+    assert "nct_number" in allowed_block
+    assert "grade_3_plus_trae" not in allowed_block

--- a/melanoma/tests/test_results_validation_service.py
+++ b/melanoma/tests/test_results_validation_service.py
@@ -15,6 +15,7 @@ import pytest
 from src.app.results_validation_service import (
     ResultsValidationConfig,
     ResultsValidationService,
+    ResultsValidationWriter,
     RouteOutcome,
     effective_status,
     route_arm,
@@ -550,3 +551,80 @@ def test_the_recall_report_groups_missed_values_by_field(tmp_path: Path) -> None
     missed = json.loads((tmp_path / "validation" / "missed_values.json").read_text())
 
     assert missed == {"total": 0, "by_field": {}}
+
+
+# ---------------------------------------------------------------------------
+# cost report accumulation across resumes
+# ---------------------------------------------------------------------------
+
+
+def _cost_totals(tmp_path: Path) -> dict:
+    report = json.loads((tmp_path / "validation" / "cost_report.json").read_text())
+    return report["summary"]
+
+
+def test_a_resumed_run_adds_its_spend_to_the_previous_report(tmp_path: Path) -> None:
+    """cost_report.json is rewritten every run. Without carrying the previous
+    spend forward, a resume pass makes a $14 cohort look like it cost $0.61."""
+    calc_one = CostCalculator()
+    calc_one.record_api_call(
+        prompt_tokens=1000, completion_tokens=100, model="stub", operation="a"
+    )
+    writer = ResultsValidationWriter(tmp_path / "validation")
+    writer.write_cost_report(calc_one)
+    first = _cost_totals(tmp_path)
+    assert first["total_requests"] == 1
+
+    calc_two = CostCalculator()
+    calc_two.record_api_call(
+        prompt_tokens=2000, completion_tokens=200, model="stub", operation="b"
+    )
+    resumed = ResultsValidationWriter(tmp_path / "validation", carry_forward_cost=True)
+    resumed.write_cost_report(calc_two)
+
+    total = _cost_totals(tmp_path)
+    assert total["total_requests"] == 2
+    assert total["total_prompt_tokens"] == 3000
+    assert total["total_completion_tokens"] == 300
+    assert total["total_cost"] == pytest.approx(
+        first["total_cost"] + calc_two.get_summary().total_cost
+    )
+
+
+def test_repeated_writes_within_one_run_do_not_double_count(tmp_path: Path) -> None:
+    """write_cost_report runs after every document; the carried baseline must be
+    snapshotted once, not re-merged on each incremental write."""
+    seed = CostCalculator()
+    seed.record_api_call(
+        prompt_tokens=1000, completion_tokens=100, model="stub", operation="a"
+    )
+    ResultsValidationWriter(tmp_path / "validation").write_cost_report(seed)
+
+    calc = CostCalculator()
+    writer = ResultsValidationWriter(tmp_path / "validation", carry_forward_cost=True)
+    for _ in range(3):
+        calc.record_api_call(
+            prompt_tokens=10, completion_tokens=1, model="stub", operation="b"
+        )
+        writer.write_cost_report(calc)
+
+    total = _cost_totals(tmp_path)
+    assert total["total_requests"] == 4
+    assert total["total_prompt_tokens"] == 1030
+
+
+def test_a_fresh_run_does_not_inherit_a_previous_cost_report(tmp_path: Path) -> None:
+    """--no-resume discards the previous results, so its spend must not be carried."""
+    seed = CostCalculator()
+    seed.record_api_call(
+        prompt_tokens=1000, completion_tokens=100, model="stub", operation="a"
+    )
+    ResultsValidationWriter(tmp_path / "validation").write_cost_report(seed)
+
+    calc = CostCalculator()
+    calc.record_api_call(
+        prompt_tokens=5, completion_tokens=1, model="stub", operation="b"
+    )
+    ResultsValidationWriter(tmp_path / "validation").write_cost_report(calc)
+
+    assert _cost_totals(tmp_path)["total_requests"] == 1

--- a/melanoma/tests/test_results_validation_service.py
+++ b/melanoma/tests/test_results_validation_service.py
@@ -126,6 +126,29 @@ def test_a_middle_dot_outside_a_number_is_not_treated_as_a_decimal_point() -> No
     assert not value_supported_by_quote("1.2", "· 1 patient · 2 patients")
 
 
+def test_an_integer_percentage_stored_as_a_float_matches_its_quote() -> None:
+    """Abstracts store whole-number percentages as '24.0' while the source prints
+    '24%'. Without this, most abstract percentages are downgraded to UNCERTAIN."""
+    assert value_supported_by_quote("24.0", "the grade 3-4 irAE rate was 24%")
+    assert value_supported_by_quote("57.0", "57% grade 3-4")
+    assert value_supported_by_quote("100.0", "toxicity occurred in 100%")
+    # The source may itself print the trailing zero.
+    assert value_supported_by_quote("24.0", "the rate was 24.0%")
+
+
+def test_a_float_value_still_must_not_match_a_longer_number() -> None:
+    """Relaxing the trailing zero must not let '24.0' be satisfied by '240'."""
+    assert not value_supported_by_quote("24.0", "240 patients were enrolled")
+    assert not value_supported_by_quote("24.0", "the rate was 24.5%")
+    assert not value_supported_by_quote("2.0", "the rate was 2.05%")
+
+
+def test_a_genuine_decimal_is_unaffected_by_the_trailing_zero_rule() -> None:
+    """'24.5' must keep matching '24.50' and must not match a bare '24'."""
+    assert value_supported_by_quote("24.5", "the rate was 24.5%")
+    assert not value_supported_by_quote("24.5", "the rate was 24%")
+
+
 def test_a_lancet_style_value_still_must_match_the_right_number() -> None:
     assert not value_supported_by_quote("11.0", "median survival was 25·1 months")
 

--- a/melanoma/tests/test_results_validation_service.py
+++ b/melanoma/tests/test_results_validation_service.py
@@ -1,0 +1,529 @@
+"""Tests for the validation service's pure decision logic.
+
+No LLM and no I/O: these cover the guards that decide whether a judge verdict is
+trustworthy, and the routing table that turns verdicts into per-arm outcomes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from src.app.results_validation_service import (
+    ResultsValidationConfig,
+    ResultsValidationService,
+    RouteOutcome,
+    effective_status,
+    route_arm,
+    value_supported_by_quote,
+)
+from src.domain.results_validation_models import (
+    ArmFieldEvaluation,
+    AttributeGroup,
+    DerivationKind,
+    GroupVerdict,
+    MissedValue,
+    ValidationDecision,
+    ValidationFieldStatus,
+)
+from src.infrastructure.cost_calculator import CostCalculator
+from src.infrastructure.document_source_loader import (
+    DocumentSourceLoader,
+    SourceDocument,
+)
+from src.infrastructure.results_deterministic_validator import (
+    DROP,
+    FLAG,
+    DeterministicViolation,
+)
+
+_SOURCE = (
+    "Median PFS was 14.7 months (95% CI 10.2-19.8) in the experimental arm.\n"
+    "Grade 3 events occurred in 12.0%, grade 4 in 3.0% and grade 5 in 1.0%.\n"
+    "12-month PFS rate was 56%."
+)
+
+
+def _evaluation(**overrides: object) -> ArmFieldEvaluation:
+    payload: dict = {
+        "arm_id": "arm_1",
+        "field_name": "median_pfs",
+        "extracted_value": "14.7",
+        "status": ValidationFieldStatus.PASS,
+        "source_evidence_quote": "Median PFS was 14.7 months",
+        "derivation": DerivationKind.UNIT_STRIPPED,
+        "arm_attribution_ok": True,
+    }
+    payload.update(overrides)
+    return ArmFieldEvaluation(**payload)  # type: ignore[arg-type]
+
+
+def _route(
+    evaluations: list[ArmFieldEvaluation] | None = None,
+    *,
+    missed_values: list[MissedValue] | None = None,
+    violations: list[DeterministicViolation] | None = None,
+    apply_fixes: bool = False,
+    validation_score: float = 0.9,
+) -> RouteOutcome:
+    return route_arm(
+        evaluations=evaluations if evaluations is not None else [_evaluation()],
+        missed_values=missed_values or [],
+        violations=violations or [],
+        source_text=_SOURCE,
+        validation_score=validation_score,
+        apply_fixes=apply_fixes,
+        score_threshold=0.75,
+    )
+
+
+# ---------------------------------------------------------------------------
+# value_supported_by_quote
+# ---------------------------------------------------------------------------
+
+
+def test_a_value_present_in_its_quote_is_supported() -> None:
+    assert value_supported_by_quote("14.7", "Median PFS was 14.7 months")
+
+
+def test_a_value_absent_from_its_quote_is_not_supported() -> None:
+    assert not value_supported_by_quote("22.9", "Median PFS was 14.7 months")
+
+
+def test_a_percentage_matches_its_quote_without_the_symbol() -> None:
+    assert value_supported_by_quote("56", "12-month PFS rate was 56%")
+
+
+def test_a_confidence_interval_matches_across_dash_styles() -> None:
+    assert value_supported_by_quote("10.2-19.8", "95% CI 10.2–19.8")
+
+
+def test_a_value_does_not_match_a_longer_number_containing_it() -> None:
+    """'56' must not be satisfied by '561' or '5.6'."""
+    assert not value_supported_by_quote("56", "the total was 561 patients")
+    assert not value_supported_by_quote("56", "the rate was 5.6%")
+
+
+def test_an_empty_quote_supports_nothing() -> None:
+    assert not value_supported_by_quote("14.7", "")
+
+
+def test_a_value_matches_a_lancet_style_middle_dot_decimal() -> None:
+    """The Lancet and JCO print decimals as '11·0'. Without this, every correct
+    numeric value in those journals is downgraded to UNCERTAIN."""
+    assert value_supported_by_quote(
+        "11.0", "median progression-free survival was 11·0 months"
+    )
+    assert value_supported_by_quote("0.67", "HR 0·67, 95% CI 0·53-0·84")
+    assert value_supported_by_quote("0.53-0.84", "HR 0·67, 95% CI 0·53–0·84")
+
+
+def test_a_middle_dot_outside_a_number_is_not_treated_as_a_decimal_point() -> None:
+    """Markdown bullets must not be rewritten into digits."""
+    assert not value_supported_by_quote("1.2", "· 1 patient · 2 patients")
+
+
+def test_a_lancet_style_value_still_must_match_the_right_number() -> None:
+    assert not value_supported_by_quote("11.0", "median survival was 25·1 months")
+
+
+def test_a_confidence_interval_matches_a_quote_written_with_to() -> None:
+    """Sources write CIs as '0.43 to 0.76'; the extractor normalises to a dash."""
+    assert value_supported_by_quote("0.43-0.76", "95% CI, 0.43 to 0.76")
+
+
+def test_a_non_numeric_value_is_supported_by_any_grounded_quote() -> None:
+    """'NR' is written 'not reached' in prose - a numeric containment check
+    cannot express the relationship, so it must not veto the value."""
+    assert value_supported_by_quote("NR", "median duration of response was not reached")
+    assert value_supported_by_quote("Significant", "the difference was significant")
+
+
+def test_a_numeric_value_is_still_checked_when_mixed_with_text() -> None:
+    assert not value_supported_by_quote("14.7", "median was not reached")
+
+
+# ---------------------------------------------------------------------------
+# effective_status - the anti-hallucination guards
+# ---------------------------------------------------------------------------
+
+
+def test_a_pass_with_a_grounded_quote_stays_a_pass() -> None:
+    assert effective_status(_evaluation(), _SOURCE) is ValidationFieldStatus.PASS
+
+
+def test_a_pass_whose_quote_is_not_in_the_source_becomes_uncertain() -> None:
+    evaluation = _evaluation(source_evidence_quote="Median PFS was 99.9 months")
+
+    assert effective_status(evaluation, _SOURCE) is ValidationFieldStatus.UNCERTAIN
+
+
+def test_a_pass_without_any_quote_becomes_uncertain() -> None:
+    assert (
+        effective_status(_evaluation(source_evidence_quote=None), _SOURCE)
+        is ValidationFieldStatus.UNCERTAIN
+    )
+
+
+def test_a_verbatim_pass_whose_value_is_absent_from_the_quote_becomes_uncertain() -> (
+    None
+):
+    evaluation = _evaluation(
+        extracted_value="22.9",
+        derivation=DerivationKind.VERBATIM,
+        source_evidence_quote="Median PFS was 14.7 months",
+    )
+
+    assert effective_status(evaluation, _SOURCE) is ValidationFieldStatus.UNCERTAIN
+
+
+def test_a_summed_pass_is_not_required_to_show_its_value_in_the_quote() -> None:
+    """Grade 3+ is 12.0 + 3.0 + 1.0; '16' appears nowhere in the source."""
+    evaluation = _evaluation(
+        field_name="grade_3_plus_ae",
+        extracted_value="16.0",
+        derivation=DerivationKind.SUMMED,
+        derivation_justification="12.0 + 3.0 + 1.0",
+        source_evidence_quote="grade 4 in 3.0% and grade 5 in 1.0%",
+    )
+
+    assert effective_status(evaluation, _SOURCE) is ValidationFieldStatus.PASS
+
+
+def test_a_computed_pass_still_needs_a_grounded_quote() -> None:
+    evaluation = _evaluation(
+        derivation=DerivationKind.COMPUTED,
+        source_evidence_quote="a phrase that is not in the document",
+    )
+
+    assert effective_status(evaluation, _SOURCE) is ValidationFieldStatus.UNCERTAIN
+
+
+def test_a_pass_with_failed_arm_attribution_becomes_a_fail() -> None:
+    evaluation = _evaluation(arm_attribution_ok=False)
+
+    assert effective_status(evaluation, _SOURCE) is ValidationFieldStatus.FAIL
+
+
+def test_a_declared_fail_stays_a_fail() -> None:
+    evaluation = _evaluation(status=ValidationFieldStatus.FAIL)
+
+    assert effective_status(evaluation, _SOURCE) is ValidationFieldStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# route_arm - advisory mode (the shipping default)
+# ---------------------------------------------------------------------------
+
+
+def test_an_arm_whose_values_all_pass_is_kept() -> None:
+    assert _route().decision is ValidationDecision.KEPT
+
+
+def test_an_arm_with_no_extracted_values_is_kept() -> None:
+    assert _route([]).decision is ValidationDecision.KEPT
+
+
+def test_a_droppable_violation_drops_the_arm() -> None:
+    violations = [
+        DeterministicViolation("arm_name", "arm_identity", DROP, "unnamed arm")
+    ]
+
+    assert _route(violations=violations).decision is ValidationDecision.DROPPED
+
+
+def test_a_droppable_violation_outranks_a_clean_judge_verdict() -> None:
+    violations = [
+        DeterministicViolation("patient_count", "patient_count", DROP, "count is 0")
+    ]
+
+    assert _route(violations=violations).decision is ValidationDecision.DROPPED
+
+
+def test_an_advisory_violation_routes_to_review() -> None:
+    violations = [
+        DeterministicViolation("hr_pfs", "value_format", FLAG, "not a decimal")
+    ]
+
+    assert _route(violations=violations).decision is ValidationDecision.HITL
+
+
+def test_a_failed_value_routes_to_review_in_advisory_mode() -> None:
+    outcome = _route([_evaluation(status=ValidationFieldStatus.FAIL)])
+
+    assert outcome.decision is ValidationDecision.HITL
+    assert outcome.applied_corrections == []
+
+
+def test_an_uncertain_value_routes_to_review() -> None:
+    outcome = _route([_evaluation(status=ValidationFieldStatus.UNCERTAIN)])
+
+    assert outcome.decision is ValidationDecision.HITL
+
+
+def test_an_ungrounded_pass_routes_to_review() -> None:
+    outcome = _route([_evaluation(source_evidence_quote="not in the document")])
+
+    assert outcome.decision is ValidationDecision.HITL
+
+
+def test_a_missed_value_routes_an_otherwise_clean_arm_to_review() -> None:
+    missed = [
+        MissedValue(
+            arm_id="arm_1",
+            field_name="pfs_rate_12m",
+            suggested_value="56",
+            source_evidence_quote="12-month PFS rate was 56%",
+        )
+    ]
+
+    assert _route(missed_values=missed).decision is ValidationDecision.HITL
+
+
+def test_advisory_mode_never_fixes_even_with_a_perfect_correction() -> None:
+    evaluation = _evaluation(
+        status=ValidationFieldStatus.FAIL,
+        corrected_value="14.7",
+        source_evidence_quote="Median PFS was 14.7 months",
+    )
+
+    outcome = _route([evaluation], validation_score=1.0)
+
+    assert outcome.decision is ValidationDecision.HITL
+    assert outcome.applied_corrections == []
+
+
+# ---------------------------------------------------------------------------
+# route_arm - gated auto-fix (off by default, enabled after calibration)
+# ---------------------------------------------------------------------------
+
+
+def test_a_grounded_correction_above_threshold_is_applied() -> None:
+    evaluation = _evaluation(
+        status=ValidationFieldStatus.FAIL,
+        extracted_value="22.9",
+        corrected_value="14.7",
+        source_evidence_quote="Median PFS was 14.7 months",
+    )
+
+    outcome = _route([evaluation], apply_fixes=True, validation_score=0.9)
+
+    assert outcome.decision is ValidationDecision.FIXED
+    assert outcome.applied_corrections == [
+        {
+            "field": "median_pfs",
+            "corrected": "14.7",
+            "evidence_quote": "Median PFS was 14.7 months",
+            "score": 0.9,
+        }
+    ]
+
+
+def test_a_correction_below_the_score_threshold_is_not_applied() -> None:
+    evaluation = _evaluation(
+        status=ValidationFieldStatus.FAIL,
+        corrected_value="14.7",
+        source_evidence_quote="Median PFS was 14.7 months",
+    )
+
+    outcome = _route([evaluation], apply_fixes=True, validation_score=0.5)
+
+    assert outcome.decision is ValidationDecision.HITL
+
+
+def test_a_correction_whose_quote_is_not_in_the_source_is_not_applied() -> None:
+    evaluation = _evaluation(
+        status=ValidationFieldStatus.FAIL,
+        corrected_value="14.7",
+        source_evidence_quote="invented supporting text",
+    )
+
+    outcome = _route([evaluation], apply_fixes=True)
+
+    assert outcome.decision is ValidationDecision.HITL
+
+
+def test_a_failure_with_no_correction_goes_to_review_rather_than_dropping_the_arm() -> (
+    None
+):
+    """One bad value among 165 must not discard an arm's good data."""
+    evaluation = _evaluation(status=ValidationFieldStatus.FAIL, corrected_value=None)
+
+    outcome = _route([evaluation], apply_fixes=True)
+
+    assert outcome.decision is ValidationDecision.HITL
+
+
+def test_uncertainty_always_needs_a_human_even_with_fixes_enabled() -> None:
+    outcome = _route(
+        [_evaluation(status=ValidationFieldStatus.UNCERTAIN)], apply_fixes=True
+    )
+
+    assert outcome.decision is ValidationDecision.HITL
+
+
+def test_a_missed_value_is_never_auto_added() -> None:
+    missed = [
+        MissedValue(
+            arm_id="arm_1",
+            field_name="pfs_rate_12m",
+            suggested_value="56",
+            source_evidence_quote="12-month PFS rate was 56%",
+        )
+    ]
+
+    outcome = _route(missed_values=missed, apply_fixes=True)
+
+    assert outcome.decision is ValidationDecision.HITL
+    assert outcome.applied_corrections == []
+
+
+@pytest.mark.parametrize("apply_fixes", [False, True])
+def test_a_droppable_violation_drops_the_arm_in_either_mode(
+    apply_fixes: bool,
+) -> None:
+    violations = [
+        DeterministicViolation("arm_name", "arm_identity", DROP, "unnamed arm")
+    ]
+
+    outcome = _route(violations=violations, apply_fixes=apply_fixes)
+
+    assert outcome.decision is ValidationDecision.DROPPED
+
+
+# ---------------------------------------------------------------------------
+# Run loop - checkpoint and derived outputs
+# ---------------------------------------------------------------------------
+
+
+class _StubLoader(DocumentSourceLoader):
+    """Serves a fixed source text for every document."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def load(self, doc_id: str) -> SourceDocument:
+        return SourceDocument(
+            doc_id=doc_id, text=self._text, sha256="deadbeef", path=Path(f"{doc_id}.md")
+        )
+
+    def available_ids(self) -> set[str]:
+        return {"pub_ok", "pub_boom"}
+
+
+class _StubJudge:
+    """Returns a clean verdict, or raises for a document under test."""
+
+    def __init__(self, failing_source: str | None = None) -> None:
+        self._failing_source = failing_source
+        self.calls = 0
+
+    async def generate_structured(self, prompt: str, **kwargs: object) -> GroupVerdict:
+        self.calls += 1
+        if self._failing_source and self._failing_source in prompt:
+            raise TimeoutError("Read timed out.")
+        return GroupVerdict(is_valid=True, validation_score=1.0)
+
+
+def _write_results(tmp_path: Path, doc_ids: list[str]) -> Path:
+    path = tmp_path / "extraction_results_Publications_test.json"
+    path.write_text(
+        json.dumps(
+            {
+                "source": "publications",
+                "publications": [
+                    {
+                        "pub_id": doc_id,
+                        "total_arms": 1,
+                        "arm_results": {
+                            "arm_1": {
+                                "arm_id": "arm_1",
+                                "arm_name": "Pembrolizumab",
+                                "patient_count": 100,
+                                "attributes": {
+                                    "median_pfs": {"value": "14.7", "confidence": 0.8}
+                                },
+                            }
+                        },
+                    }
+                    for doc_id in doc_ids
+                ],
+            }
+        )
+    )
+    return path
+
+
+def _run(
+    tmp_path: Path, doc_ids: list[str], judge: _StubJudge
+) -> ResultsValidationService:
+    config = ResultsValidationConfig(
+        results_paths=[_write_results(tmp_path, doc_ids)],
+        doc_type="publication",
+        output_dir=tmp_path / "validation",
+        model="stub",
+        concurrency=2,
+    )
+    service = ResultsValidationService.from_config(
+        config,
+        judge,  # type: ignore[arg-type]
+        _StubLoader(_SOURCE),
+        CostCalculator(),
+    )
+    asyncio.run(service.run())
+    return service
+
+
+def test_a_clean_run_keeps_its_arms_and_writes_the_cleaned_cohort(
+    tmp_path: Path,
+) -> None:
+    _run(tmp_path, ["pub_ok"], _StubJudge())
+
+    cleaned = json.loads((tmp_path / "validation" / "results.cleaned.json").read_text())
+
+    assert cleaned["total_arms"] == 1
+    assert cleaned["publications"][0]["pub_id"] == "pub_ok"
+    assert "arm_1" in cleaned["publications"][0]["arm_results"]
+
+
+def test_an_errored_document_is_not_checkpointed_so_resume_retries_it(
+    tmp_path: Path,
+) -> None:
+    """A transient timeout must not silently exclude a document forever."""
+    judge = _StubJudge(failing_source=_SOURCE)
+
+    _run(tmp_path, ["pub_boom"], judge)
+    checkpoint_path = tmp_path / "validation" / "validation_checkpoint.json"
+    recorded = (
+        json.loads(checkpoint_path.read_text()) if checkpoint_path.exists() else {}
+    )
+    calls_after_first_run = judge.calls
+
+    _run(tmp_path, ["pub_boom"], judge)
+
+    assert recorded == {}
+    assert judge.calls > calls_after_first_run, "resume did not retry the failure"
+
+
+def test_a_successful_document_is_checkpointed_and_skipped_on_resume(
+    tmp_path: Path,
+) -> None:
+    judge = _StubJudge()
+
+    _run(tmp_path, ["pub_ok"], judge)
+    first_pass_calls = judge.calls
+    _run(tmp_path, ["pub_ok"], judge)
+
+    assert first_pass_calls == len(AttributeGroup)
+    assert judge.calls == first_pass_calls
+
+
+def test_the_recall_report_groups_missed_values_by_field(tmp_path: Path) -> None:
+    _run(tmp_path, ["pub_ok"], _StubJudge())
+
+    missed = json.loads((tmp_path / "validation" / "missed_values.json").read_text())
+
+    assert missed == {"total": 0, "by_field": {}}


### PR DESCRIPTION
## Why

The trials cohort has had an LLM-as-a-Judge validator since #73. The abstract and publication extraction runs had no equivalent, and their values are the ones with clinical content: ORR, median PFS, hazard ratios and their CIs, grade 3+ AE rates. Those feed the efficacy and safety views directly, so a wrong number - or a right number filed onto the wrong treatment arm - is a clinical-content error, not a cosmetic one.

This branch adds that validator, plus three fixes the first real runs surfaced.

## What changed

**Three judge calls per document - identification, efficacy, safety.** Each call sees the full source markdown and every treatment arm side by side. All arms in one call is what makes arm attribution checkable at all; passing the full source rather than the extractor's RAG slice lets the judge find content that retrieval never surfaced. Routing is per arm, because an arm is what a CSV row is.

**Deliberately not a copy of the trials validator.** The data differs: extraction normalises as it reads - strips `%` and units, sums G3+G4+G5, computes ORR from CR+PR - so "the value must appear in its quote" cannot be a gate here. That rule splits in two. The quote must be a literal substring of the source (hard requirement). Value-in-quote is enforced only for derivations that preserve the number.

**A deterministic pre-pass** adds cross-field rules no single-value check can see: CR <= ORR <= DCR, grade 3+ within its all-grade total, CI bracketing its own HR, non-rising survival curves, median PFS <= median OS.

**Advisory by default.** The judge routes to a review queue and edits nothing. `--apply-fixes` is wired but off until gold-set calibration. Arm-level drops are reserved for identity failures - one bad value among 165 does not discard an arm's good data. `modality` and `target` are excluded; the trials pipeline owns them. The prompts embed the extractor's own `FAMILY_PROMPTS` so the judge grades compliance against the same rules, keeping one source of truth.

### Fixes found by running it

**Gemini structured calls now stream** (`866b50d`). Non-streaming `generate_content` buffers the whole generation server-side, so the 90s client read timeout was bounding total generation time rather than socket health. The judge emits ~3k completion tokens per call and blew that budget deterministically - Batch-I_24 and Batch-I_22 timed out on every attempt, and retrying at an unchanged budget failed identically. Consuming `generate_content_stream` makes the same 90s measure the gap between chunks: a stalled socket still dies, a long response completes. `.parsed` is documented as unavailable for streaming, so accumulated text goes through the existing `model_validate_json` + JSON-repair path. Also drops a hardcoded 60s backoff floor left in this method when `476fd77` shrank it elsewhere.

**Whole-number percentages spelled as floats** (`7965d2e`). The abstract extractor stores every percentage as a float, so `24.0` was checked against a source printing `24%`, the containment check failed, and the guard downgraded a correct value to UNCERTAIN. `value_supported_by_quote` now treats a whole number as matching either spelling in both directions, while still refusing a different decimal: `24.0` matches `24` and `24.00`, never `24.5`; `240` still fails. On a 6-document sample, 13 guard downgrades drop to 1, and the survivor is genuine.

**Cost report carries forward across resumes** (`ae8d808`). `cost_report.json` was rewritten from scratch by every run, so a cohort needing two resume passes reported the last pass alone - $0.61 for a run that cost $14.78, wrong by 20x. The writer now folds the previous report's `api_calls` into the new one and recomputes every summary figure from the union, matching what `write_validation` already does. The carried baseline is snapshotted once at construction, since `write_cost_report` runs after every document and re-reading would compound. `--no-resume` starts from zero.

## Runs so far (advisory, nothing applied)

| Cohort | Docs | Arms | kept | hitl | dropped | errored | Cost |
|---|---|---|---|---|---|---|---|
| Publications_May_2026 | 70 | 128 | 23 | 105 | 0 | 1 | $14.78 |
| Abstracts_April_2026 | 1135 | 1842 | 69 | 1518 | 255 | 0 | $77.24 |

Gold-set publications: 117 PASS, 15 FAIL, no errors. The FAILs are real - a trial named COMBI-d extracted as "No Name", and a PFS hazard ratio, CI and p-value filed onto the control arm.

Both runs are advisory. No extraction output was modified.

## Verification

- `make quality` green: 614 passed, 13 skipped; ruff + black + mypy clean
- Streaming fix verified against the live API: Batch-I_22 went from failing twice to completing in ~100s, and the 70-publication run finished 69/70 with token accounting intact
- Melanoma-only branch; no `web/` files touched

## Known, not settled here

**255 abstract arms were dropped for `patient_count = 0`.** That is the identity rule firing as designed, but whether a missing enrolment count should discard an arm's efficacy and safety values is a policy call, not a bug - it needs a decision before `--apply-fixes` is ever turned on.

**The HITL queue is large by construction** (1518 of 1842 abstract arms). The judge is tuned to over-refer while it is advisory. Calibration against a gold set is the next step and is human-gated.

**Concurrency is 2, not 5.** Higher settings hit Gemini rate limits on this workload.
