### PR TITLE
chore(web): bump js-yaml to 4.3.1 for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6371,9 +6371,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
`npm audit --audit-level=high` fails CI on every branch:

> js-yaml 4.0.0 - 4.3.0 — high — Quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870 fix not backported)

js-yaml reaches us only through `eslint` → `@eslint/eslintrc`, so the exposure is dev-only, but the audit gates every push and this blocks unrelated PRs.

Patch bump, lockfile only - three lines. `npm audit` now reports `found 0 vulnerabilities`; lint and `tsc --noEmit` clean.

`npm audit fix` also offered to remove `@emnapi/core`, `@napi-rs/wasm-runtime` and `@tybys/wasm-util`. Those are extraneous entries in local `node_modules`, not lockfile dependencies, so they are deliberately not part of this diff.

Worth merging ahead of #76, which is red only because of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)